### PR TITLE
fix: harden MCMC acceptance and proposal invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This crate provides:
 
 - A generic Metropolis–Hastings implementation
 - Two proposal models:
-  - **`Proposal<S>`** — clone-based, for simple/small state spaces
+  - **`Proposal<S>`** — by-value proposals for simple/small state spaces
   - **`ProposalMut<S>`** — in-place mutation with rollback, for large combinatorial state spaces (triangulations, graphs) where cloning is expensive
-- `Chain<S>` with `step` (clone-based) and `step_mut` (in-place) methods
+- `Chain<S>` with `step` (by-value) and `step_mut` (in-place) methods
 - `Sampler<S, T, P, R>` — ergonomic wrapper that bundles a chain with its target, proposal, and RNG; supports `run(n)` / `run_mut(n)` for bulk sampling and implements `Iterator`
 - NaN and +∞ detection with automatic state rollback on error
 - Chain statistics: `acceptance_rate()`, `total_steps()`, `reset_counters()`
@@ -105,11 +105,11 @@ fn main() -> Result<(), McmcError> {
 
     // Burn-in
     sampler.run(1000)?;
-    sampler.chain.reset_counters();
+    sampler.chain_mut().reset_counters();
 
     // Production
     sampler.run(10_000)?;
-    assert!(sampler.chain.acceptance_rate() > 0.0);
+    assert!(sampler.chain_ref().acceptance_rate() > 0.0);
     Ok(())
 }
 ```

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -77,7 +77,7 @@ changes still affect user matching and documentation.
 Defines user extension points:
 
 - `Target<S>` for target distributions through `log_prob(&S) -> f64`
-- `Proposal<S>` for clone-based proposals
+- `Proposal<S>` for by-value proposals
 - `ProposalMut<S>` for in-place proposals with rollback through an undo token
 
 This is the right place for small, fundamental traits that users implement for
@@ -91,7 +91,7 @@ This module owns:
 
 - current state and current log-probability
 - accepted/rejected counters
-- clone-based `step`
+- by-value `step`
 - in-place `step_mut`
 - state accessors and replacement helpers
 - acceptance-rate and counter utilities
@@ -108,7 +108,7 @@ This module owns:
 
 - single-step forwarding methods
 - bulk `run` and `run_mut` loops
-- clone-based `Iterator` support
+- by-value `Iterator` support
 - access to the bundled `Chain`
 
 Use `Sampler` for workflow ergonomics; use `Chain` for the core transition
@@ -118,9 +118,9 @@ logic.
 
 Examples demonstrate complete, runnable sampling workflows:
 
-- `examples/normal_1d.rs` shows a simple clone-based random-walk sampler.
+- `examples/normal_1d.rs` shows a simple by-value random-walk sampler.
 - `examples/ising_1d.rs` shows in-place mutation with rollback.
-- `examples/iterator_sampling.rs` shows the clone-based `Sampler` iterator API.
+- `examples/iterator_sampling.rs` shows the by-value `Sampler` iterator API.
 
 Keep examples deterministic when possible. The `validate-examples` recipe checks
 for expected output markers, so example output should remain stable enough for
@@ -135,7 +135,7 @@ Tests are split by scope:
 - `tests/semgrep/` validates repository-owned Semgrep rules.
 
 For narrow behavior changes, prefer focused unit tests near the implementation.
-For invariants spanning clone-based and in-place paths, prefer integration or
+For invariants spanning by-value and in-place paths, prefer integration or
 property tests.
 
 ## Tooling and Configuration
@@ -172,4 +172,3 @@ Configuration files support the same gate:
   a change affects Metropolis-Hastings invariants.
 - Run `just check` before handing off ordinary changes, and `just ci` before
   release or broad behavior changes.
-

--- a/examples/ising_1d.rs
+++ b/examples/ising_1d.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), McmcError> {
     println!("1-D Ising model ({n_spins} spins, β={beta}, J={coupling}, seed={seed})");
     println!(
         "Initial magnetization: {:.3}",
-        sampler.chain.state().magnetization()
+        sampler.chain_ref().state().magnetization()
     );
 
     // Burn-in
@@ -103,11 +103,11 @@ fn main() -> Result<(), McmcError> {
     sampler.run_mut(burn_in)?;
     println!(
         "After {burn_in} burn-in steps: m = {:.3}",
-        sampler.chain.state().magnetization()
+        sampler.chain_ref().state().magnetization()
     );
 
     // Reset counters so acceptance rate reflects production only
-    sampler.chain.reset_counters();
+    sampler.chain_mut().reset_counters();
 
     // Collect samples
     let n_samples: u32 = 20_000;
@@ -115,7 +115,7 @@ fn main() -> Result<(), McmcError> {
     let mut mag_sq_sum = 0.0;
     for _ in 0..n_samples {
         sampler.step_mut()?;
-        let m = sampler.chain.state().magnetization();
+        let m = sampler.chain_ref().state().magnetization();
         mag_sum += m;
         mag_sq_sum += m * m;
     }
@@ -130,7 +130,7 @@ fn main() -> Result<(), McmcError> {
     println!("  susceptibility:  {susceptibility:.2}");
     println!(
         "  acceptance rate: {:.1}%",
-        sampler.chain.acceptance_rate() * 100.0
+        sampler.chain_ref().acceptance_rate() * 100.0
     );
 
     Ok(())

--- a/examples/iterator_sampling.rs
+++ b/examples/iterator_sampling.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), McmcError> {
     println!("Burn-in complete ({burn_in} steps via iterator)");
 
     // Reset counters so acceptance rate reflects production only
-    sampler.chain.reset_counters();
+    sampler.chain_mut().reset_counters();
 
     // Collect samples: use step() when you need to read state between steps.
     // The iterator yields Result<(), McmcError> (not the state), so collecting
@@ -66,7 +66,7 @@ fn main() -> Result<(), McmcError> {
     let mut sum_sq = 0.0;
     for _ in 0..n_samples {
         sampler.step()?;
-        let x = sampler.chain.state().0;
+        let x = sampler.chain_ref().state().0;
         sum += x;
         sum_sq += x * x;
     }
@@ -79,7 +79,7 @@ fn main() -> Result<(), McmcError> {
     println!("  Sample variance: {variance:.4} (expected: 1.0)");
     println!(
         "  Acceptance rate: {:.1}%",
-        sampler.chain.acceptance_rate() * 100.0
+        sampler.chain_ref().acceptance_rate() * 100.0
     );
 
     Ok(())

--- a/examples/normal_1d.rs
+++ b/examples/normal_1d.rs
@@ -45,18 +45,18 @@ fn main() -> Result<(), McmcError> {
     let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
 
     println!("Sampling N(0,1) with Metropolis–Hastings (seed={seed})");
-    println!("Initial state: x = {:.3}", sampler.chain.state().0);
+    println!("Initial state: x = {:.3}", sampler.chain_ref().state().0);
 
     // Burn-in
     let burn_in = 1_000;
     sampler.run(burn_in)?;
     println!(
         "After {burn_in} burn-in steps: x = {:.3}",
-        sampler.chain.state().0
+        sampler.chain_ref().state().0
     );
 
     // Reset counters so acceptance rate reflects production only
-    sampler.chain.reset_counters();
+    sampler.chain_mut().reset_counters();
 
     // Collect samples
     let n_samples = 10_000;
@@ -64,8 +64,8 @@ fn main() -> Result<(), McmcError> {
     let mut sum_sq = 0.0;
     for _ in 0..n_samples {
         sampler.step()?;
-        sum += sampler.chain.state().0;
-        sum_sq += sampler.chain.state().0 * sampler.chain.state().0;
+        sum += sampler.chain_ref().state().0;
+        sum_sq += sampler.chain_ref().state().0 * sampler.chain_ref().state().0;
     }
 
     let mean = sum / f64::from(n_samples);
@@ -76,7 +76,7 @@ fn main() -> Result<(), McmcError> {
     println!("  Sample variance: {variance:.4} (expected: 1.0)");
     println!(
         "  Acceptance rate: {:.1}%",
-        sampler.chain.acceptance_rate() * 100.0
+        sampler.chain_ref().acceptance_rate() * 100.0
     );
     Ok(())
 }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,8 +1,26 @@
 //! MCMC chain implementation.
 
+use rand::distr::Open01;
 use rand::{Rng, RngExt};
 
 use crate::{McmcError, Proposal, ProposalMut, Target};
+
+fn accept_from_log_uniform(log_alpha: f64, log_u: f64) -> bool {
+    // NaN can arise from valid inputs such as -inf - (-inf); treat that as a
+    // zero acceptance probability instead of relying on float comparison quirks.
+    if log_alpha.is_nan() {
+        false
+    } else if log_alpha >= 0.0 {
+        true
+    } else {
+        log_u < log_alpha
+    }
+}
+
+fn accept_log_alpha<R: Rng + ?Sized>(log_alpha: f64, rng: &mut R) -> bool {
+    let log_u: f64 = rng.sample::<f64, _>(Open01).ln();
+    accept_from_log_uniform(log_alpha, log_u)
+}
 
 /// A single MCMC chain.
 #[derive(Debug)]
@@ -53,10 +71,11 @@ impl<S> Chain<S> {
         })
     }
 
-    /// Perform a single Metropolis–Hastings step (clone-based).
+    /// Perform a single Metropolis–Hastings step with a by-value proposal.
     ///
-    /// This method requires `S: Clone` because the proposal returns a new
-    /// state by value.  For non-`Clone` state spaces, use [`step_mut`](Self::step_mut).
+    /// The proposal returns a new state by value.  For state spaces where
+    /// constructing a whole proposed state is expensive, use
+    /// [`step_mut`](Self::step_mut).
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::*;
@@ -87,7 +106,6 @@ impl<S> Chain<S> {
     /// NaN or +∞.
     pub fn step<T, P, R>(&mut self, target: &T, proposal: &P, rng: &mut R) -> Result<(), McmcError>
     where
-        S: Clone,
         T: Target<S>,
         P: Proposal<S>,
         R: Rng + ?Sized,
@@ -111,11 +129,7 @@ impl<S> Chain<S> {
 
         let log_alpha = log_prob_new - self.log_prob + log_q;
 
-        let accept = if log_alpha >= 0.0 {
-            true
-        } else {
-            rng.random::<f64>() < log_alpha.exp()
-        };
+        let accept = accept_log_alpha(log_alpha, rng);
 
         if accept {
             self.state = proposed;
@@ -129,9 +143,10 @@ impl<S> Chain<S> {
 
     /// Perform a single Metropolis–Hastings step (in-place with rollback).
     ///
-    /// Unlike [`step`](Self::step), this method does not require `S: Clone`.
-    /// The proposal mutates the state in place and returns an undo token;
-    /// on rejection (or NaN error) the state is rolled back automatically.
+    /// Unlike [`step`](Self::step), this method avoids constructing a whole
+    /// proposed state. The proposal mutates the state in place and returns an
+    /// undo token; on rejection (or NaN error) the state is rolled back
+    /// automatically.
     ///
     /// Returns `Ok(true)` if the move was accepted, `Ok(false)` if rejected
     /// (including when the proposal returns `None`).
@@ -201,11 +216,7 @@ impl<S> Chain<S> {
 
         let log_alpha = log_prob_new - self.log_prob + log_q;
 
-        let accept = if log_alpha >= 0.0 {
-            true
-        } else {
-            rng.random::<f64>() < log_alpha.exp()
-        };
+        let accept = accept_log_alpha(log_alpha, rng);
 
         if accept {
             self.log_prob = log_prob_new;
@@ -519,6 +530,30 @@ mod tests {
         assert!((chain.acceptance_rate()).abs() < f64::EPSILON);
     }
 
+    #[test]
+    fn accept_log_alpha_rejects_nan() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        assert!(
+            !accept_log_alpha(f64::NAN, &mut rng),
+            "NaN log acceptance ratio should be an explicit rejection"
+        );
+    }
+
+    #[test]
+    fn accept_from_log_uniform_handles_extreme_tail_without_exp() {
+        let log_alpha = -800.0;
+
+        assert!(
+            accept_from_log_uniform(log_alpha, -801.0),
+            "Should accept when log(u) is below an extreme log acceptance ratio"
+        );
+        assert!(
+            !accept_from_log_uniform(log_alpha, -799.0),
+            "Should reject when log(u) is above an extreme log acceptance ratio"
+        );
+    }
+
     // --- MH acceptance logic ---
 
     #[test]
@@ -830,6 +865,18 @@ mod tests {
         fn undo(&self, _state: &mut MutScalar, _token: ()) {}
     }
 
+    /// Proposal that probes a mutation, rolls it back internally, and returns None.
+    struct ProbeThenNoMoveProposal;
+    impl ProposalMut<MutScalar> for ProbeThenNoMoveProposal {
+        type Undo = ();
+        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut MutScalar, _rng: &mut R) -> Option<()> {
+            state.0 += 1.0;
+            state.0 -= 1.0;
+            None
+        }
+        fn undo(&self, _state: &mut MutScalar, _token: ()) {}
+    }
+
     // --- step_mut acceptance ---
 
     #[test]
@@ -872,12 +919,41 @@ mod tests {
     #[test]
     fn step_mut_returns_false_on_none_proposal() {
         let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let log_prob = chain.log_prob();
         let mut rng = StdRng::seed_from_u64(42);
 
         let accepted = chain.step_mut(&Normal, &NoMoveProposal, &mut rng).unwrap();
 
         assert!(!accepted, "Should return false when proposal returns None");
         assert_eq!(chain.state, MutScalar(1.0), "State should be unchanged");
+        assert!(
+            (chain.log_prob() - log_prob).abs() < f64::EPSILON,
+            "Cached log_prob should remain synchronized after no-move proposal"
+        );
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 1);
+    }
+
+    #[test]
+    fn step_mut_allows_internal_rollback_before_none() {
+        let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let log_prob = chain.log_prob();
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let accepted = chain
+            .step_mut(&Normal, &ProbeThenNoMoveProposal, &mut rng)
+            .unwrap();
+
+        assert!(!accepted, "Should return false when no move is produced");
+        assert_eq!(
+            chain.state,
+            MutScalar(1.0),
+            "ProposalMut::propose_mut(None) must leave state unchanged"
+        );
+        assert!(
+            (chain.log_prob() - log_prob).abs() < f64::EPSILON,
+            "Cached log_prob should remain synchronized after internally rolled-back no-move"
+        );
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 1);
     }
@@ -1190,6 +1266,25 @@ mod tests {
         }
     }
 
+    /// In-place proposal whose proposal ratio depends on both old and new state.
+    struct StateDependentMutProposal {
+        target_value: f64,
+    }
+    impl ProposalMut<MutScalar> for StateDependentMutProposal {
+        type Undo = f64;
+        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut MutScalar, _rng: &mut R) -> Option<f64> {
+            let old = state.0;
+            state.0 = self.target_value;
+            Some(old)
+        }
+        fn undo(&self, state: &mut MutScalar, old: f64) {
+            state.0 = old;
+        }
+        fn log_q_ratio(&self, state: &MutScalar, old: &f64) -> f64 {
+            old - state.0
+        }
+    }
+
     #[test]
     fn positive_log_q_ratio_promotes_acceptance() {
         // From x=0 (log_prob=0) to x=1 (log_prob=-0.5).
@@ -1255,6 +1350,33 @@ mod tests {
         let accepted2 = chain2.step_mut(&Normal, &proposal2, &mut rng2).unwrap();
         assert!(!accepted2, "Large negative log_q should force rejection");
         assert_eq!(chain2.state, MutScalar(2.0));
+    }
+
+    #[test]
+    fn step_mut_log_q_ratio_can_depend_on_old_and_new_state() {
+        let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let proposal = StateDependentMutProposal { target_value: 0.0 };
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let accepted = chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+
+        assert!(
+            accepted,
+            "old - new log q-ratio should contribute to acceptance"
+        );
+        assert_eq!(chain.state, MutScalar(0.0));
+
+        let mut chain2 = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let proposal2 = StateDependentMutProposal { target_value: 2.0 };
+        let mut rng2 = StdRng::seed_from_u64(42);
+
+        let accepted2 = chain2.step_mut(&Normal, &proposal2, &mut rng2).unwrap();
+
+        assert!(
+            !accepted2,
+            "new state and old-state undo token should both affect log q-ratio"
+        );
+        assert_eq!(chain2.state, MutScalar(0.0));
     }
 
     // --- Edge case: -inf log-probability ---
@@ -1331,6 +1453,33 @@ mod tests {
             chain.state,
             Scalar(0.0),
             "Should reject when both states have -inf log_prob"
+        );
+        assert_eq!(chain.rejected(), 1);
+    }
+
+    #[test]
+    fn step_mut_rejects_both_neg_inf() {
+        struct AlwaysNegInf;
+        impl Target<MutScalar> for AlwaysNegInf {
+            fn log_prob(&self, _state: &MutScalar) -> f64 {
+                f64::NEG_INFINITY
+            }
+        }
+
+        let mut chain = Chain::new(MutScalar(0.0), &AlwaysNegInf).unwrap();
+        let proposal = FixedMutProposal(1.0);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let accepted = chain.step_mut(&AlwaysNegInf, &proposal, &mut rng).unwrap();
+
+        assert!(
+            !accepted,
+            "Should reject when both states have -inf log_prob"
+        );
+        assert_eq!(
+            chain.state,
+            MutScalar(0.0),
+            "State should be rolled back after NaN log acceptance ratio"
         );
         assert_eq!(chain.rejected(), 1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,27 @@
 //! methods over arbitrary state spaces, including discrete and combinatorial
 //! systems (e.g., triangulations).
 //!
+//! [`Target::log_prob`] should return an unnormalized natural log-probability
+//! or log-density.  Additive constants are fine because Metropolis-Hastings
+//! only uses differences, but arbitrary scores or logits will sample a
+//! different distribution.
+//!
+//! # Numerical semantics
+//!
+//! The core Metropolis-Hastings acceptance calculation is performed in log
+//! space using `f64`.  Domain-specific code may use exact arithmetic internally
+//! for predicates or invariant checks, but targets and proposal ratios cross the
+//! crate boundary as log weights:
+//!
+//! - finite values represent unnormalized log probability mass/density
+//! - `f64::NEG_INFINITY` represents an impossible or zero-probability state
+//! - `NaN` log-probabilities and log proposal ratios are rejected with
+//!   [`McmcError`]
+//! - `+∞` log-probabilities and log proposal ratios are rejected with
+//!   [`McmcError`]
+//! - acceptance ratios that become `NaN` during arithmetic, such as
+//!   `-∞ - (-∞)`, are treated as rejection
+//!
 //! # Example
 //!
 //! Sample from a standard normal distribution using Metropolis–Hastings:
@@ -127,11 +148,11 @@
 //!
 //! // Burn-in
 //! sampler.run(1000)?;
-//! sampler.chain.reset_counters();
+//! sampler.chain_mut().reset_counters();
 //!
 //! // Production
 //! sampler.run(10_000)?;
-//! assert!(sampler.chain.acceptance_rate() > 0.0);
+//! assert!(sampler.chain_ref().acceptance_rate() > 0.0);
 //! # Ok::<(), McmcError>(())
 //! ```
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -14,7 +14,7 @@ use crate::{Chain, McmcError, Proposal, ProposalMut, Target};
 /// single Metropolis–Hastings steps and [`run`](Self::run) /
 /// [`run_mut`](Self::run_mut) for bulk sampling.
 ///
