### PR TITLE
feat: add delayed-commit proposal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The design emphasizes:
 ### Clone-based (simple states)
 
 ```rust
-use markov_chain_monte_carlo::prelude::*;
+use markov_chain_monte_carlo::prelude::by_value::*;
 use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 
 #[derive(Clone)]
@@ -84,7 +84,7 @@ fn main() -> Result<(), McmcError> {
 ### Using `Sampler` (ergonomic wrapper)
 
 ```rust
-use markov_chain_monte_carlo::prelude::*;
+use markov_chain_monte_carlo::prelude::by_value::*;
 use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 
 # #[derive(Clone)] struct Scalar(f64);
@@ -117,7 +117,7 @@ fn main() -> Result<(), McmcError> {
 ### In-place mutation (combinatorial states)
 
 ```rust
-use markov_chain_monte_carlo::prelude::*;
+use markov_chain_monte_carlo::prelude::in_place::*;
 use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 
 struct SpinChain { spins: Vec<i8> }  // not Clone

--- a/examples/ising_1d.rs
+++ b/examples/ising_1d.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: `cargo run --example ising_1d`
 
-use markov_chain_monte_carlo::prelude::*;
+use markov_chain_monte_carlo::prelude::in_place::*;
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
 

--- a/examples/iterator_sampling.rs
+++ b/examples/iterator_sampling.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: `cargo run --example iterator_sampling`
 
-use markov_chain_monte_carlo::prelude::*;
+use markov_chain_monte_carlo::prelude::by_value::*;
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
 

--- a/examples/normal_1d.rs
+++ b/examples/normal_1d.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: `cargo run --example normal_1d`
 
-use markov_chain_monte_carlo::prelude::*;
+use markov_chain_monte_carlo::prelude::by_value::*;
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,10 +1,18 @@
 //! MCMC chain implementation.
 
+use std::error::Error;
+use std::fmt;
+
 use rand::distr::Open01;
 use rand::{Rng, RngExt};
 
-use crate::{McmcError, Proposal, ProposalMut, Target};
+use crate::{DelayedProposal, McmcError, Proposal, ProposalMut, Target};
 
+/// Decide acceptance from a precomputed `log(u)`.
+///
+/// This helper keeps the edge-case policy in one place: nonnegative
+/// log-acceptance ratios always accept, negative ratios compare in log space,
+/// and NaN acceptance ratios are treated as ordinary rejections.
 fn accept_from_log_uniform(log_alpha: f64, log_u: f64) -> bool {
     // NaN can arise from valid inputs such as -inf - (-inf); treat that as a
     // zero acceptance probability instead of relying on float comparison quirks.
@@ -17,9 +25,116 @@ fn accept_from_log_uniform(log_alpha: f64, log_u: f64) -> bool {
     }
 }
 
+/// Draw a log-uniform variate and apply Metropolis-Hastings acceptance.
+///
+/// This exists so all step implementations use the same stable log-space
+/// acceptance rule without exponentiating tiny probabilities.
 fn accept_log_alpha<R: Rng + ?Sized>(log_alpha: f64, rng: &mut R) -> bool {
     let log_u: f64 = rng.sample::<f64, _>(Open01).ln();
     accept_from_log_uniform(log_alpha, log_u)
+}
+
+/// Check a proposed state's log-probability.
+///
+/// This centralizes the crate's numeric contract for proposed states:
+/// finite values and `-inf` are allowed, while NaN and `+inf` are reported
+/// with the proposal-specific `McmcError` variants.
+fn check_proposed_log_prob(log_prob: f64) -> Result<(), McmcError> {
+    if log_prob.is_nan() {
+        return Err(McmcError::NanProposedLogProb);
+    }
+    if log_prob == f64::INFINITY {
+        return Err(McmcError::InfiniteProposedLogProb);
+    }
+    Ok(())
+}
+
+/// Check a proposal log q-ratio.
+///
+/// This keeps by-value, in-place, and delayed proposal paths orthogonal in
+/// implementation while preserving identical NaN and `+inf` error semantics.
+fn check_log_q_ratio(log_q: f64) -> Result<(), McmcError> {
+    if log_q.is_nan() {
+        return Err(McmcError::NanLogQRatio);
+    }
+    if log_q == f64::INFINITY {
+        return Err(McmcError::InfiniteLogQRatio);
+    }
+    Ok(())
+}
+
+/// Telemetry for a single Metropolis-Hastings step.
+#[derive(Debug, Clone, PartialEq)]
+#[must_use]
+pub struct Step<I> {
+    /// Whether the move was accepted and committed.
+    pub accepted: bool,
+    /// Whether a proposal was produced.
+    pub proposed: bool,
+    /// Proposal-specific metadata, when a proposal was produced.
+    pub info: Option<I>,
+    /// Cached log-probability before the step.
+    pub log_prob_before: f64,
+    /// Cached log-probability after the step, when it changed.
+    pub log_prob_after: Option<f64>,
+    /// Metropolis-Hastings log acceptance ratio, when one was evaluated.
+    pub log_alpha: Option<f64>,
+}
+
+/// Telemetry for a delayed-commit Metropolis-Hastings step.
+pub type DelayedStep<I> = Step<I>;
+
+/// Errors from a delayed-commit Metropolis-Hastings step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DelayedStepError<E> {
+    /// The delayed proposal produced invalid MCMC numerics.
+    Mcmc(McmcError),
+    /// Planning a delayed proposal failed.
+    Plan(E),
+    /// Evaluating the proposed state's log-probability failed.
+    ProposedLogProb(E),
+    /// Evaluating the proposal log q-ratio failed.
+    LogQRatio(E),
+    /// Committing an accepted proposal failed.
+    Commit(E),
+}
+
+impl<E: fmt::Display> fmt::Display for DelayedStepError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Mcmc(err) => write!(f, "{err}"),
+            Self::Plan(err) => write!(f, "delayed proposal planning failed: {err}"),
+            Self::ProposedLogProb(err) => {
+                write!(
+                    f,
+                    "delayed proposal log-probability evaluation failed: {err}"
+                )
+            }
+            Self::LogQRatio(err) => {
+                write!(f, "delayed proposal log q-ratio evaluation failed: {err}")
+            }
+            Self::Commit(err) => write!(f, "delayed proposal commit failed: {err}"),
+        }
+    }
+}
+
+impl<E> From<McmcError> for DelayedStepError<E> {
+    fn from(err: McmcError) -> Self {
+        Self::Mcmc(err)
+    }
+}
+
+impl<E: Error + 'static> Error for DelayedStepError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Mcmc(err) => Some(err),
+            Self::Plan(err)
+            | Self::ProposedLogProb(err)
+            | Self::LogQRatio(err)
+            | Self::Commit(err) => Some(err),
+        }
+    }
 }
 
 /// A single MCMC chain.
@@ -78,7 +193,7 @@ impl<S> Chain<S> {
     /// [`step_mut`](Self::step_mut).
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// # #[derive(Clone)] struct S(f64);
@@ -112,20 +227,10 @@ impl<S> Chain<S> {
     {
         let proposed = proposal.propose(&self.state, rng);
         let log_prob_new = target.log_prob(&proposed);
-        if log_prob_new.is_nan() {
-            return Err(McmcError::NanProposedLogProb);
-        }
-        if log_prob_new == f64::INFINITY {
-            return Err(McmcError::InfiniteProposedLogProb);
-        }
+        check_proposed_log_prob(log_prob_new)?;
 
         let log_q = proposal.log_q_ratio(&self.state, &proposed);
-        if log_q.is_nan() {
-            return Err(McmcError::NanLogQRatio);
-        }
-        if log_q == f64::INFINITY {
-            return Err(McmcError::InfiniteLogQRatio);
-        }
+        check_log_q_ratio(log_q)?;
 
         let log_alpha = log_prob_new - self.log_prob + log_q;
 
@@ -152,7 +257,7 @@ impl<S> Chain<S> {
     /// (including when the proposal returns `None`).
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// # struct S(f64);
@@ -195,23 +300,15 @@ impl<S> Chain<S> {
         };
 
         let log_prob_new = target.log_prob(&self.state);
-        if log_prob_new.is_nan() {
+        if let Err(err) = check_proposed_log_prob(log_prob_new) {
             proposal.undo(&mut self.state, token);
-            return Err(McmcError::NanProposedLogProb);
-        }
-        if log_prob_new == f64::INFINITY {
-            proposal.undo(&mut self.state, token);
-            return Err(McmcError::InfiniteProposedLogProb);
+            return Err(err);
         }
 
         let log_q = proposal.log_q_ratio(&self.state, &token);
-        if log_q.is_nan() {
+        if let Err(err) = check_log_q_ratio(log_q) {
             proposal.undo(&mut self.state, token);
-            return Err(McmcError::NanLogQRatio);
-        }
-        if log_q == f64::INFINITY {
-            proposal.undo(&mut self.state, token);
-            return Err(McmcError::InfiniteLogQRatio);
+            return Err(err);
         }
 
         let log_alpha = log_prob_new - self.log_prob + log_q;
@@ -226,6 +323,149 @@ impl<S> Chain<S> {
             self.rejected += 1;
         }
         Ok(accept)
+    }
+
+    /// Perform a single delayed-commit Metropolis-Hastings step.
+    ///
+    /// The proposal first returns a move plan without mutating the state.
+    /// `Chain` evaluates the Metropolis-Hastings accept/reject decision and
+    /// calls [`DelayedProposal::commit`] only after acceptance.
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct TargetLine;
+    /// impl Target<i32> for TargetLine {
+    ///     fn log_prob(&self, state: &i32) -> f64 {
+    ///         -f64::from(state.abs())
+    ///     }
+    /// }
+    ///
+    /// struct MoveRight;
+    /// impl DelayedProposal<i32> for MoveRight {
+    ///     type Plan = i32;
+    ///     type Info = i32;
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _state: &i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<Option<i32>, Self::Error> {
+    ///         Ok(Some(1))
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<i32>>(
+    ///         &self,
+    ///         state: &i32,
+    ///         plan: &i32,
+    ///         target: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         Ok(target.log_prob(&(*state + *plan)))
+    ///     }
+    ///
+    ///     fn info(&self, plan: &i32) -> i32 {
+    ///         *plan
+    ///     }
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         state: &mut i32,
+    ///         plan: i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         *state += plan;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let target = TargetLine;
+    /// let mut proposal = MoveRight;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let mut chain = Chain::new(-1, &target)?;
+    ///
+    /// let step = chain.step_delayed(&target, &mut proposal, &mut rng)?;
+    /// assert!(step.accepted);
+    /// assert_eq!(*chain.state(), 0);
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DelayedStepError::Plan`] if planning fails,
+    /// [`DelayedStepError::ProposedLogProb`] if proposed log-probability
+    /// evaluation fails, [`DelayedStepError::LogQRatio`] if proposal-ratio
+    /// evaluation fails, [`DelayedStepError::Mcmc`] on invalid
+    /// log-probability or log q-ratio values, and [`DelayedStepError::Commit`]
+    /// if applying an accepted move fails.
+    pub fn step_delayed<T, P, R>(
+        &mut self,
+        target: &T,
+        proposal: &mut P,
+        rng: &mut R,
+    ) -> Result<DelayedStep<P::Info>, DelayedStepError<P::Error>>
+    where
+        T: Target<S>,
+        P: DelayedProposal<S>,
+        R: Rng + ?Sized,
+    {
+        let log_prob_before = self.log_prob;
+        let Some(plan) = proposal
+            .propose_plan(&self.state, rng)
+            .map_err(DelayedStepError::Plan)?
+        else {
+            self.rejected += 1;
+            return Ok(Step {
+                accepted: false,
+                proposed: false,
+                info: None,
+                log_prob_before,
+                log_prob_after: None,
+                log_alpha: None,
+            });
+        };
+
+        let log_prob_new = proposal
+            .proposed_log_prob(&self.state, &plan, target)
+            .map_err(DelayedStepError::ProposedLogProb)?;
+        check_proposed_log_prob(log_prob_new).map_err(DelayedStepError::Mcmc)?;
+
+        let log_q = proposal
+            .log_q_ratio(&self.state, &plan)
+            .map_err(DelayedStepError::LogQRatio)?;
+        check_log_q_ratio(log_q).map_err(DelayedStepError::Mcmc)?;
+
+        let log_alpha = log_prob_new - self.log_prob + log_q;
+        let accept = accept_log_alpha(log_alpha, rng);
+        let info = proposal.info(&plan);
+
+        if accept {
+            proposal
+                .commit(&mut self.state, plan, rng)
+                .map_err(DelayedStepError::Commit)?;
+            self.log_prob = log_prob_new;
+            self.accepted += 1;
+            Ok(Step {
+                accepted: true,
+                proposed: true,
+                info: Some(info),
+                log_prob_before,
+                log_prob_after: Some(log_prob_new),
+                log_alpha: Some(log_alpha),
+            })
+        } else {
+            self.rejected += 1;
+            Ok(Step {
+                accepted: false,
+                proposed: true,
+                info: Some(info),
+                log_prob_before,
+                log_prob_after: None,
+                log_alpha: Some(log_alpha),
+            })
+        }
     }
 
     /// Shared reference to the current state.
