### PR TITLE
Changed: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-06
+
 ### Added
 
 - `Sampler<S, T, P, R>` ergonomic wrapper that bundles a `Chain` with its target, proposal, and RNG
@@ -23,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Chain::state()`, `Chain::replace_state()`, `Chain::into_state()` accessor methods (field now private)
 - `#[non_exhaustive]` on `McmcError` for forward-compatible error variants
 - `Debug` implementation for `Sampler` (prints chain state)
+- `publish-check` justfile recipe for crates.io metadata validation
+- `iterator_sampling` example demonstrating `Sampler`'s `Iterator` impl with `.take(n)` and `.by_ref()`
+- Doctest for `Iterator::next` on `Sampler`
 - Doctests for all public `Chain` methods
 - Display tests for all `McmcError` variants
 - Asymmetric proposal tests (non-zero `log_q_ratio`)
@@ -34,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `Sampler` added to `prelude`
 - Split crate into modules: `chain`, `error`, `sampler`, `traits`
 - Examples (`normal_1d`, `ising_1d`) updated to use `Sampler` with `reset_counters()`
-- `justfile`: `examples` and `validate-examples` recipes now include `ising_1d`
+- `justfile` recipes sorted lexicographically; `examples` and `validate-examples` now include `ising_1d`
 
 ## [0.1.0] - 2026-03-24
 
@@ -64,6 +69,7 @@ First usable release of the MCMC framework.
 - `normal_1d` example
 - CI/CD infrastructure
 
-[Unreleased]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/acgetchell/markov-chain-monte-carlo/releases/tag/v0.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "markov-chain-monte-carlo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proptest",
  "rand 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markov-chain-monte-carlo"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Adam Getchell <adam@adamgetchell.org>"]
 edition = "2024"
 rust-version = "1.94.0"

--- a/examples/iterator_sampling.rs
+++ b/examples/iterator_sampling.rs
@@ -1,0 +1,90 @@
+//! Iterator-based sampling from a 1D standard normal distribution.
+//!
+//! Demonstrates [`Sampler`]'s `Iterator` implementation for idiomatic Rust
+//! composability with `.take(n)`, `.by_ref()`, and standard iterator adaptors.
+//!
+//! Run with: `cargo run --example iterator_sampling`
+
+use markov_chain_monte_carlo::prelude::*;
+use rand::rngs::StdRng;
+use rand::{Rng, RngExt, SeedableRng};
+
+// --- State ---
+
+#[derive(Clone, Debug)]
+struct Scalar(f64);
+
+// --- Target: N(0,1) ---
+
+struct StandardNormal;
+impl Target<Scalar> for StandardNormal {
+    fn log_prob(&self, state: &Scalar) -> f64 {
+        -0.5 * state.0 * state.0
+    }
+}
+
+// --- Proposal: symmetric random walk ---
+
+struct RandomWalk {
+    width: f64,
+}
+impl Proposal<Scalar> for RandomWalk {
+    fn propose<R: Rng + ?Sized>(&self, current: &Scalar, rng: &mut R) -> Scalar {
+        Scalar(current.0 + rng.random_range(-self.width..self.width))
+    }
+}
+
+fn main() -> Result<(), McmcError> {
+    let seed = 42;
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    let target = StandardNormal;
+    let proposal = RandomWalk { width: 1.0 };
+    let chain = Chain::new(Scalar(5.0), &target)?;
+    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
+
+    println!("Iterator-based sampling of N(0,1) (seed={seed})");
+
+    // Burn-in using iterator: take exactly 1000 steps, stop on first error.
+    // This is the primary use case for the Iterator impl — fire-and-forget
+    // stepping where you don't need to inspect state between steps.
+    let burn_in = 1_000;
+    let errors: Vec<_> = sampler
+        .by_ref()
+        .take(burn_in)
+        .filter_map(Result::err)
+        .collect();
+    if let Some(err) = errors.into_iter().next() {
+        return Err(err);
+    }
+    println!("Burn-in complete ({burn_in} steps via iterator)");
+
+    // Reset counters so acceptance rate reflects production only
+    sampler.chain.reset_counters();
+
+    // Collect samples: use step() when you need to read state between steps.
+    // The iterator yields Result<(), McmcError> (not the state), so collecting
+    // samples requires interleaving step + state access.
+    let n_samples: u32 = 10_000;
+    let mut sum = 0.0;
+    let mut sum_sq = 0.0;
+    for _ in 0..n_samples {
+        sampler.step()?;
+        let x = sampler.chain.state().0;
+        sum += x;
+        sum_sq += x * x;
+    }
+
+    let mean = sum / f64::from(n_samples);
+    let variance = sum_sq / f64::from(n_samples) - mean * mean;
+
+    println!("\nResults ({n_samples} samples via iterator):");
+    println!("  Sample mean:     {mean:+.4} (expected: 0.0)");
+    println!("  Sample variance: {variance:.4} (expected: 1.0)");
+    println!(
+        "  Acceptance rate: {:.1}%",
+        sampler.chain.acceptance_rate() * 100.0
+    );
+
+    Ok(())
+}