-/// For the clone-based path (`P: Proposal<S>`), `Sampler` also implements
+/// For the by-value proposal path (`P: Proposal<S>`), `Sampler` also implements
 /// [`Iterator`], yielding `Result<(), McmcError>` on each step.
 ///
 /// # Example
@@ -44,17 +44,17 @@ use crate::{Chain, McmcError, Proposal, ProposalMut, Target};
 ///
 /// // Burn-in
 /// sampler.run(1000)?;
-/// sampler.chain.reset_counters();
+/// sampler.chain_mut().reset_counters();
 ///
 /// // Production sampling
 /// sampler.run(10_000)?;
-/// assert!(sampler.chain.acceptance_rate() > 0.0);
+/// assert!(sampler.chain_ref().acceptance_rate() > 0.0);
 /// # Ok::<(), McmcError>(())
 /// ```
 #[must_use]
 pub struct Sampler<'a, S, T, P, R: ?Sized> {
     /// The MCMC chain being sampled.
-    pub chain: Chain<S>,
+    chain: Chain<S>,
     target: &'a T,
     proposal: &'a P,
     rng: &'a mut R,
@@ -81,6 +81,20 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
         }
     }
 
+    /// Shared reference to the inner chain.
+    pub const fn chain_ref(&self) -> &Chain<S> {
+        &self.chain
+    }
+
+    /// Mutable reference to the inner chain.
+    ///
+    /// This permits operations such as [`Chain::reset_counters`] or
+    /// [`Chain::replace_state`] without exposing `Sampler`'s fields as part of
+    /// its public representation.
+    pub const fn chain_mut(&mut self) -> &mut Chain<S> {
+        &mut self.chain
+    }
+
     /// Consume the sampler and return the inner chain.
     ///
     /// ```
