### PR TITLE
feat: add in-place mutation API (ProposalMut) for non-Clone state spaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,10 @@ When creating or updating issues:
 - This is a single Rust *library crate* (no `src/main.rs`). The crate root is `src/lib.rs`.
 - The MCMC framework is implemented in `src/lib.rs`:
   - `McmcError`: error type for NaN detection in log-probabilities and proposal ratios
-  - `State`: marker trait for MCMC state types (requires `Clone`)
   - `Target<S>`: trait for target distributions (log-probability)
-  - `Proposal<S>`: trait for proposal distributions (propose + log q-ratio)
-  - `Chain<S>`: Metropolis–Hastings chain with acceptance tracking
+  - `Proposal<S>`: clone-based proposal distributions (propose + log q-ratio; requires `S: Clone`)
+  - `ProposalMut<S>`: in-place proposal with rollback (associated `Undo` type; no `Clone` required)
+  - `Chain<S>`: Metropolis–Hastings chain with `step` (clone-based) and `step_mut` (in-place)
   - `prelude`: convenience re-exports for common usage
 - Rust tests are inline `#[cfg(test)]` modules in `src/lib.rs`.
 - The `justfile` defines all dev workflows (see `just --list`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,7 +49,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -47,10 +68,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
 
 [[package]]
 name = "getrandom"
@@ -60,8 +115,8 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -124,6 +179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,7 +194,8 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "markov-chain-monte-carlo"
 version = "0.0.1"
 dependencies = [
- "rand",
+ "proptest",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -141,6 +203,30 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -162,6 +248,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,9 +283,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -183,8 +310,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
- "getrandom",
- "rand_core",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -192,6 +338,46 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "semver"
@@ -253,6 +439,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +468,15 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"
@@ -314,6 +528,21 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -402,6 +631,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,14 @@ license = "BSD-3-Clause"
 repository = "https://github.com/acgetchell/markov-chain-monte-carlo"
 readme = "README.md"
 
-keywords = ["mcmc", "markov", "monte-carlo", "sampling", "metropolis"]
+keywords = ["mcmc", "markov-chain", "monte-carlo", "sampling", "metropolis-hastings"]
 categories = ["science", "mathematics", "algorithms"]
 
 [dependencies]
 rand = "0.10.0"
+
+[dev-dependencies]
+proptest = "1.10.0"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ struct SpinFlip;
 impl ProposalMut<SpinChain> for SpinFlip {
     type Undo = usize;  // which site was flipped
     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+        if state.spins.is_empty() { return None; }
         let idx = rng.random_range(0..state.spins.len());
         state.spins[idx] *= -1;
         Some(idx)

--- a/README.md
+++ b/README.md
@@ -16,14 +16,101 @@ A composable **Markov Chain Monte Carlo (MCMC)** framework for arbitrary state s
 This crate provides:
 
 - A generic Metropolis–Hastings implementation
-- Pluggable proposal distributions
-- Support for arbitrary state spaces (including discrete and combinatorial systems)
+- Two proposal models:
+  - **`Proposal<S>`** — clone-based, for simple/small state spaces
+  - **`ProposalMut<S>`** — in-place mutation with rollback, for large combinatorial state spaces (triangulations, graphs) where cloning is expensive
+- `Chain<S>` with `step` (clone-based) and `step_mut` (in-place) methods
+- NaN detection and automatic state rollback on error
+- Seeded RNG support for reproducible simulations
 
 The design emphasizes:
 
 - Zero-cost abstractions
 - Log-space numerical stability
 - Extensibility for research and experimentation
+
+---
+
+## Quick Start
+
+### Clone-based (simple states)
+
+```rust
+use markov_chain_monte_carlo::prelude::*;
+use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+
+#[derive(Clone)]
+struct Scalar(f64);
+
+struct Normal;
+impl Target<Scalar> for Normal {
+    fn log_prob(&self, state: &Scalar) -> f64 {
+        -0.5 * state.0 * state.0
+    }
+}
+
+struct RandomWalk { width: f64 }
+impl Proposal<Scalar> for RandomWalk {
+    fn propose<R: Rng + ?Sized>(&self, current: &Scalar, rng: &mut R) -> Scalar {
+        Scalar(current.0 + rng.random_range(-self.width..self.width))
+    }
+}
+
+fn main() -> Result<(), McmcError> {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut chain = Chain::new(Scalar(0.0), &Normal)?;
+
+    for _ in 0..1000 {
+        chain.step(&Normal, &RandomWalk { width: 1.0 }, &mut rng)?;
+    }
+
+    assert!(chain.acceptance_rate() > 0.2);
+    Ok(())
+}
+```
+
+### In-place mutation (combinatorial states)
+
+```rust
+use markov_chain_monte_carlo::prelude::*;
+use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+
+struct SpinChain { spins: Vec<i8> }  // not Clone
+
+struct Ising;
+impl Target<SpinChain> for Ising {
+    fn log_prob(&self, state: &SpinChain) -> f64 {
+        state.spins.windows(2)
+            .map(|w| f64::from(w[0]) * f64::from(w[1]))
+            .sum()
+    }
+}
+
+struct SpinFlip;
+impl ProposalMut<SpinChain> for SpinFlip {
+    type Undo = usize;  // which site was flipped
+    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+        let idx = rng.random_range(0..state.spins.len());
+        state.spins[idx] *= -1;
+        Some(idx)
+    }
+    fn undo(&self, state: &mut SpinChain, idx: usize) {
+        state.spins[idx] *= -1;
+    }
+}
+
+fn main() -> Result<(), McmcError> {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut chain = Chain::new(SpinChain { spins: vec![1; 20] }, &Ising)?;
+
+    for _ in 0..1000 {
+        chain.step_mut(&Ising, &SpinFlip, &mut rng)?;
+    }
+
+    assert!(chain.acceptance_rate() > 0.0);
+    Ok(())
+}
+```
 
 ---
 
@@ -50,10 +137,4 @@ The long-term architecture separates:
 - [ ] Parallel chains
 - [ ] Diagnostics (ESS, autocorrelation)
 - [ ] Learned proposals (ML integration)
-
----
-
-## Usage
-
-⚠️ Not yet stabilized. API will change.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # markov-chain-monte-carlo
 
-[![CI](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/ci.yml/badge.svg)](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/ci.yml)
-[![rust-clippy analyze](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/rust-clippy.yml/badge.svg)](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/rust-clippy.yml)
-[![codecov](https://codecov.io/gh/acgetchell/markov-chain-monte-carlo/graph/badge.svg)](https://codecov.io/gh/acgetchell/markov-chain-monte-carlo)
-[![Audit dependencies](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/audit.yml/badge.svg)](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/audit.yml)
+[![Crates.io](https://img.shields.io/crates/v/markov-chain-monte-carlo.svg)](https://crates.io/crates/markov-chain-monte-carlo) [![Downloads](https://img.shields.io/crates/d/markov-chain-monte-carlo.svg)](https://crates.io/crates/markov-chain-monte-carlo) [![Docs.rs](https://docs.rs/markov-chain-monte-carlo/badge.svg)](https://docs.rs/markov-chain-monte-carlo) [![CI](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/ci.yml/badge.svg)](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/ci.yml) [![rust-clippy analyze](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/rust-clippy.yml/badge.svg)](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/rust-clippy.yml) [![codecov](https://codecov.io/gh/acgetchell/markov-chain-monte-carlo/graph/badge.svg)](https://codecov.io/gh/acgetchell/markov-chain-monte-carlo) [![Audit dependencies](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/audit.yml/badge.svg)](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/audit.yml)
 
 A composable **Markov Chain Monte Carlo (MCMC)** framework for arbitrary state spaces in Rust.
 

--- a/examples/ising_1d.rs
+++ b/examples/ising_1d.rs
@@ -65,6 +65,9 @@ impl ProposalMut<SpinChain> for SpinFlip {
     type Undo = usize;
 
     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+        if state.spins.is_empty() {
+            return None;
+        }
         let idx = rng.random_range(0..state.spins.len());
         state.spins[idx] *= -1;
         Some(idx)

--- a/examples/ising_1d.rs
+++ b/examples/ising_1d.rs
@@ -1,0 +1,126 @@
+//! 1-D Ising model sampled with `ProposalMut` (in-place mutation + rollback).
+//!
+//! Demonstrates the zero-copy MCMC API on a discrete, non-Clone state space.
+//!
+//! Run with: `cargo run --example ising_1d`
+
+use markov_chain_monte_carlo::prelude::*;
+use rand::rngs::StdRng;
+use rand::{Rng, RngExt, SeedableRng};
+
+// --- State: a chain of ±1 spins (intentionally not Clone) ---
+
+/// A one-dimensional chain of Ising spins.
+struct SpinChain {
+    spins: Vec<i8>,
+}
+
+impl SpinChain {
+    /// Create a uniform +1 spin chain of the given length.
+    fn all_up(n: usize) -> Self {
+        Self { spins: vec![1; n] }
+    }
+
+    /// Magnetization per spin: m = (1/N) Σ `s_i`.
+    fn magnetization(&self) -> f64 {
+        let sum: i32 = self.spins.iter().map(|&s| i32::from(s)).sum();
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "spin chain length won't exceed 2^52"
+        )]
+        let n = self.spins.len() as f64;
+        f64::from(sum) / n
+    }
+}
+
+// --- Target: nearest-neighbour Ising energy at inverse temperature β ---
+
+/// Nearest-neighbour Ising Hamiltonian: H = −J Σ `s_i` · `s_{i+1}`.
+///
+/// `log_prob = −β H = β J Σ s_i · s_{i+1}`.
+struct Ising {
+    /// Coupling constant (positive = ferromagnetic).
+    coupling: f64,
+    /// Inverse temperature.
+    beta: f64,
+}
+
+impl Target<SpinChain> for Ising {
+    fn log_prob(&self, state: &SpinChain) -> f64 {
+        let s = &state.spins;
+        let interaction: f64 = s
+            .windows(2)
+            .map(|w| f64::from(w[0]) * f64::from(w[1]))
+            .sum();
+        self.beta * self.coupling * interaction
+    }
+}
+
+// --- Proposal: flip one random spin ---
+
+/// Single-site spin flip.  Undo token is the flipped site index.
+struct SpinFlip;
+
+impl ProposalMut<SpinChain> for SpinFlip {
+    type Undo = usize;
+
+    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+        let idx = rng.random_range(0..state.spins.len());
+        state.spins[idx] *= -1;
+        Some(idx)
+    }
+
+    fn undo(&self, state: &mut SpinChain, idx: usize) {
+        state.spins[idx] *= -1; // flipping twice = identity
+    }
+}
+
+fn main() -> Result<(), McmcError> {
+    let seed = 42;
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    let n_spins = 50;
+    let beta = 0.5; // moderate temperature
+    let coupling = 1.0;
+
+    let target = Ising { coupling, beta };
+    let proposal = SpinFlip;
+    let state = SpinChain::all_up(n_spins);
+    let mut chain = Chain::new(state, &target)?;
+
+    println!("1-D Ising model ({n_spins} spins, β={beta}, J={coupling}, seed={seed})");
+    println!("Initial magnetization: {:.3}", chain.state.magnetization());
+
+    // Burn-in
+    let burn_in = 5_000;
+    for _ in 0..burn_in {
+        chain.step_mut(&target, &proposal, &mut rng)?;
+    }
+    println!(
+        "After {burn_in} burn-in steps: m = {:.3}",
+        chain.state.magnetization()
+    );
+
+    // Collect samples
+    let n_samples: i32 = 20_000;
+    let mut mag_sum = 0.0;
+    let mut mag_sq_sum = 0.0;
+    for _ in 0..n_samples {
+        chain.step_mut(&target, &proposal, &mut rng)?;
+        let m = chain.state.magnetization();
+        mag_sum += m;
+        mag_sq_sum += m * m;
+    }
+
+    let mean_mag = mag_sum / f64::from(n_samples);
+    let mean_mag_sq = mag_sq_sum / f64::from(n_samples);
+    let susceptibility = f64::from(n_samples) * (mean_mag_sq - mean_mag * mean_mag);
+
+    println!("\nResults ({n_samples} samples):");
+    println!("  <m>:             {mean_mag:+.4}");
+    println!("  <m²>:            {mean_mag_sq:.4}");
+    println!("  susceptibility:  {susceptibility:.2}");
+    println!("  acceptance rate: {:.1}%", chain.acceptance_rate() * 100.0);
+
+    Ok(())
+}

--- a/examples/ising_1d.rs
+++ b/examples/ising_1d.rs
@@ -102,7 +102,7 @@ fn main() -> Result<(), McmcError> {
     );
 
     // Collect samples
-    let n_samples: i32 = 20_000;
+    let n_samples: u32 = 20_000;
     let mut mag_sum = 0.0;
     let mut mag_sq_sum = 0.0;
     for _ in 0..n_samples {

--- a/examples/normal_1d.rs
+++ b/examples/normal_1d.rs
@@ -10,7 +10,6 @@ use rand::{Rng, RngExt, SeedableRng};
 
 #[derive(Clone, Debug)]
 struct Scalar(f64);
-impl State for Scalar {}
 
 // --- Target: N(0,1) ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 //!
 //! #[derive(Clone)]
 //! struct Scalar(f64);
-//! impl State for Scalar {}
 //!
 //! struct Normal;
 //! impl Target<Scalar> for Normal {
@@ -44,6 +43,59 @@
 //!     }
 //!
 //!     assert!(chain.acceptance_rate() > 0.2);
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # In-place mutation with rollback
+//!
+//! For state spaces where cloning is expensive, use [`ProposalMut`] with
+//! [`Chain::step_mut`].  The proposal mutates the state in place and returns
+//! a small undo token for rollback on rejection:
+//!
+//! ```
+//! use markov_chain_monte_carlo::prelude::*;
+//! use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+//!
+//! /// A lattice of spins (not Clone — only mutated in place).
+//! struct SpinChain { spins: Vec<i8> }
+//!
+//! /// Energy = −Σ s_i · s_{i+1}  (1-D Ising, no field).
+//! struct Ising;
+//! impl Target<SpinChain> for Ising {
+//!     fn log_prob(&self, state: &SpinChain) -> f64 {
+//!         let s = &state.spins;
+//!         let energy: f64 = s.windows(2)
+//!             .map(|w| -f64::from(w[0]) * f64::from(w[1]))
+//!             .sum();
+//!         -energy  // log_prob = −E  (T = 1)
+//!     }
+//! }
+//!
+//! /// Flip one random spin; undo token is the site index.
+//! struct SpinFlip;
+//! impl ProposalMut<SpinChain> for SpinFlip {
+//!     type Undo = usize;
+//!     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+//!         let idx = rng.random_range(0..state.spins.len());
+//!         state.spins[idx] *= -1;
+//!         Some(idx)
+//!     }
+//!     fn undo(&self, state: &mut SpinChain, idx: usize) {
+//!         state.spins[idx] *= -1;  // flipping twice = identity
+//!     }
+//! }
+//!
+//! fn main() -> Result<(), McmcError> {
+//!     let mut rng = StdRng::seed_from_u64(42);
+//!     let state = SpinChain { spins: vec![1; 20] };
+//!     let mut chain = Chain::new(state, &Ising)?;
+//!
+//!     for _ in 0..1000 {
+//!         chain.step_mut(&Ising, &SpinFlip, &mut rng)?;
+//!     }
+//!
+//!     assert!(chain.acceptance_rate() > 0.0);
 //!     Ok(())
 //! }
 //! ```
@@ -90,20 +142,22 @@ impl std::error::Error for McmcError {}
 /// use markov_chain_monte_carlo::prelude::*;
 /// ```
 pub mod prelude {
-    pub use crate::{Chain, McmcError, Proposal, State, Target};
+    pub use crate::{Chain, McmcError, Proposal, ProposalMut, Target};
 }
 
-/// Marker trait for MCMC state types.
-pub trait State: Clone {}
-
-/// Target distribution (or log-probability / negative action).
+/// Target distribution
 pub trait Target<S> {
     /// Compute log-probability (or negative energy/action).
     fn log_prob(&self, state: &S) -> f64;
 }
 
 /// Proposal distribution for generating new states.
-pub trait Proposal<S> {
+///
+/// This trait uses a clone-based model: [`propose`](Proposal::propose) returns
+/// a new state by value.  For state spaces where cloning is expensive (e.g.,
+/// triangulations, large graphs), see [`ProposalMut`] which mutates in place
+/// and supports cheap rollback.
+pub trait Proposal<S: Clone> {
     /// Propose a new state from the current one.
     fn propose<R: Rng + ?Sized>(&self, current: &S, rng: &mut R) -> S;
 
@@ -112,6 +166,37 @@ pub trait Proposal<S> {
     ///
     /// Defaults to 0 for symmetric proposals.
     fn log_q_ratio(&self, _current: &S, _proposed: &S) -> f64 {
+        0.0
+    }
+}
+
+/// In-place proposal distribution with rollback.
+///
+/// Unlike [`Proposal`], which clones the state for each proposal,
+/// `ProposalMut` mutates the state in place and returns an undo token
+/// that can reverse the mutation on rejection.  This is the natural
+/// model for combinatorial state spaces (e.g., triangulations, graphs)
+/// where moves are invertible and cloning is expensive.
+///
+/// # Associated Types
+///
+/// * [`Undo`](ProposalMut::Undo) — a small token that captures
+///   exactly what is needed to reverse a move.
+pub trait ProposalMut<S> {
+    /// Token that records how to reverse a proposed move.
+    type Undo;
+
+    /// Mutate `state` in place, returning `Some(undo_token)` on success
+    /// or `None` if no valid move could be found.
+    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, rng: &mut R) -> Option<Self::Undo>;
+
+    /// Reverse a previously applied move using its undo token.
+    fn undo(&self, state: &mut S, token: Self::Undo);
+
+    /// Log proposal ratio for the in-place move.
+    ///
+    /// Defaults to 0 for symmetric proposals.
+    fn log_q_ratio(&self, _state: &S, _token: &Self::Undo) -> f64 {
         0.0
     }
 }
@@ -129,7 +214,7 @@ pub struct Chain<S> {
     pub rejected: usize,
 }
 
-impl<S: State> Chain<S> {
+impl<S> Chain<S> {
     /// Create a new chain from an initial state.
     ///
     /// # Errors
@@ -149,7 +234,10 @@ impl<S: State> Chain<S> {
         })
     }
 
-    /// Perform a single Metropolis–Hastings step.
+    /// Perform a single Metropolis–Hastings step (clone-based).
+    ///
+    /// This method requires `S: Clone` because the proposal returns a new
+    /// state by value.  For non-`Clone` state spaces, use [`step_mut`](Self::step_mut).
     ///
     /// # Errors
     ///
@@ -158,6 +246,7 @@ impl<S: State> Chain<S> {
     /// proposal's log q-ratio is NaN.
     pub fn step<T, P, R>(&mut self, target: &T, proposal: &P, rng: &mut R) -> Result<(), McmcError>
     where
+        S: Clone,
         T: Target<S>,
         P: Proposal<S>,
         R: Rng + ?Sized,
@@ -191,6 +280,65 @@ impl<S: State> Chain<S> {
         Ok(())
     }
 
+    /// Perform a single Metropolis–Hastings step (in-place with rollback).
+    ///
+    /// Unlike [`step`](Self::step), this method does not require `S: Clone`.
+    /// The proposal mutates the state in place and returns an undo token;
+    /// on rejection (or NaN error) the state is rolled back automatically.
+    ///
+    /// Returns `Ok(true)` if the move was accepted, `Ok(false)` if rejected
+    /// (including when the proposal returns `None`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`McmcError::NanProposedLogProb`] or [`McmcError::NanLogQRatio`]
+    /// after rolling back the state.
+    pub fn step_mut<T, P, R>(
+        &mut self,
+        target: &T,
+        proposal: &P,
+        rng: &mut R,
+    ) -> Result<bool, McmcError>
+    where
+        T: Target<S>,
+        P: ProposalMut<S>,
+        R: Rng + ?Sized,
+    {
+        let Some(token) = proposal.propose_mut(&mut self.state, rng) else {
+            self.rejected += 1;
+            return Ok(false);
+        };
+
+        let log_prob_new = target.log_prob(&self.state);
+        if log_prob_new.is_nan() {
+            proposal.undo(&mut self.state, token);
+            return Err(McmcError::NanProposedLogProb);
+        }
+
+        let log_q = proposal.log_q_ratio(&self.state, &token);
+        if log_q.is_nan() {
+            proposal.undo(&mut self.state, token);
+            return Err(McmcError::NanLogQRatio);
+        }
+
+        let log_alpha = log_prob_new - self.log_prob + log_q;
+
+        let accept = if log_alpha >= 0.0 {
+            true
+        } else {
+            rng.random::<f64>() < log_alpha.exp()
+        };
+
+        if accept {
+            self.log_prob = log_prob_new;
+            self.accepted += 1;
+        } else {
+            proposal.undo(&mut self.state, token);
+            self.rejected += 1;
+        }
+        Ok(accept)
+    }
+
     /// Acceptance rate of the chain.
     #[expect(
         clippy::cast_precision_loss,
@@ -216,7 +364,6 @@ mod tests {
 
     #[derive(Clone, Debug, PartialEq)]
     struct Scalar(f64);
-    impl State for Scalar {}
 
     /// Target: standard normal log-density, log p(x) = -x²/2
     struct Normal;
@@ -438,6 +585,287 @@ mod tests {
         assert!(
             ratio.abs() < f64::EPSILON,
             "Symmetric proposal should have log_q_ratio = 0"
+        );
+    }
+
+    // =====================================================================
+    // ProposalMut / step_mut tests
+    // =====================================================================
+
+    // --- Test fixtures for step_mut ---
+
+    /// Non-Clone state for testing `ProposalMut`.
+    #[derive(Debug, PartialEq)]
+    struct MutScalar(f64);
+
+    impl Target<MutScalar> for Normal {
+        fn log_prob(&self, state: &MutScalar) -> f64 {
+            -0.5 * state.0 * state.0
+        }
+    }
+
+    /// Deterministic in-place proposal: set state to a fixed value.
+    struct FixedMutProposal(f64);
+    impl ProposalMut<MutScalar> for FixedMutProposal {
+        type Undo = f64; // store old value
+        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut MutScalar, _rng: &mut R) -> Option<f64> {
+            let old = state.0;
+            state.0 = self.0;
+            Some(old)
+        }
+        fn undo(&self, state: &mut MutScalar, old: f64) {
+            state.0 = old;
+        }
+    }
+
+    /// Proposal that always returns None (no valid move).
+    struct NoMoveProposal;
+    impl ProposalMut<MutScalar> for NoMoveProposal {
+        type Undo = ();
+        fn propose_mut<R: Rng + ?Sized>(&self, _state: &mut MutScalar, _rng: &mut R) -> Option<()> {
+            None
+        }
+        fn undo(&self, _state: &mut MutScalar, _token: ()) {}
+    }
+
+    // --- step_mut acceptance ---
+
+    #[test]
+    fn step_mut_accepts_move_to_higher_probability() {
+        // From x=2.0 (log_prob=-2) to x=0.0 (log_prob=0): always accept
+        let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let proposal = FixedMutProposal(0.0);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let accepted = chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+
+        assert!(accepted, "Should accept move to higher probability");
+        assert_eq!(chain.state, MutScalar(0.0));
+        assert_eq!(chain.accepted, 1);
+        assert_eq!(chain.rejected, 0);
+    }
+
+    #[test]
+    fn step_mut_rejects_move_to_much_lower_probability() {
+        // From x=0.0 (log_prob=0) to x=100.0 (log_prob=-5000): virtually always reject
+        let mut chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let proposal = FixedMutProposal(100.0);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let accepted = chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+
+        assert!(!accepted, "Should reject move to much lower probability");
+        // State should be rolled back to original
+        assert_eq!(
+            chain.state,
+            MutScalar(0.0),
+            "State should be rolled back after rejection"
+        );
+        assert_eq!(chain.accepted, 0);
+        assert_eq!(chain.rejected, 1);
+    }
+
+    // --- step_mut None proposal ---
+
+    #[test]
+    fn step_mut_returns_false_on_none_proposal() {
+        let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let accepted = chain.step_mut(&Normal, &NoMoveProposal, &mut rng).unwrap();
+
+        assert!(!accepted, "Should return false when proposal returns None");
+        assert_eq!(chain.state, MutScalar(1.0), "State should be unchanged");
+        assert_eq!(chain.accepted, 0);
+        assert_eq!(chain.rejected, 1);
+    }
+
+    // --- step_mut NaN rollback ---
+
+    #[test]
+    fn step_mut_rolls_back_on_nan_log_prob() {
+        struct NanAtOrigin;
+        impl Target<MutScalar> for NanAtOrigin {
+            fn log_prob(&self, state: &MutScalar) -> f64 {
+                if state.0 == 0.0 {
+                    f64::NAN
+                } else {
+                    -0.5 * state.0 * state.0
+                }
+            }
+        }
+        let mut chain = Chain::new(MutScalar(1.0), &NanAtOrigin).unwrap();
+        let proposal = FixedMutProposal(0.0);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_mut(&NanAtOrigin, &proposal, &mut rng);
+        assert!(matches!(result, Err(McmcError::NanProposedLogProb)));
+        assert_eq!(
+            chain.state,
+            MutScalar(1.0),
+            "State should be rolled back after NaN log_prob"
+        );
+    }
+
+    #[test]
+    fn step_mut_rolls_back_on_nan_log_q_ratio() {
+        struct NanQProposal;
+        impl ProposalMut<MutScalar> for NanQProposal {
+            type Undo = f64;
+            fn propose_mut<R: Rng + ?Sized>(
+                &self,
+                state: &mut MutScalar,
+                _rng: &mut R,
+            ) -> Option<f64> {
+                let old = state.0;
+                state.0 = 0.0;
+                Some(old)
+            }
+            fn undo(&self, state: &mut MutScalar, old: f64) {
+                state.0 = old;
+            }
+            fn log_q_ratio(&self, _state: &MutScalar, _token: &f64) -> f64 {
+                f64::NAN
+            }
+        }
+        let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_mut(&Normal, &NanQProposal, &mut rng);
+        assert!(matches!(result, Err(McmcError::NanLogQRatio)));
+        assert_eq!(
+            chain.state,
+            MutScalar(1.0),
+            "State should be rolled back after NaN log_q_ratio"
+        );
+    }
+
+    // --- step_mut seeded determinism ---
+
+    #[test]
+    fn step_mut_same_seed_produces_identical_chains() {
+        /// Random-walk `ProposalMut` for `MutScalar`.
+        struct MutRandomWalk {
+            width: f64,
+        }
+        impl ProposalMut<MutScalar> for MutRandomWalk {
+            type Undo = f64;
+            fn propose_mut<R: Rng + ?Sized>(
+                &self,
+                state: &mut MutScalar,
+                rng: &mut R,
+            ) -> Option<f64> {
+                let old = state.0;
+                let delta: f64 = rng.random_range(-self.width..self.width);
+                state.0 += delta;
+                Some(old)
+            }
+            fn undo(&self, state: &mut MutScalar, old: f64) {
+                state.0 = old;
+            }
+        }
+
+        let proposal = MutRandomWalk { width: 1.0 };
+        let steps = 100;
+
+        let mut chain1 = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut rng1 = StdRng::seed_from_u64(12345);
+        for _ in 0..steps {
+            chain1.step_mut(&Normal, &proposal, &mut rng1).unwrap();
+        }
+
+        let mut chain2 = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut rng2 = StdRng::seed_from_u64(12345);
+        for _ in 0..steps {
+            chain2.step_mut(&Normal, &proposal, &mut rng2).unwrap();
+        }
+
+        assert_eq!(
+            chain1.state, chain2.state,
+            "Same seed should produce identical final state"
+        );
+        assert_eq!(chain1.accepted, chain2.accepted);
+        assert_eq!(chain1.rejected, chain2.rejected);
+    }
+
+    // --- step_mut statistical sanity ---
+
+    #[test]
+    fn step_mut_samples_near_mode_of_normal() {
+        struct MutRandomWalk {
+            width: f64,
+        }
+        impl ProposalMut<MutScalar> for MutRandomWalk {
+            type Undo = f64;
+            fn propose_mut<R: Rng + ?Sized>(
+                &self,
+                state: &mut MutScalar,
+                rng: &mut R,
+            ) -> Option<f64> {
+                let old = state.0;
+                state.0 += rng.random_range(-self.width..self.width);
+                Some(old)
+            }
+            fn undo(&self, state: &mut MutScalar, old: f64) {
+                state.0 = old;
+            }
+        }
+
+        let proposal = MutRandomWalk { width: 1.0 };
+        let mut chain = Chain::new(MutScalar(5.0), &Normal).unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+
+        // Burn-in
+        for _ in 0..1_000 {
+            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+        }
+
+        // Collect samples
+        let n = 10_000;
+        let mut sum = 0.0;
+        for _ in 0..n {
+            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+            sum += chain.state.0;
+        }
+        let mean = sum / f64::from(n);
+
+        assert!(
+            mean.abs() < 0.1,
+            "Sample mean {mean} should be near 0 for standard normal"
+        );
+
+        let rate = chain.acceptance_rate();
+        assert!(
+            (0.1..0.95).contains(&rate),
+            "Acceptance rate {rate} should be in a reasonable range"
+        );
+    }
+
+    // --- step_mut non-Clone state ---
+
+    #[test]
+    fn step_mut_works_with_non_clone_state() {
+        // MutScalar intentionally does not derive Clone.
+        // This test verifies the ProposalMut path compiles and works.
+        let mut chain = Chain::new(MutScalar(5.0), &Normal).unwrap();
+        let proposal = FixedMutProposal(0.0);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        // Should accept (moving to mode)
+        let accepted = chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+        assert!(accepted);
+        assert_eq!(chain.state, MutScalar(0.0));
+    }
+
+    // --- ProposalMut log_q_ratio default ---
+
+    #[test]
+    fn symmetric_proposal_mut_has_zero_log_q_ratio() {
+        let proposal = FixedMutProposal(0.0);
+        let ratio = proposal.log_q_ratio(&MutScalar(1.0), &2.0);
+        assert!(
+            ratio.abs() < f64::EPSILON,
+            "Default ProposalMut log_q_ratio should be 0"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@
 //! impl ProposalMut<SpinChain> for SpinFlip {
 //!     type Undo = usize;
 //!     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+//!         if state.spins.is_empty() { return None; }
 //!         let idx = rng.random_range(0..state.spins.len());
 //!         state.spins[idx] *= -1;
 //!         Some(idx)

--- a/tests/proptest_chain.rs
+++ b/tests/proptest_chain.rs
@@ -1,0 +1,168 @@
+//! Property-based tests for [`Chain`] invariants.
+//!
+//! These tests verify mathematical properties of Metropolis–Hastings that must
+//! hold for *all* inputs, not just specific test cases.
+
+use markov_chain_monte_carlo::prelude::*;
+use proptest::prelude::*;
+use rand::rngs::StdRng;
+use rand::{Rng, RngExt, SeedableRng};
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+/// Clone-able scalar state (used by both `step` and `step_mut` paths).
+#[derive(Clone, Debug, PartialEq)]
+struct Scalar(f64);
+
+/// Standard normal target: log p(x) = −x²/2.
+struct Normal;
+impl Target<Scalar> for Normal {
+    fn log_prob(&self, state: &Scalar) -> f64 {
+        -0.5 * state.0 * state.0
+    }
+}
+
+/// Clone-based random walk proposal.
+struct CloneWalk {
+    width: f64,
+}
+impl Proposal<Scalar> for CloneWalk {
+    fn propose<R: Rng + ?Sized>(&self, current: &Scalar, rng: &mut R) -> Scalar {
+        Scalar(current.0 + rng.random_range(-self.width..self.width))
+    }
+}
+
+/// In-place random walk proposal (equivalent to `CloneWalk`).
+struct MutWalk {
+    width: f64,
+}
+impl ProposalMut<Scalar> for MutWalk {
+    type Undo = f64;
+    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut Scalar, rng: &mut R) -> Option<f64> {
+        let old = state.0;
+        state.0 += rng.random_range(-self.width..self.width);
+        Some(old)
+    }
+    fn undo(&self, state: &mut Scalar, old: f64) {
+        state.0 = old;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// After any number of steps, `chain.log_prob` must equal the target
+    /// evaluated at the current state.  This catches bugs where `log_prob`
+    /// is not updated on acceptance or is corrupted during rollback.
+    #[test]
+    fn log_prob_consistent_after_step_mut(
+        initial in -10.0f64..10.0,
+        width in 0.1f64..5.0,
+        steps in 1u32..500,
+        seed in any::<u64>(),
+    ) {
+        let mut chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let proposal = MutWalk { width };
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        for _ in 0..steps {
+            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+        }
+
+        let expected = Normal.log_prob(&chain.state);
+        prop_assert!(
+            (chain.log_prob - expected).abs() < 1e-12,
+            "log_prob {:.15} != target {:.15} after {} steps",
+            chain.log_prob, expected, steps,
+        );
+    }
+
+    /// Same property for the clone-based `step`.
+    #[test]
+    fn log_prob_consistent_after_step(
+        initial in -10.0f64..10.0,
+        width in 0.1f64..5.0,
+        steps in 1u32..500,
+        seed in any::<u64>(),
+    ) {
+        let mut chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let proposal = CloneWalk { width };
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        for _ in 0..steps {
+            chain.step(&Normal, &proposal, &mut rng).unwrap();
+        }
+
+        let expected = Normal.log_prob(&chain.state);
+        prop_assert!(
+            (chain.log_prob - expected).abs() < 1e-12,
+            "log_prob {:.15} != target {:.15} after {} steps",
+            chain.log_prob, expected, steps,
+        );
+    }
+
+    /// `step` and `step_mut` must produce identical results when given the
+    /// same seed.  `CloneWalk` and `MutWalk` draw the same random delta,
+    /// so acceptance decisions must agree exactly.
+    #[test]
+    fn step_and_step_mut_are_equivalent(
+        initial in -10.0f64..10.0,
+        width in 0.1f64..5.0,
+        steps in 1u32..200,
+        seed in any::<u64>(),
+    ) {
+        let clone_proposal = CloneWalk { width };
+        let mut_proposal = MutWalk { width };
+
+        let mut chain_clone = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut rng_clone = StdRng::seed_from_u64(seed);
+
+        let mut chain_mut = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut rng_mut = StdRng::seed_from_u64(seed);
+
+        for _ in 0..steps {
+            chain_clone.step(&Normal, &clone_proposal, &mut rng_clone).unwrap();
+            chain_mut.step_mut(&Normal, &mut_proposal, &mut rng_mut).unwrap();
+        }
+
+        prop_assert_eq!(
+            chain_clone.state, chain_mut.state,
+            "Final states diverged after {} steps", steps,
+        );
+        prop_assert!(
+            (chain_clone.log_prob - chain_mut.log_prob).abs() < 1e-12,
+            "log_prob diverged: clone={:.15}, mut={:.15}",
+            chain_clone.log_prob, chain_mut.log_prob,
+        );
+        prop_assert_eq!(chain_clone.accepted, chain_mut.accepted);
+        prop_assert_eq!(chain_clone.rejected, chain_mut.rejected);
+    }
+
+    /// accepted + rejected must always equal the number of steps taken.
+    #[test]
+    fn counts_invariant_step_mut(
+        initial in -10.0f64..10.0,
+        width in 0.1f64..5.0,
+        steps in 1u32..500,
+        seed in any::<u64>(),
+    ) {
+        let mut chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let proposal = MutWalk { width };
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        for _ in 0..steps {
+            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+        }
+
+        prop_assert_eq!(
+            chain.accepted + chain.rejected,
+            steps as usize,
+            "accepted ({}) + rejected ({}) != steps ({})",
+            chain.accepted, chain.rejected, steps,
+        );
+    }
+}

--- a/tests/proptest_chain.rs
+++ b/tests/proptest_chain.rs
@@ -165,4 +165,28 @@ proptest! {
             chain.accepted, chain.rejected, steps,
         );
     }
+
+    /// Same counts invariant for the clone-based `step`.
+    #[test]
+    fn counts_invariant_step(
+        initial in -10.0f64..10.0,
+        width in 0.1f64..5.0,
+        steps in 1u32..500,
+        seed in any::<u64>(),
+    ) {
+        let mut chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let proposal = CloneWalk { width };
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        for _ in 0..steps {
+            chain.step(&Normal, &proposal, &mut rng).unwrap();
+        }
+
+        prop_assert_eq!(
+            chain.accepted + chain.rejected,
+            steps as usize,
+            "accepted ({}) + rejected ({}) != steps ({})",
+            chain.accepted, chain.rejected, steps,
+        );
+    }
 }


### PR DESCRIPTION
API changes:
- Remove State marker trait; Chain<S> now works with any S
- Add ProposalMut<S> trait with associated Undo type for cheap rollback
- Add Chain::step_mut for zero-copy Metropolis-Hastings
- Move Clone bound from State to Proposal<S> and Chain::step

New files:
- examples/ising_1d.rs: 1-D Ising model demonstrating ProposalMut
- tests/proptest_chain.rs: property-based tests for MH invariants (log_prob consistency, step/step_mut equivalence, counts invariant)

Tests: 20 unit + 3 doc + 4 proptest, all passing
Documentation: crate-level doc examples, updated README and AGENTS.md

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flexible proposal support: both clone-based and in-place mutation workflows, with dual stepping modes and rollback for mutations
  * Seeded RNG for reproducible runs

* **Documentation**
  * Expanded quick-start with runnable examples (including a 1D Ising example)
  * Added badges and clarified feature descriptions

* **Bug Fixes**
  * Automatic NaN detection and state rollback on errors

* **Tests**
  * Added property-based tests to validate determinism and API parity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->