@@ -353,7 +593,7 @@ impl<S> Chain<S> {
     /// Total number of steps taken (`accepted + rejected`).
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// # #[derive(Clone)] struct S(f64);
@@ -382,7 +622,7 @@ impl<S> Chain<S> {
     /// Acceptance rate of the chain.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// # #[derive(Clone)] struct S(f64);
@@ -424,7 +664,7 @@ impl<S> Chain<S> {
     /// production phase only.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// # #[derive(Clone)] struct S(f64);
@@ -541,7 +781,7 @@ mod tests {
     }
 
     #[test]
-    fn accept_from_log_uniform_handles_extreme_tail_without_exp() {
+    fn accept_extreme_tail_log_space() {
         let log_alpha = -800.0;
 
         assert!(
@@ -695,7 +935,7 @@ mod tests {
     }
 
     #[test]
-    fn step_mut_rolls_back_on_inf_log_q_ratio() {
+    fn step_mut_undoes_inf_log_q() {
         struct InfQMutProposal;
         impl ProposalMut<MutScalar> for InfQMutProposal {
             type Undo = f64;
@@ -728,7 +968,7 @@ mod tests {
     }
 
     #[test]
-    fn step_mut_rolls_back_on_inf_log_prob() {
+    fn step_mut_undoes_inf_log_prob() {
         struct InfAtOrigin;
         impl Target<MutScalar> for InfAtOrigin {
             fn log_prob(&self, state: &MutScalar) -> f64 {
@@ -917,7 +1157,7 @@ mod tests {
     // --- step_mut None proposal ---
 
     #[test]
-    fn step_mut_returns_false_on_none_proposal() {
+    fn step_mut_none_rejects() {
         let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
         let log_prob = chain.log_prob();
         let mut rng = StdRng::seed_from_u64(42);
@@ -935,7 +1175,7 @@ mod tests {
     }
 
     #[test]
-    fn step_mut_allows_internal_rollback_before_none() {
+    fn step_mut_none_allows_probe() {
         let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
         let log_prob = chain.log_prob();
         let mut rng = StdRng::seed_from_u64(42);
@@ -961,7 +1201,7 @@ mod tests {
     // --- step_mut NaN rollback ---
 
     #[test]
-    fn step_mut_rolls_back_on_nan_log_prob() {
+    fn step_mut_undoes_nan_log_prob() {
         struct NanAtOrigin;
         impl Target<MutScalar> for NanAtOrigin {
             fn log_prob(&self, state: &MutScalar) -> f64 {
@@ -986,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn step_mut_rolls_back_on_nan_log_q_ratio() {
+    fn step_mut_undoes_nan_log_q() {
         struct NanQProposal;
         impl ProposalMut<MutScalar> for NanQProposal {
             type Undo = f64;
@@ -1147,10 +1387,362 @@ mod tests {
         );
     }
 
+    // =====================================================================
+    // DelayedProposal / step_delayed tests
+    // =====================================================================
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum DelayedFixtureError {
+        Plan,
+        Score,
+        Ratio,
+        Commit,
+    }
+
+    impl fmt::Display for DelayedFixtureError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{self:?}")
+        }
+    }
+
+    impl Error for DelayedFixtureError {}
+
+    struct FixedDelayedProposal {
+        proposed: f64,
+        log_q: Result<f64, DelayedFixtureError>,
+        plan_error: Option<DelayedFixtureError>,
+        score_error: Option<DelayedFixtureError>,
+        commit_error: Option<DelayedFixtureError>,
+    }
+
+    impl FixedDelayedProposal {
+        const fn new(proposed: f64) -> Self {
+            Self {
+                proposed,
+                log_q: Ok(0.0),
+                plan_error: None,
+                score_error: None,
+                commit_error: None,
+            }
+        }
+    }
+
+    impl DelayedProposal<MutScalar> for FixedDelayedProposal {
+        type Plan = f64;
+        type Info = f64;
+        type Error = DelayedFixtureError;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            _state: &MutScalar,
+            _rng: &mut R,
+        ) -> Result<Option<f64>, Self::Error> {
+            if let Some(err) = self.plan_error {
+                Err(err)
+            } else {
+                Ok(Some(self.proposed))
+            }
+        }
+
+        fn proposed_log_prob<T: Target<MutScalar>>(
+            &self,
+            _state: &MutScalar,
+            plan: &f64,
+            target: &T,
+        ) -> Result<f64, Self::Error> {
+            self.score_error
+                .map_or_else(|| Ok(target.log_prob(&MutScalar(*plan))), Err)
+        }
+
+        fn log_q_ratio(&self, _state: &MutScalar, _plan: &f64) -> Result<f64, Self::Error> {
+            self.log_q
+        }
+
+        fn info(&self, plan: &f64) -> f64 {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut MutScalar,
+            plan: f64,
+            _rng: &mut R,
+        ) -> Result<(), Self::Error> {
+            if let Some(err) = self.commit_error {
+                Err(err)
+            } else {
+                state.0 = plan;
+                Ok(())
+            }
+        }
+    }
+
+    struct NoDelayedProposal;
+
+    impl DelayedProposal<MutScalar> for NoDelayedProposal {
+        type Plan = f64;
+        type Info = f64;
+        type Error = DelayedFixtureError;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            _state: &MutScalar,
+            _rng: &mut R,
+        ) -> Result<Option<f64>, Self::Error> {
+            Ok(None)
+        }
+
+        fn proposed_log_prob<T: Target<MutScalar>>(
+            &self,
+            _state: &MutScalar,
+            _plan: &f64,
+            _target: &T,
+        ) -> Result<f64, Self::Error> {
+            unreachable!("no plan should not be scored")
+        }
+
+        fn info(&self, plan: &f64) -> f64 {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            _state: &mut MutScalar,
+            _plan: f64,
+            _rng: &mut R,
+        ) -> Result<(), Self::Error> {
+            unreachable!("no plan should not be committed")
+        }
+    }
+
+    #[test]
+    fn delayed_accepts_uphill() {
+        let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = FixedDelayedProposal::new(0.0);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let step = chain
+            .step_delayed(&Normal, &mut proposal, &mut rng)
+            .unwrap();
+
+        assert!(step.accepted);
+        assert!(step.proposed);
+        assert_eq!(step.info, Some(0.0));
+        assert!((step.log_prob_before - (-2.0)).abs() < 1e-12);
+        assert_eq!(step.log_prob_after, Some(0.0));
+        assert_eq!(step.log_alpha, Some(2.0));
+        assert_eq!(chain.state, MutScalar(0.0));
+        assert_eq!(chain.accepted(), 1);
+        assert_eq!(chain.rejected(), 0);
+    }
+
+    #[test]
+    fn delayed_rejects_downhill() {
+        let mut chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut proposal = FixedDelayedProposal::new(100.0);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let step = chain
+            .step_delayed(&Normal, &mut proposal, &mut rng)
+            .unwrap();
+
+        assert!(!step.accepted);
+        assert!(step.proposed);
+        assert_eq!(step.info, Some(100.0));
+        assert!(step.log_prob_before.abs() < f64::EPSILON);
+        assert_eq!(step.log_prob_after, None);
+        assert_eq!(step.log_alpha, Some(-5000.0));
+        assert_eq!(chain.state, MutScalar(0.0));
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 1);
+    }
+
+    #[test]
+    fn delayed_no_plan_rejects() {
+        let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let log_prob = chain.log_prob();
+        let mut proposal = NoDelayedProposal;
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let step = chain
+            .step_delayed(&Normal, &mut proposal, &mut rng)
+            .unwrap();
+
+        assert!(!step.accepted);
+        assert!(!step.proposed);
+        assert_eq!(step.info, None);
+        assert!((step.log_prob_before - log_prob).abs() < f64::EPSILON);
+        assert_eq!(step.log_prob_after, None);
+        assert_eq!(step.log_alpha, None);
+        assert_eq!(chain.state, MutScalar(1.0));
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 1);
+    }
+
+    #[test]
+    fn delayed_rejects_nan_log_prob() {
+        struct NanAtOrigin;
+        impl Target<MutScalar> for NanAtOrigin {
+            fn log_prob(&self, state: &MutScalar) -> f64 {
+                if state.0 == 0.0 {
+                    f64::NAN
+                } else {
+                    -0.5 * state.0 * state.0
+                }
+            }
+        }
+
+        let mut chain = Chain::new(MutScalar(1.0), &NanAtOrigin).unwrap();
+        let mut proposal = FixedDelayedProposal::new(0.0);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed(&NanAtOrigin, &mut proposal, &mut rng);
+
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::Mcmc(McmcError::NanProposedLogProb))
+        ));
+        assert_eq!(chain.state, MutScalar(1.0));
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 0);
+    }
+
+    #[test]
+    fn delayed_rejects_inf_log_prob() {
+        struct InfAtOrigin;
+        impl Target<MutScalar> for InfAtOrigin {
+            fn log_prob(&self, state: &MutScalar) -> f64 {
+                if state.0 == 0.0 {
+                    f64::INFINITY
+                } else {
+                    -0.5 * state.0 * state.0
+                }
+            }
+        }
+
+        let mut chain = Chain::new(MutScalar(1.0), &InfAtOrigin).unwrap();
+        let mut proposal = FixedDelayedProposal::new(0.0);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed(&InfAtOrigin, &mut proposal, &mut rng);
+
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::Mcmc(McmcError::InfiniteProposedLogProb))
+        ));
+        assert_eq!(chain.state, MutScalar(1.0));
+    }
+
+    #[test]
+    fn delayed_rejects_bad_log_q() {
+        let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let mut proposal = FixedDelayedProposal {
+            log_q: Ok(f64::NAN),
+            ..FixedDelayedProposal::new(0.0)
+        };
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
+
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::Mcmc(McmcError::NanLogQRatio))
+        ));
+        assert_eq!(chain.state, MutScalar(1.0));
+
+        proposal.log_q = Ok(f64::INFINITY);
+        let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::Mcmc(McmcError::InfiniteLogQRatio))
+        ));
+        assert_eq!(chain.state, MutScalar(1.0));
+    }
+
+    #[test]
+    fn delayed_maps_errors() {
+        let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let mut proposal = FixedDelayedProposal {
+            plan_error: Some(DelayedFixtureError::Plan),
+            ..FixedDelayedProposal::new(0.0)
+        };
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::Plan(DelayedFixtureError::Plan))
+        ));
+
+        proposal.plan_error = None;
+        proposal.score_error = Some(DelayedFixtureError::Score);
+        let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::ProposedLogProb(
+                DelayedFixtureError::Score
+            ))
+        ));
+
+        proposal.score_error = None;
+        proposal.log_q = Err(DelayedFixtureError::Ratio);
+        let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::LogQRatio(DelayedFixtureError::Ratio))
+        ));
+    }
+
+    #[test]
+    fn delayed_error_messages_name_stage() {
+        assert_eq!(
+            DelayedStepError::Plan(DelayedFixtureError::Plan).to_string(),
+            "delayed proposal planning failed: Plan"
+        );
+        assert_eq!(
+            DelayedStepError::ProposedLogProb(DelayedFixtureError::Score).to_string(),
+            "delayed proposal log-probability evaluation failed: Score"
+        );
+        assert_eq!(
+            DelayedStepError::LogQRatio(DelayedFixtureError::Ratio).to_string(),
+            "delayed proposal log q-ratio evaluation failed: Ratio"
+        );
+        assert_eq!(
+            DelayedStepError::Commit(DelayedFixtureError::Commit).to_string(),
+            "delayed proposal commit failed: Commit"
+        );
+        assert_eq!(
+            DelayedStepError::<DelayedFixtureError>::Mcmc(McmcError::NanLogQRatio).to_string(),
+            "proposal returned NaN log q-ratio"
+        );
+    }
+
+    #[test]
+    fn delayed_commit_error_is_atomic() {
+        let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let log_prob = chain.log_prob();
+        let mut proposal = FixedDelayedProposal {
+            commit_error: Some(DelayedFixtureError::Commit),
+            ..FixedDelayedProposal::new(0.0)
+        };
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
+
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::Commit(DelayedFixtureError::Commit))
+        ));
+        assert_eq!(chain.state, MutScalar(2.0));
+        assert!((chain.log_prob() - log_prob).abs() < f64::EPSILON);
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 0);
+    }
+
     // --- state accessors ---
 
     #[test]