@@ -105,16 +119,15 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     }
 }
 
-// --- Clone-based stepping ---
+// --- By-value stepping ---
 
 impl<S, T, P, R> Sampler<'_, S, T, P, R>
 where
-    S: Clone,
     T: Target<S>,
     P: Proposal<S>,
     R: Rng + ?Sized,
 {
-    /// Perform a single clone-based Metropolis–Hastings step.
+    /// Perform a single by-value Metropolis–Hastings step.
     ///
     /// Delegates to [`Chain::step`].
     ///
@@ -135,7 +148,7 @@ where
     /// let chain = Chain::new(S(0.0), &T)?;
     /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
     /// sampler.step()?;
-    /// assert_eq!(sampler.chain.total_steps(), 1);
+    /// assert_eq!(sampler.chain_ref().total_steps(), 1);
     /// # Ok::<(), McmcError>(())
     /// ```
     ///
@@ -146,7 +159,7 @@ where
         self.chain.step(self.target, self.proposal, self.rng)
     }
 
-    /// Run `steps` clone-based Metropolis–Hastings steps.
+    /// Run `steps` by-value Metropolis–Hastings steps.
     ///
     /// Stops and returns the first error encountered.
     ///
@@ -168,7 +181,7 @@ where
     /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
     ///
     /// sampler.run(1000)?;