--- a/examples/iterator_sampling.rs
+++ b/examples/iterator_sampling.rs
@@ -49,14 +49,10 @@ fn main() -> Result<(), McmcError> {
     // This is the primary use case for the Iterator impl — fire-and-forget
     // stepping where you don't need to inspect state between steps.
     let burn_in = 1_000;
-    let errors: Vec<_> = sampler
+    sampler
         .by_ref()
         .take(burn_in)
-        .filter_map(Result::err)
-        .collect();
-    if let Some(err) = errors.into_iter().next() {
-        return Err(err);
-    }
+        .try_for_each(|result| result)?;
     println!("Burn-in complete ({burn_in} steps via iterator)");
 
     // Reset counters so acceptance rate reflects production only

--- a/justfile
+++ b/justfile
@@ -19,6 +19,11 @@ _ensure-actionlint:
     set -euo pipefail
     command -v actionlint >/dev/null || { echo "❌ 'actionlint' not found. Install: brew install actionlint"; exit 1; }
 
+_ensure-jq:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v jq >/dev/null || { echo "❌ 'jq' not found. Install: brew install jq"; exit 1; }
+
 _ensure-yamllint:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -99,6 +104,7 @@ doc:
 examples:
     cargo run --quiet --example normal_1d
     cargo run --quiet --example ising_1d
+    cargo run --quiet --example iterator_sampling
 
 # Fix (mutating): apply formatters
 fix: fmt
@@ -108,17 +114,82 @@ fix: fmt
 fmt:
     cargo fmt --all
 
+# Rust format check
 fmt-check:
     cargo fmt --all -- --check
+
+# Pre-publish validation: checks crates.io metadata rules that cargo publish --dry-run does NOT catch
+publish-check: _ensure-jq
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "🔍 Validating crates.io metadata..."
+    errors=0
+
+    # Keywords: max 5, each ≤20 chars, ASCII alphanumeric/hyphen only
+    keywords=$(cargo metadata --no-deps --format-version=1 2>/dev/null \
+        | jq -r '.packages[0].keywords[]')
+    count=0
+    while IFS= read -r kw; do
+        [[ -z "$kw" ]] && continue
+        count=$((count + 1))
+        if (( ${#kw} > 20 )); then
+            echo "  ❌ keyword '${kw}' exceeds 20-char limit (${#kw} chars)"
+            errors=1
+        fi
+        if ! [[ "$kw" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            echo "  ❌ keyword '${kw}' contains invalid characters"
+            errors=1
+        fi
+    done <<< "$keywords"
+    if (( count > 5 )); then
+        echo "  ❌ too many keywords ($count > 5)"
+        errors=1
+    fi
+    echo "  ✓ keywords ($count): $keywords"
+
+    # Categories: max 5
+    cat_count=$(cargo metadata --no-deps --format-version=1 2>/dev/null \
+        | jq '.packages[0].categories | length')
+    if (( cat_count > 5 )); then
+        echo "  ❌ too many categories ($cat_count > 5)"
+        errors=1
+    fi
+    echo "  ✓ categories ($cat_count)"
+
+    # Description: required, ≤1000 chars
+    desc=$(cargo metadata --no-deps --format-version=1 2>/dev/null \
+        | jq -r '.packages[0].description // ""')
+    if [[ -z "$desc" ]]; then
+        echo "  ❌ description is missing"
+        errors=1
+    elif (( ${#desc} > 1000 )); then
+        echo "  ❌ description exceeds 1000-char limit (${#desc} chars)"
+        errors=1
+    fi
+    echo "  ✓ description (${#desc} chars)"
+
+    if (( errors )); then
+        echo ""
+        echo "❌ Metadata validation failed. Fix Cargo.toml before publishing."
+        exit 1
+    fi
+
+    echo ""
+    echo "📦 Running cargo publish --dry-run..."
+    cargo publish --locked --allow-dirty --dry-run
+    echo ""
+    echo "✅ Publish check passed!"
 
 # Testing
 test:
     cargo test --lib --verbose
     cargo test --doc --verbose
 
+# All tests (lib + doc + integration)
 test-all: test test-integration
     @echo "✅ All tests passed"
 
+# Integration tests
 test-integration:
     cargo test --tests --verbose
 
@@ -136,6 +207,11 @@ validate-examples:
     echo "$output" | grep -q "<m>" || { echo "❌ ising_1d: Missing magnetization"; exit 1; }
     echo "$output" | grep -q "acceptance rate" || { echo "❌ ising_1d: Missing acceptance rate"; exit 1; }
     echo "✅ ising_1d validated"
+    output=$(cargo run --quiet --example iterator_sampling)
+    echo "$output"
+    echo "$output" | grep -q "Sample mean" || { echo "❌ iterator_sampling: Missing sample mean"; exit 1; }
+    echo "$output" | grep -q "Acceptance rate" || { echo "❌ iterator_sampling: Missing acceptance rate"; exit 1; }
+    echo "✅ iterator_sampling validated"
 
 # YAML lint
 yaml-lint: _ensure-yamllint

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -21,6 +21,17 @@ pub struct Chain<S> {
 impl<S> Chain<S> {
     /// Create a new chain from an initial state.
     ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// let chain = Chain::new(1.0_f64, &T)?;
+    /// assert_eq!(chain.accepted(), 0);
+    /// assert!((chain.log_prob() - (-0.5)).abs() < 1e-12);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns [`McmcError::NanInitialLogProb`] if the target's log-probability
@@ -46,6 +57,26 @@ impl<S> Chain<S> {
     ///
     /// This method requires `S: Clone` because the proposal returns a new
     /// state by value.  For non-`Clone` state spaces, use [`step_mut`](Self::step_mut).
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+    ///
+    /// # #[derive(Clone)] struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl Proposal<S> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, c: &S, r: &mut R) -> S {
+    /// #         S(c.0 + r.random_range(-1.0..1.0))
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let mut chain = Chain::new(S(0.0), &T)?;
+    /// chain.step(&T, &P, &mut rng)?;
+    /// assert_eq!(chain.total_steps(), 1);
+    /// # Ok::<(), McmcError>(())
+    /// ```
     ///
     /// # Errors
     ///
@@ -104,6 +135,28 @@ impl<S> Chain<S> {
     ///
     /// Returns `Ok(true)` if the move was accepted, `Ok(false)` if rejected
     /// (including when the proposal returns `None`).
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl ProposalMut<S> for P {
+    /// #     type Undo = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, r: &mut R) -> Option<f64> {
+    /// #         let old = s.0; s.0 += r.random_range(-1.0..1.0); Some(old)
+    /// #     }
+    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let mut chain = Chain::new(S(0.0), &T)?;
+    /// let accepted = chain.step_mut(&T, &P, &mut rng)?;
+    /// assert_eq!(chain.total_steps(), 1);
+    /// # Ok::<(), McmcError>(())
+    /// ```
     ///
     /// # Errors
     ///
@@ -220,6 +273,17 @@ impl<S> Chain<S> {
     }
 
     /// Consume the chain and return the state.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// let chain = Chain::new(3.0_f64, &T)?;
+    /// let state = chain.into_state();
+    /// assert!((state - 3.0).abs() < f64::EPSILON);
+    /// # Ok::<(), McmcError>(())
+    /// ```
     #[must_use]
     pub fn into_state(self) -> S {
         self.state

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -223,6 +223,34 @@ where
     ///
     /// This is an infinite iterator — it always returns `Some`.
     /// Use `.take(n)` to limit the number of steps.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+    ///
+    /// #[derive(Clone)]
+    /// struct Val(f64);
+    /// struct Flat;
+    /// impl Target<Val> for Flat {
+    ///     fn log_prob(&self, _: &Val) -> f64 { 0.0 }
+    /// }
+    /// struct Walk;
+    /// impl Proposal<Val> for Walk {
+    ///     fn propose<R: Rng + ?Sized>(&self, c: &Val, r: &mut R) -> Val {
+    ///         Val(c.0 + r.random_range(-1.0..1.0))
+    ///     }
+    /// }
+    ///
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(Val(0.0), &Flat)?;
+    /// let mut sampler = Sampler::new(chain, &Flat, &Walk, &mut rng);
+    ///
+    /// // Take exactly 100 steps using iterator
+    /// let errors: Vec<_> = sampler.by_ref().take(100).filter_map(Result::err).collect();
+    /// assert!(errors.is_empty());
+    /// assert_eq!(sampler.chain.total_steps(), 100);
+    /// # Ok::<(), McmcError>(())
+    /// ```
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.step())
     }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -82,6 +82,24 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     }
 
     /// Consume the sampler and return the inner chain.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    /// use rand::{SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: rand::Rng + ?Sized>(&self, c: &f64, _r: &mut R) -> f64 { c + 1.0 }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(1.0_f64, &T)?;
+    /// let sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let chain = sampler.into_chain();
+    /// assert!((chain.log_prob() - (-0.5)).abs() < 1e-12);
+    /// # Ok::<(), McmcError>(())
+    /// ```
     pub fn into_chain(self) -> Chain<S> {
         self.chain
     }
@@ -99,6 +117,27 @@ where
     /// Perform a single clone-based Metropolis–Hastings step.
     ///
     /// Delegates to [`Chain::step`].
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+    ///
+    /// # #[derive(Clone)] struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl Proposal<S> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, c: &S, r: &mut R) -> S {
+    /// #         S(c.0 + r.random_range(-1.0..1.0))
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// sampler.step()?;
+    /// assert_eq!(sampler.chain.total_steps(), 1);
+    /// # Ok::<(), McmcError>(())
+    /// ```
     ///
     /// # Errors
     ///
@@ -156,6 +195,29 @@ where
     ///
     /// Delegates to [`Chain::step_mut`].  Returns `Ok(true)` if accepted,
     /// `Ok(false)` if rejected.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl ProposalMut<S> for P {
+    /// #     type Undo = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, r: &mut R) -> Option<f64> {
+    /// #         let old = s.0; s.0 += r.random_range(-1.0..1.0); Some(old)
+    /// #     }
+    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let accepted = sampler.step_mut()?;
+    /// assert_eq!(sampler.chain.total_steps(), 1);
+    /// # Ok::<(), McmcError>(())
+    /// ```
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Bump crate version to 0.2.0 and update CHANGELOG.md with recent features and breaking changes. Add a new example demonstrating Sampler's Iterator implementation and a justfile recipe to validate crates.io metadata prior to publishing. Reorganize justfile recipes lexicographically for better maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an example demonstrating iterator-based MCMC sampling with the Sampler API.
  * Added a publish-check task to validate package metadata before dry-run publish.

* **Documentation**
  * Added doctests showing iterator consumption and common Sampler/Chain usage patterns.
  * Updated changelog and release entry for version 0.2.0, including compare links.

* **Chores**
  * Bumped package version to 0.2.0 and extended example validation to assert sample output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->