### PR TITLE
chore: prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-30
+
 ### Added
 
 - `docs/code_organization.md` and `docs/RELEASING.md` developer documentation.
+- CodeQL, Codacy, Codecov, Semgrep, TOML, spelling, and GitHub Actions validation
+  configuration for stronger release checks.
+
+### Changed
+
+- Updated `rand` from 0.10.0 to 0.10.1.
+- Hardened Rust tooling installation and CI validation workflows.
 
 ## [0.2.0] - 2026-04-06
 
@@ -73,7 +82,8 @@ First usable release of the MCMC framework.
 - `normal_1d` example
 - CI/CD infrastructure
 
-[Unreleased]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/acgetchell/markov-chain-monte-carlo/releases/tag/v0.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "markov-chain-monte-carlo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proptest",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markov-chain-monte-carlo"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "Adam Getchell <adam@adamgetchell.org>" ]
 edition = "2024"
 rust-version = "1.95.0"


### PR DESCRIPTION
- Bump crate version to 0.2.1 in Cargo.toml and Cargo.lock
- Add the 0.2.1 changelog section in Keep a Changelog format
- Update changelog comparison links for v0.2.1