-    /// assert_eq!(sampler.chain.total_steps(), 1000);
+    /// assert_eq!(sampler.chain_ref().total_steps(), 1000);
     /// # Ok::<(), McmcError>(())
     /// ```
     ///
@@ -215,7 +228,7 @@ where
     /// let chain = Chain::new(S(0.0), &T)?;
     /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
     /// let accepted = sampler.step_mut()?;
-    /// assert_eq!(sampler.chain.total_steps(), 1);
+    /// assert_eq!(sampler.chain_ref().total_steps(), 1);
     /// # Ok::<(), McmcError>(())
     /// ```
     ///
@@ -255,7 +268,7 @@ where
     /// let mut sampler = Sampler::new(chain, &Ising, &Flip, &mut rng);
     ///
     /// sampler.run_mut(1000)?;
-    /// assert_eq!(sampler.chain.total_steps(), 1000);
+    /// assert_eq!(sampler.chain_ref().total_steps(), 1000);
     /// # Ok::<(), McmcError>(())
     /// ```
     ///
@@ -270,18 +283,17 @@ where
     }
 }
 
-// --- Iterator (clone-based path only) ---
+// --- Iterator (by-value proposal path only) ---
 
 impl<S, T, P, R> Iterator for Sampler<'_, S, T, P, R>
 where