-    fn replace_state_updates_state_and_log_prob() {
+    fn replace_state_updates_log_prob() {
         let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
         chain.replace_state(Scalar(2.0), &Normal).unwrap();
         assert_eq!(chain.state, Scalar(2.0));
@@ -1217,7 +1809,7 @@ mod tests {
     }
 
     #[test]
-    fn total_steps_equals_accepted_plus_rejected() {
+    fn total_steps_matches_counts() {
         let mut chain = Chain::new(Scalar(0.0), &Normal).unwrap();
         let proposal = RandomWalk { width: 1.0 };
         let mut rng = StdRng::seed_from_u64(42);
@@ -1286,7 +1878,7 @@ mod tests {
     }
 
     #[test]
-    fn positive_log_q_ratio_promotes_acceptance() {
+    fn positive_log_q_promotes_acceptance() {
         // From x=0 (log_prob=0) to x=1 (log_prob=-0.5).
         // Without asymmetry: log_alpha = -0.5, might reject.
         // With large positive log_q: log_alpha = -0.5 + 100 = 99.5, always accept.
@@ -1306,7 +1898,7 @@ mod tests {
     }
 
     #[test]
-    fn negative_log_q_ratio_promotes_rejection() {
+    fn negative_log_q_promotes_rejection() {
         // From x=2 (log_prob=-2) to x=0 (log_prob=0).
         // Without asymmetry: log_alpha = 2.0, always accept.
         // With large negative log_q: log_alpha = 2 - 100 = -98, always reject.
@@ -1326,7 +1918,7 @@ mod tests {
     }
 
     #[test]
-    fn step_mut_respects_asymmetric_log_q_ratio() {
+    fn step_mut_respects_log_q() {
         // Acceptance via step_mut with positive log_q
         let mut chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
         let proposal = AsymmetricMutProposal {
@@ -1353,7 +1945,7 @@ mod tests {
     }
 
     #[test]
-    fn step_mut_log_q_ratio_can_depend_on_old_and_new_state() {
+    fn step_mut_log_q_sees_old_and_new() {
         let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let proposal = StateDependentMutProposal { target_value: 0.0 };
         let mut rng = StdRng::seed_from_u64(42);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! Sample from a standard normal distribution using Metropolis–Hastings:
 //!
 //! ```
-//! use markov_chain_monte_carlo::prelude::*;
+//! use markov_chain_monte_carlo::prelude::by_value::*;
 //! use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 //!
 //! #[derive(Clone)]
@@ -75,7 +75,7 @@
 //! a small undo token for rollback on rejection:
 //!
 //! ```
-//! use markov_chain_monte_carlo::prelude::*;
+//! use markov_chain_monte_carlo::prelude::in_place::*;
 //! use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 //!
 //! /// A lattice of spins (not Clone — only mutated in place).
@@ -122,13 +122,82 @@
 //! }
 //! ```
 //!
+//! # Delayed commit proposals
+//!
+//! Use [`DelayedProposal`] with [`Chain::step_delayed`] when a proposal can
+//! plan and score a move before mutating the state, then commit only after the
+//! Metropolis-Hastings decision accepts it.
+//!
+//! ```
+//! use core::convert::Infallible;
+//! use markov_chain_monte_carlo::prelude::delayed::*;
+//! use rand::{Rng, SeedableRng, rngs::StdRng};
+//!
+//! struct TargetLine;
+//! impl Target<i32> for TargetLine {
+//!     fn log_prob(&self, state: &i32) -> f64 {
+//!         -f64::from(state.abs())
+//!     }
+//! }
+//!
+//! struct MoveRight;
+//! impl DelayedProposal<i32> for MoveRight {
+//!     type Plan = i32;
+//!     type Info = i32;
+//!     type Error = Infallible;
+//!
+//!     fn propose_plan<R: Rng + ?Sized>(
+//!         &mut self,
+//!         _state: &i32,
+//!         _rng: &mut R,
+//!     ) -> Result<Option<i32>, Self::Error> {
+//!         Ok(Some(1))
+//!     }
+//!
+//!     fn proposed_log_prob<T: Target<i32>>(
+//!         &self,
+//!         state: &i32,
+//!         plan: &i32,
+//!         target: &T,
+//!     ) -> Result<f64, Self::Error> {
+//!         Ok(target.log_prob(&(*state + *plan)))
+//!     }
+//!
+//!     fn info(&self, plan: &i32) -> i32 {
+//!         *plan
+//!     }
+//!
+//!     fn commit<R: Rng + ?Sized>(
+//!         &mut self,
+//!         state: &mut i32,
+//!         plan: i32,
+//!         _rng: &mut R,
+//!     ) -> Result<(), Self::Error> {
+//!         *state += plan;
+//!         Ok(())
+//!     }
+//! }
+//!
+//! fn main() -> Result<(), DelayedStepError<Infallible>> {
+//!     let target = TargetLine;
+//!     let mut proposal = MoveRight;
+//!     let mut rng = StdRng::seed_from_u64(42);
+//!     let mut chain = Chain::new(-1, &target).map_err(DelayedStepError::Mcmc)?;
+//!
+//!     let step = chain.step_delayed(&target, &mut proposal, &mut rng)?;
+//!     assert!(step.accepted);
+//!     assert_eq!(*chain.state(), 0);
+//!     Ok(())
+//! }
+//! ```
+//!
 //! # Ergonomic sampling with [`Sampler`]
 //!
 //! [`Sampler`] bundles a chain with its target, proposal, and RNG so you
 //! don't have to pass them on every step:
 //!
 //! ```
-//! use markov_chain_monte_carlo::prelude::*;
+//! use markov_chain_monte_carlo::prelude::by_value::*;
 //! use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 //!
 //! # #[derive(Clone)] struct Scalar(f64);
@@ -161,16 +230,63 @@ mod error;
 mod sampler;
 mod traits;
 
-pub use chain::Chain;
+pub use chain::{Chain, DelayedStep, DelayedStepError, Step};
 pub use error::McmcError;
 pub use sampler::Sampler;
-pub use traits::{Proposal, ProposalMut, Target};
+pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 
 /// Convenience re-exports for common usage.
 ///
+/// The top-level prelude contains only the shared sampling foundation:
+///
 /// ```
 /// use markov_chain_monte_carlo::prelude::*;
+///
+/// fn accepts_target<T: Target<f64>>(_: &T) {}
+/// ```
+///
+/// Workflow-specific preludes are available when tests, examples, or
+/// benchmarks should import only one proposal API:
+///
+/// ```
+/// use markov_chain_monte_carlo::prelude::by_value::*;
+/// use markov_chain_monte_carlo::prelude::delayed as delayed_prelude;
+/// use markov_chain_monte_carlo::prelude::in_place as in_place_prelude;
+///
+/// fn needs_by_value<T: Target<f64>, P: Proposal<f64>>(_: &T, _: &P) {}
+/// fn needs_in_place<
+///     T: in_place_prelude::Target<f64>,
+///     P: in_place_prelude::ProposalMut<f64>,
+/// >(_: &T, _: &P) {}
+/// fn needs_delayed<
+///     T: delayed_prelude::Target<f64>,
+///     P: delayed_prelude::DelayedProposal<f64>,
+/// >(_: &T, _: &P) {}
 /// ```
 pub mod prelude {
-    pub use crate::{Chain, McmcError, Proposal, ProposalMut, Sampler, Target};
+    pub use crate::{Chain, McmcError, Sampler, Target};
+
+    /// Prelude for by-value proposals.
+    ///
+    /// This imports the shared sampling types plus [`Proposal`], without
+    /// importing the in-place or delayed proposal traits.
+    pub mod by_value {
+        pub use crate::{Chain, McmcError, Proposal, Sampler, Target};
+    }
+
+    /// Prelude for in-place proposals with rollback.
+    ///
+    /// This imports the shared sampling types plus [`ProposalMut`], without
+    /// importing the by-value or delayed proposal traits.
+    pub mod in_place {
+        pub use crate::{Chain, McmcError, ProposalMut, Sampler, Target};
+    }
+
+    /// Prelude for delayed-commit proposals.
+    ///
+    /// This imports the shared sampling types plus delayed-step telemetry and
+    /// errors, without importing the by-value or in-place proposal traits.
+    pub mod delayed {
+        pub use crate::{Chain, DelayedProposal, DelayedStep, DelayedStepError, Sampler, Target};
+    }
 }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -4,12 +4,17 @@ use std::fmt;
 
 use rand::Rng;
 
-use crate::{Chain, McmcError, Proposal, ProposalMut, Target};
+use crate::{
+    Chain, DelayedProposal, DelayedStep, DelayedStepError, McmcError, Proposal, ProposalMut, Target,
+};
 
 /// Bundles a [`Chain`] with its target, proposal, and RNG for ergonomic
 /// sampling.
 ///
-/// `Sampler` owns the chain and borrows the target, proposal, and RNG.
+/// `Sampler` owns the chain and stores a proposal handle.  In typical use that
+/// handle is a shared borrow (`&P`) for by-value and in-place proposals, or a
+/// mutable borrow (`&mut P`) for delayed-commit proposals.  It also borrows the
+/// target and RNG.
 /// It provides [`step`](Self::step) / [`step_mut`](Self::step_mut) for
 /// single Metropolis–Hastings steps and [`run`](Self::run) /
 /// [`run_mut`](Self::run_mut) for bulk sampling.
@@ -20,7 +25,7 @@ use crate::{Chain, McmcError, Proposal, ProposalMut, Target};
 /// # Example
 ///
 /// ```
-/// use markov_chain_monte_carlo::prelude::*;
+/// use markov_chain_monte_carlo::prelude::by_value::*;
 /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 ///
 /// #[derive(Clone)]
@@ -56,7 +61,7 @@ pub struct Sampler<'a, S, T, P, R: ?Sized> {
     /// The MCMC chain being sampled.
     chain: Chain<S>,
     target: &'a T,
-    proposal: &'a P,
+    proposal: P,
     rng: &'a mut R,
 }
 
@@ -72,7 +77,27 @@ impl<S: fmt::Debug, T, P, R: ?Sized> fmt::Debug for Sampler<'_, S, T, P, R> {
 
 impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// Create a new sampler from its components.
-    pub const fn new(chain: Chain<S>, target: &'a T, proposal: &'a P, rng: &'a mut R) -> Self {
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T)?;
+    /// let sampler = Sampler::new(chain, &T, &P, &mut rng);
+    ///
+    /// assert_eq!(sampler.chain_ref().total_steps(), 0);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub const fn new(chain: Chain<S>, target: &'a T, proposal: P, rng: &'a mut R) -> Self {
         Self {
             chain,
             target,
@@ -82,6 +107,26 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     }
 
     /// Shared reference to the inner chain.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(1.0, &T)?;
+    /// let sampler = Sampler::new(chain, &T, &P, &mut rng);
+    ///
+    /// assert!((*sampler.chain_ref().state() - 1.0).abs() < f64::EPSILON);
+    /// # Ok::<(), McmcError>(())
+    /// ```
     pub const fn chain_ref(&self) -> &Chain<S> {
         &self.chain
     }
@@ -91,14 +136,90 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// This permits operations such as [`Chain::reset_counters`] or
     /// [`Chain::replace_state`] without exposing `Sampler`'s fields as part of
     /// its public representation.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(1.0, &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    ///
+    /// sampler.chain_mut().replace_state(2.0, &T)?;
+    /// assert!((*sampler.chain_ref().state() - 2.0).abs() < f64::EPSILON);
+    /// # Ok::<(), McmcError>(())
+    /// ```
     pub const fn chain_mut(&mut self) -> &mut Chain<S> {
         &mut self.chain
+    }
+
+    /// Shared reference to the stored proposal handle.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// struct Walk { width: f64 }
+    /// impl Proposal<f64> for Walk {
+    ///     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    ///         current + self.width
+    ///     }
+    /// }
+    ///
+    /// let proposal = Walk { width: 1.0 };
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T)?;
+    /// let sampler = Sampler::new(chain, &T, &proposal, &mut rng);
+    ///
+    /// assert!((sampler.proposal_ref().width - 1.0).abs() < f64::EPSILON);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    #[must_use]
+    pub const fn proposal_ref(&self) -> &P {
+        &self.proposal
+    }
+
+    /// Mutable reference to the stored proposal handle.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// struct Walk { width: f64 }
+    /// impl Proposal<f64> for Walk {
+    ///     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    ///         current + self.width
+    ///     }
+    /// }
+    ///
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, Walk { width: 1.0 }, &mut rng);
+    /// sampler.proposal_mut().width = 0.5;
+    ///
+    /// assert!((sampler.proposal_ref().width - 0.5).abs() < f64::EPSILON);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub const fn proposal_mut(&mut self) -> &mut P {
+        &mut self.proposal
     }
 
     /// Consume the sampler and return the inner chain.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{SeedableRng, rngs::StdRng};
     ///
     /// # struct T;
@@ -132,7 +253,7 @@ where
     /// Delegates to [`Chain::step`].
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// # #[derive(Clone)] struct S(f64);
@@ -156,7 +277,7 @@ where
     ///
     /// Returns [`McmcError`] on NaN or +∞ log-probability or NaN log q-ratio.
     pub fn step(&mut self) -> Result<(), McmcError> {
-        self.chain.step(self.target, self.proposal, self.rng)
+        self.chain.step(self.target, &self.proposal, self.rng)
     }
 
     /// Run `steps` by-value Metropolis–Hastings steps.
@@ -164,7 +285,7 @@ where
     /// Stops and returns the first error encountered.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// # #[derive(Clone)] struct S(f64);
@@ -210,7 +331,7 @@ where
     /// `Ok(false)` if rejected.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// # struct S(f64);
@@ -237,7 +358,7 @@ where
     /// Returns [`McmcError`] on NaN or +∞ log-probability or NaN log q-ratio
     /// (state is rolled back before the error is returned).
     pub fn step_mut(&mut self) -> Result<bool, McmcError> {
-        self.chain.step_mut(self.target, self.proposal, self.rng)
+        self.chain.step_mut(self.target, &self.proposal, self.rng)
     }
 
     /// Run `steps` in-place Metropolis–Hastings steps.
@@ -245,7 +366,7 @@ where
     /// Stops and returns the first error encountered.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// # struct Spins(Vec<i8>);
@@ -283,6 +404,157 @@ where
     }
 }
 
+// --- Delayed-commit stepping ---
+
+impl<S, T, P, R> Sampler<'_, S, T, P, R>
+where
+    T: Target<S>,
+    P: DelayedProposal<S>,
+    R: Rng + ?Sized,
+{
+    /// Perform a single delayed-commit Metropolis-Hastings step.
+    ///
+    /// Delegates to [`Chain::step_delayed`].
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct TargetLine;
+    /// impl Target<i32> for TargetLine {
+    ///     fn log_prob(&self, state: &i32) -> f64 { -f64::from(state.abs()) }
+    /// }
+    ///
+    /// struct MoveRight;
+    /// impl DelayedProposal<i32> for MoveRight {
+    ///     type Plan = i32;
+    ///     type Info = i32;
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _state: &i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<Option<i32>, Self::Error> {
+    ///         Ok(Some(1))
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<i32>>(
+    ///         &self,
+    ///         state: &i32,
+    ///         plan: &i32,
+    ///         target: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         Ok(target.log_prob(&(*state + *plan)))
+    ///     }
+    ///
+    ///     fn info(&self, plan: &i32) -> i32 { *plan }
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         state: &mut i32,
+    ///         plan: i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         *state += plan;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let target = TargetLine;
+    /// let mut proposal = MoveRight;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(-1, &target)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    ///
+    /// let step = sampler.step_delayed()?;
+    /// assert!(step.accepted);
+    /// assert_eq!(*sampler.chain_ref().state(), 0);
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DelayedStepError`] when planning, numerical validation, or
+    /// accepted-move commit fails.
+    pub fn step_delayed(&mut self) -> Result<DelayedStep<P::Info>, DelayedStepError<P::Error>> {
+        self.chain
+            .step_delayed(self.target, &mut self.proposal, self.rng)
+    }
+
+    /// Run `steps` delayed-commit Metropolis-Hastings steps.
+    ///
+    /// Stops and returns the first error encountered.
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct Flat;
+    /// impl Target<i32> for Flat {
+    ///     fn log_prob(&self, _: &i32) -> f64 { 0.0 }
+    /// }
+    ///
+    /// struct Increment;
+    /// impl DelayedProposal<i32> for Increment {
+    ///     type Plan = i32;
+    ///     type Info = i32;
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _state: &i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<Option<i32>, Self::Error> {
+    ///         Ok(Some(1))
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<i32>>(
+    ///         &self,
+    ///         state: &i32,
+    ///         plan: &i32,
+    ///         target: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         Ok(target.log_prob(&(*state + *plan)))
+    ///     }
+    ///
+    ///     fn info(&self, plan: &i32) -> i32 { *plan }
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         state: &mut i32,
+    ///         plan: i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         *state += plan;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let target = Flat;
+    /// let mut proposal = Increment;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &target)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    ///
+    /// sampler.run_delayed(3)?;
+    /// assert_eq!(*sampler.chain_ref().state(), 3);
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DelayedStepError`] on the first step that fails.
+    pub fn run_delayed(&mut self, steps: usize) -> Result<(), DelayedStepError<P::Error>> {
+        for _ in 0..steps {
+            let _ = self.step_delayed()?;
+        }
+        Ok(())
+    }
+}
+
 // --- Iterator (by-value proposal path only) ---
 
 impl<S, T, P, R> Iterator for Sampler<'_, S, T, P, R>
@@ -299,7 +571,7 @@ where
     /// Use `.take(n)` to limit the number of steps.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::*;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
     ///
     /// #[derive(Clone)]
@@ -332,6 +604,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use core::convert::Infallible;
+
     use super::*;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
 
@@ -446,6 +720,141 @@ mod tests {
 
         sampler.run_mut(500).unwrap();
         assert_eq!(sampler.chain_ref().total_steps(), 500);
+    }
+
+    // --- Delayed commit: step_delayed and run_delayed ---
+
+    struct DelayedToZero;
+    impl DelayedProposal<MutScalar> for DelayedToZero {
+        type Plan = f64;
+        type Info = f64;
+        type Error = Infallible;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            _state: &MutScalar,
+            _rng: &mut R,
+        ) -> Result<Option<f64>, Self::Error> {
+            Ok(Some(0.0))
+        }
+
+        fn proposed_log_prob<T: Target<MutScalar>>(
+            &self,
+            _state: &MutScalar,
+            plan: &f64,
+            target: &T,
+        ) -> Result<f64, Self::Error> {
+            Ok(target.log_prob(&MutScalar(*plan)))
+        }
+
+        fn info(&self, plan: &f64) -> f64 {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut MutScalar,
+            plan: f64,
+            _rng: &mut R,
+        ) -> Result<(), Self::Error> {
+            state.0 = plan;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn step_delayed_advances_chain() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = DelayedToZero;
+        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+
+        let step = sampler.step_delayed().unwrap();
+
+        assert!(step.accepted);
+        assert_eq!(sampler.chain_ref().state(), &MutScalar(0.0));
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
+    }
+
+    #[test]
+    fn run_delayed_n_steps() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = DelayedToZero;
+        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+
+        sampler.run_delayed(10).unwrap();
+
+        assert_eq!(sampler.chain_ref().state(), &MutScalar(0.0));
+        assert_eq!(sampler.chain_ref().total_steps(), 10);
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum DelayedRunError {
+        PlannedStop,
+    }
+
+    struct StopAfterFirstDelayed {
+        calls: usize,
+    }
+
+    impl DelayedProposal<MutScalar> for StopAfterFirstDelayed {
+        type Plan = f64;
+        type Info = f64;
+        type Error = DelayedRunError;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            _state: &MutScalar,
+            _rng: &mut R,
+        ) -> Result<Option<f64>, Self::Error> {
+            self.calls += 1;
+            if self.calls == 1 {
+                Ok(Some(0.0))
+            } else {
+                Err(DelayedRunError::PlannedStop)
+            }
+        }
+
+        fn proposed_log_prob<T: Target<MutScalar>>(
+            &self,
+            _state: &MutScalar,
+            plan: &f64,
+            target: &T,
+        ) -> Result<f64, Self::Error> {
+            Ok(target.log_prob(&MutScalar(*plan)))
+        }
+
+        fn info(&self, plan: &f64) -> f64 {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut MutScalar,
+            plan: f64,
+            _rng: &mut R,
+        ) -> Result<(), Self::Error> {
+            state.0 = plan;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn run_delayed_stops_on_first_error() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = StopAfterFirstDelayed { calls: 0 };
+        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+
+        let result = sampler.run_delayed(3);
+
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::Plan(DelayedRunError::PlannedStop))
+        ));
+        assert_eq!(sampler.chain_ref().state(), &MutScalar(0.0));
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
 
     // --- Iterator ---

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -37,6 +37,26 @@ pub trait Proposal<S> {
     }
 }
 
+impl<S, P: Proposal<S> + ?Sized> Proposal<S> for &P {
+    fn propose<R: Rng + ?Sized>(&self, current: &S, rng: &mut R) -> S {
+        (**self).propose(current, rng)
+    }
+
+    fn log_q_ratio(&self, current: &S, proposed: &S) -> f64 {
+        (**self).log_q_ratio(current, proposed)
+    }
+}
+
+impl<S, P: Proposal<S> + ?Sized> Proposal<S> for &mut P {
+    fn propose<R: Rng + ?Sized>(&self, current: &S, rng: &mut R) -> S {
+        (**self).propose(current, rng)
+    }
+
+    fn log_q_ratio(&self, current: &S, proposed: &S) -> f64 {
+        (**self).log_q_ratio(current, proposed)
+    }
+}
+
 /// In-place proposal distribution with rollback.
 ///
 /// Unlike [`Proposal`], which clones the state for each proposal,
@@ -74,8 +94,170 @@ pub trait ProposalMut<S> {
     }
 }
 
+impl<S, P: ProposalMut<S> + ?Sized> ProposalMut<S> for &P {
+    type Undo = P::Undo;
+
+    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, rng: &mut R) -> Option<Self::Undo> {
+        (**self).propose_mut(state, rng)
+    }
+
+    fn undo(&self, state: &mut S, token: Self::Undo) {
+        (**self).undo(state, token);
+    }
+
+    fn log_q_ratio(&self, state: &S, token: &Self::Undo) -> f64 {
+        (**self).log_q_ratio(state, token)
+    }
+}
+
+impl<S, P: ProposalMut<S> + ?Sized> ProposalMut<S> for &mut P {
+    type Undo = P::Undo;
+
+    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, rng: &mut R) -> Option<Self::Undo> {
+        (**self).propose_mut(state, rng)
+    }
+
+    fn undo(&self, state: &mut S, token: Self::Undo) {
+        (**self).undo(state, token);
+    }
+
+    fn log_q_ratio(&self, state: &S, token: &Self::Undo) -> f64 {
+        (**self).log_q_ratio(state, token)
+    }
+}
+
+/// Proposal distribution for accept-before-mutation workflows.
+///
+/// `DelayedProposal` separates planning, Metropolis-Hastings evaluation, and
+/// mutation:
+///
+/// 1. [`propose_plan`](Self::propose_plan) chooses a move descriptor without
+///    mutating the state.
+/// 2. [`proposed_log_prob`](Self::proposed_log_prob) evaluates the proposed
+///    state's log-probability from that descriptor.
+/// 3. [`crate::Chain::step_delayed`] performs the accept/reject draw.
+/// 4. [`commit`](Self::commit) mutates the state only after acceptance.
+///
+/// This is useful for combinatorial state spaces where the log-probability
+/// delta is cheap to compute from a move descriptor, but applying the move may
+/// require searching for a valid local site.  If `commit` returns an error, it
+/// must be failure-atomic: either the accepted move is applied completely, or
+/// `state` is restored before returning `Err`.
+pub trait DelayedProposal<S> {
+    /// Move descriptor produced before the Metropolis-Hastings decision.
+    type Plan;
+    /// User-facing metadata returned in delayed-step telemetry.
+    type Info;
+    /// Proposal-specific error type.
+    type Error;
+
+    /// Propose a move descriptor without mutating `state`.
+    ///
+    /// Return `Ok(None)` when no valid move can be proposed from the current
+    /// state.  That is counted as a rejection by [`crate::Chain::step_delayed`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when planning fails for proposal-specific reasons.
+    fn propose_plan<R: Rng + ?Sized>(
+        &mut self,
+        state: &S,
+        rng: &mut R,
+    ) -> Result<Option<Self::Plan>, Self::Error>;
+
+    /// Compute the proposed state's log-probability without mutating `state`.
+    ///
+    /// The returned value has the same numerical contract as
+    /// [`Target::log_prob`]: finite values and `f64::NEG_INFINITY` are valid,
+    /// while `NaN` and `+∞` are rejected by [`crate::Chain::step_delayed`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when the proposal cannot evaluate the plan.
+    fn proposed_log_prob<T: Target<S>>(
+        &self,
+        state: &S,
+        plan: &Self::Plan,
+        target: &T,
+    ) -> Result<f64, Self::Error>;
+
+    /// Log proposal ratio:
+    /// log(q(current | proposed) / q(proposed | current)).
+    ///
+    /// Defaults to 0 for symmetric proposals.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when the ratio cannot be evaluated.
+    fn log_q_ratio(&self, _state: &S, _plan: &Self::Plan) -> Result<f64, Self::Error> {
+        Ok(0.0)
+    }
+
+    /// Produce telemetry metadata for `plan`.
+    fn info(&self, plan: &Self::Plan) -> Self::Info;
+
+    /// Apply an accepted move to `state`.
+    ///
+    /// This method is called only after the Metropolis-Hastings decision has
+    /// accepted `plan`.  On error, implementations must restore `state` before
+    /// returning so the chain's state and cached log-probability remain
+    /// synchronized.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when the accepted move cannot be committed.
+    fn commit<R: Rng + ?Sized>(
+        &mut self,
+        state: &mut S,
+        plan: Self::Plan,
+        rng: &mut R,
+    ) -> Result<(), Self::Error>;
+}
+
+impl<S, P: DelayedProposal<S> + ?Sized> DelayedProposal<S> for &mut P {
+    type Plan = P::Plan;
+    type Info = P::Info;
+    type Error = P::Error;
+
+    fn propose_plan<R: Rng + ?Sized>(
+        &mut self,
+        state: &S,
+        rng: &mut R,
+    ) -> Result<Option<Self::Plan>, Self::Error> {
+        (**self).propose_plan(state, rng)
+    }
+
+    fn proposed_log_prob<T: Target<S>>(
+        &self,
+        state: &S,
+        plan: &Self::Plan,
+        target: &T,
+    ) -> Result<f64, Self::Error> {
+        (**self).proposed_log_prob(state, plan, target)
+    }
+
+    fn log_q_ratio(&self, state: &S, plan: &Self::Plan) -> Result<f64, Self::Error> {
+        (**self).log_q_ratio(state, plan)
+    }
+
+    fn info(&self, plan: &Self::Plan) -> Self::Info {
+        (**self).info(plan)
+    }
+
+    fn commit<R: Rng + ?Sized>(
+        &mut self,
+        state: &mut S,
+        plan: Self::Plan,
+        rng: &mut R,
+    ) -> Result<(), Self::Error> {
+        (**self).commit(state, plan, rng)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use core::convert::Infallible;
+
     use super::*;
 
     // --- Fixtures ---
@@ -108,7 +290,7 @@ mod tests {
     // --- Default log_q_ratio tests ---
 
     #[test]
-    fn proposal_default_log_q_ratio_is_zero() {
+    fn proposal_default_log_q_zero() {
         let p = SymmetricProposal;
         let ratio = p.log_q_ratio(&Scalar(0.0), &Scalar(1.0));
         assert!(
@@ -118,12 +300,60 @@ mod tests {
     }
 
     #[test]
-    fn proposal_mut_default_log_q_ratio_is_zero() {
+    fn proposal_mut_default_log_q_zero() {
         let p = SymmetricMutProposal;
         let ratio = p.log_q_ratio(&Scalar(1.0), &0.0_f64);
         assert!(
             ratio.abs() < f64::EPSILON,
             "Default ProposalMut::log_q_ratio should be 0.0"
+        );
+    }
+
+    struct SymmetricDelayedProposal;
+    impl DelayedProposal<Scalar> for SymmetricDelayedProposal {
+        type Plan = f64;
+        type Info = f64;
+        type Error = Infallible;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            _state: &Scalar,
+            _rng: &mut R,
+        ) -> Result<Option<f64>, Self::Error> {
+            Ok(Some(1.0))
+        }
+
+        fn proposed_log_prob<T: Target<Scalar>>(
+            &self,
+            _state: &Scalar,
+            plan: &f64,
+            target: &T,
+        ) -> Result<f64, Self::Error> {
+            Ok(target.log_prob(&Scalar(*plan)))
+        }
+
+        fn info(&self, plan: &f64) -> f64 {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut Scalar,
+            plan: f64,
+            _rng: &mut R,
+        ) -> Result<(), Self::Error> {
+            state.0 = plan;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn delayed_default_log_q_zero() {
+        let p = SymmetricDelayedProposal;
+        let ratio = p.log_q_ratio(&Scalar(0.0), &1.0).unwrap();
+        assert!(
+            ratio.abs() < f64::EPSILON,
+            "Default DelayedProposal::log_q_ratio should be 0.0"
         );
     }
 }

--- a/tests/proptest_chain.rs
+++ b/tests/proptest_chain.rs
@@ -3,7 +3,8 @@
 //! These tests verify mathematical properties of Metropolis–Hastings that must
 //! hold for *all* inputs, not just specific test cases.
 
-use markov_chain_monte_carlo::prelude::*;
+use markov_chain_monte_carlo::prelude::by_value::*;
+use markov_chain_monte_carlo::prelude::in_place::ProposalMut;
 use proptest::prelude::*;
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt, SeedableRng};


### PR DESCRIPTION
- add DelayedProposal for accept-before-mutation workflows
- add Step/DelayedStep telemetry and orthogonal DelayedStepError variants
- implement Chain::step_delayed with no-plan, rejection, acceptance, and commit-failure handling
- extend Sampler with delayed stepping and generic proposal-handle storage
- add focused by-value, in-place, and delayed prelude modules
- update doctests, examples, README snippets, and property-test imports
- add tests for delayed acceptance, rejection, no-plan, invalid numerics, proposal-stage errors, commit atomicity, and run_delayed error stopping

Closes #34 