-    S: Clone,
     T: Target<S>,
     P: Proposal<S>,
     R: Rng + ?Sized,
 {
     type Item = Result<(), McmcError>;
 
-    /// Perform one clone-based step and yield the result.
+    /// Perform one by-value step and yield the result.
     ///
     /// This is an infinite iterator — it always returns `Some`.
     /// Use `.take(n)` to limit the number of steps.
@@ -310,7 +322,7 @@ where
     /// // Take exactly 100 steps using iterator
     /// let errors: Vec<_> = sampler.by_ref().take(100).filter_map(Result::err).collect();
     /// assert!(errors.is_empty());
-    /// assert_eq!(sampler.chain.total_steps(), 100);
+    /// assert_eq!(sampler.chain_ref().total_steps(), 100);
     /// # Ok::<(), McmcError>(())
     /// ```
     fn next(&mut self) -> Option<Self::Item> {
@@ -392,7 +404,7 @@ mod tests {
         assert!(debug.contains("chain"));
     }
 
-    // --- Clone-based: step and run ---
+    // --- By-value: step and run ---
 
     #[test]
     fn step_advances_chain() {
@@ -401,7 +413,7 @@ mod tests {
         let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
 
         sampler.step().unwrap();
-        assert_eq!(sampler.chain.total_steps(), 1);
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
 
     #[test]
@@ -411,7 +423,7 @@ mod tests {
         let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
 
         sampler.run(500).unwrap();
-        assert_eq!(sampler.chain.total_steps(), 500);
+        assert_eq!(sampler.chain_ref().total_steps(), 500);
     }
 
     // --- In-place: step_mut and run_mut ---
@@ -423,7 +435,7 @@ mod tests {
         let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
 
         sampler.step_mut().unwrap();
-        assert_eq!(sampler.chain.total_steps(), 1);
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
 
     #[test]
@@ -433,7 +445,7 @@ mod tests {
         let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
 
         sampler.run_mut(500).unwrap();
-        assert_eq!(sampler.chain.total_steps(), 500);
+        assert_eq!(sampler.chain_ref().total_steps(), 500);
     }
 
     // --- Iterator ---
@@ -448,7 +460,7 @@ mod tests {
         for result in sampler.by_ref().take(200) {
             result.unwrap();
         }
-        assert_eq!(sampler.chain.total_steps(), 200);
+        assert_eq!(sampler.chain_ref().total_steps(), 200);
     }
 
     #[test]
@@ -483,9 +495,9 @@ mod tests {
         let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2);
         sampler.run(steps).unwrap();
 
-        assert_eq!(chain.state, sampler.chain.state);
-        assert_eq!(chain.accepted(), sampler.chain.accepted());
-        assert_eq!(chain.rejected(), sampler.chain.rejected());
+        assert_eq!(chain.state, *sampler.chain_ref().state());
+        assert_eq!(chain.accepted(), sampler.chain_ref().accepted());
+        assert_eq!(chain.rejected(), sampler.chain_ref().rejected());
     }
 
     #[test]
@@ -506,7 +518,8 @@ mod tests {
         let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2);
         sampler.run_mut(steps).unwrap();
 
-        assert_eq!(chain.state, sampler.chain.state);
-        assert_eq!(chain.accepted(), sampler.chain.accepted());
+        assert_eq!(chain.state, *sampler.chain_ref().state());
+        assert_eq!(chain.accepted(), sampler.chain_ref().accepted());
+        assert_eq!(chain.rejected(), sampler.chain_ref().rejected());
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,19 +2,29 @@
 
 use rand::Rng;
 
-/// Target distribution
+/// Target distribution.
+///
+/// `log_prob` returns a value proportional to the natural logarithm of the
+/// target probability mass or density at `state`.  It may be an unnormalized
+/// log-density or negative energy/action; additive constants do not affect
+/// Metropolis-Hastings acceptance probabilities.
+///
+/// This is not a logit or arbitrary score: differences between two returned
+/// values must be log probability ratios for the chain to target the intended
+/// distribution.  Return `f64::NEG_INFINITY` for impossible states.
 pub trait Target<S> {
     /// Compute log-probability (or negative energy/action).
     fn log_prob(&self, state: &S) -> f64;
 }
 
-/// Proposal distribution for generating new states.
+/// Proposal distribution for generating new states by value.
 ///
-/// This trait uses a clone-based model: [`propose`](Proposal::propose) returns
-/// a new state by value.  For state spaces where cloning is expensive (e.g.,
-/// triangulations, large graphs), see [`ProposalMut`] which mutates in place
-/// and supports cheap rollback.
-pub trait Proposal<S: Clone> {
+/// This trait returns a proposed state by value.  Implementations for small
+/// state spaces often clone and modify the current state internally, but the
+/// trait itself does not require `S: Clone`.  For state spaces where allocating
+/// a whole proposed state is expensive (e.g., triangulations, large graphs),
+/// see [`ProposalMut`] which mutates in place and supports cheap rollback.
+pub trait Proposal<S> {
     /// Propose a new state from the current one.
     fn propose<R: Rng + ?Sized>(&self, current: &S, rng: &mut R) -> S;
 
@@ -45,6 +55,12 @@ pub trait ProposalMut<S> {
 
     /// Mutate `state` in place, returning `Some(undo_token)` on success
     /// or `None` if no valid move could be found.
+    ///
+    /// Returning `None` must leave `state` exactly as it was on entry.  If a
+    /// proposal mutates state before discovering that the move is invalid, it
+    /// must undo those changes before returning `None`.  Once `Some(token)` is
+    /// returned, [`undo`](ProposalMut::undo) must be able to restore the exact
+    /// prior state.
     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, rng: &mut R) -> Option<Self::Undo>;
 
     /// Reverse a previously applied move using its undo token.

--- a/tests/proptest_chain.rs
+++ b/tests/proptest_chain.rs
@@ -81,7 +81,7 @@ proptest! {
         );
     }
 
-    /// Same property for the clone-based `step`.
+    /// Same property for the by-value `step`.
     #[test]
     fn log_prob_consistent_after_step(
         initial in -10.0f64..10.0,
@@ -166,7 +166,7 @@ proptest! {
         );
     }
 
-    /// Same counts invariant for the clone-based `step`.
+    /// Same counts invariant for the by-value `step`.
     #[test]
     fn counts_invariant_step(
         initial in -10.0f64..10.0,
@@ -214,9 +214,9 @@ proptest! {
         let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2);
         sampler.run(steps as usize).unwrap();
 
-        prop_assert_eq!(chain.state(), sampler.chain.state());
-        prop_assert_eq!(chain.accepted(), sampler.chain.accepted());
-        prop_assert_eq!(chain.rejected(), sampler.chain.rejected());
+        prop_assert_eq!(chain.state(), sampler.chain_ref().state());
+        prop_assert_eq!(chain.accepted(), sampler.chain_ref().accepted());
+        prop_assert_eq!(chain.rejected(), sampler.chain_ref().rejected());
     }
 
     /// `Sampler::run_mut` must produce identical results to a raw `Chain`
@@ -243,8 +243,8 @@ proptest! {
         let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2);
         sampler.run_mut(steps as usize).unwrap();
 
-        prop_assert_eq!(chain.state(), sampler.chain.state());
-        prop_assert_eq!(chain.accepted(), sampler.chain.accepted());
-        prop_assert_eq!(chain.rejected(), sampler.chain.rejected());
+        prop_assert_eq!(chain.state(), sampler.chain_ref().state());
+        prop_assert_eq!(chain.accepted(), sampler.chain_ref().accepted());
+        prop_assert_eq!(chain.rejected(), sampler.chain_ref().rejected());
     }
 }


### PR DESCRIPTION
- keep Metropolis-Hastings acceptance decisions in log space
- explicitly reject arithmetic-created NaN acceptance ratios
- document log_prob semantics and numerical behavior at the crate level
- strengthen ProposalMut::propose_mut(None) contract
- remove unnecessary S: Clone bound from by-value Proposal APIs
- make Sampler chain storage private and expose chain_ref/chain_mut accessors
- update examples, README, and organization docs for by-value proposal wording
- add tests for extreme log-domain acceptance, no-move rollback, state-dependent log_q_ratio, and -inf edge cases