### PR TITLE
feat: add observable measurement framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,36 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +66,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +105,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +164,78 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -84,6 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +276,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -119,6 +325,17 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -161,10 +378,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -194,6 +432,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "markov-chain-monte-carlo"
 version = "0.2.1"
 dependencies = [
+ "criterion",
  "proptest",
  "rand 0.10.1",
 ]
@@ -218,6 +457,56 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -349,6 +638,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +715,15 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -392,6 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -428,6 +776,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +809,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -479,6 +849,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +874,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -529,6 +954,47 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,12 @@ categories = [ "science", "mathematics", "algorithms" ]
 rand = "0.10.1"
 
 [dev-dependencies]
+criterion = "0.8.2"
 proptest = "1.11.0"
+
+[[bench]]
+name = "stepping"
+harness = false
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ Citation metadata and background references are available in [CITATION.cff](CITA
 This crate provides:
 
 - A generic Metropolis–Hastings implementation
-- Two proposal models:
+- Three proposal models:
   - **`Proposal<S>`** — by-value proposals for simple/small state spaces
   - **`ProposalMut<S>`** — in-place mutation with rollback, for large combinatorial state spaces (triangulations, graphs) where cloning is expensive
-- `Chain<S>` with `step` (by-value) and `step_mut` (in-place) methods
+  - **`DelayedProposal<S>`** — accept-before-mutation proposals with concrete plans and failure-atomic commits
+- `Chain<S>` with `step` (by-value), `step_mut` (in-place), and `step_delayed` (accept-before-mutation) methods
 - `Sampler<S, T, P, R>` — ergonomic wrapper that bundles a chain with its target, proposal, and RNG; supports `run(n)` / `run_mut(n)` for bulk sampling and implements `Iterator`
 - `Observable<S>` and `SampleBuffer<T>` for computing and collecting derived measurements during sampling
 - NaN and +∞ detection with automatic state rollback on error
@@ -41,6 +42,10 @@ The design emphasizes:
 - Zero-cost abstractions
 - Log-space numerical stability
 - Extensibility for research and experimentation
+
+For independent parallel chains, give each worker its own `Chain`, proposal
+state, and RNG stream. The crate keeps parallelism explicit so simulations can
+control reproducibility and random-stream splitting.
 
 ---
 
@@ -224,6 +229,8 @@ just setup        # Install/verify dev tools
 just check        # Run non-mutating validation
 just fix          # Apply formatters/auto-fixes
 just ci           # Run the full local CI simulation
+just bench-compile # Compile Criterion benchmarks without measuring
+just bench        # Run Criterion benchmarks
 ```
 
 For the full command list, run `just --list`. Development tooling details live in

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This crate provides:
   - **`ProposalMut<S>`** — in-place mutation with rollback, for large combinatorial state spaces (triangulations, graphs) where cloning is expensive
 - `Chain<S>` with `step` (by-value) and `step_mut` (in-place) methods
 - `Sampler<S, T, P, R>` — ergonomic wrapper that bundles a chain with its target, proposal, and RNG; supports `run(n)` / `run_mut(n)` for bulk sampling and implements `Iterator`
+- `Observable<S>` and `SampleBuffer<T>` for computing and collecting derived measurements during sampling
 - NaN and +∞ detection with automatic state rollback on error
 - Chain statistics: `acceptance_rate()`, `total_steps()`, `reset_counters()`
 - Seeded RNG support for reproducible simulations
@@ -110,6 +111,35 @@ fn main() -> Result<(), McmcError> {
     // Production
     sampler.run(10_000)?;
     assert!(sampler.chain_ref().acceptance_rate() > 0.0);
+    Ok(())
+}
+```
+
+### Measuring observables during sampling
+
+```rust
+use markov_chain_monte_carlo::prelude::by_value::*;
+use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+
+# #[derive(Clone)] struct Scalar(f64);
+# struct Normal;
+# impl Target<Scalar> for Normal {
+#     fn log_prob(&self, s: &Scalar) -> f64 { -0.5 * s.0 * s.0 }
+# }
+# struct RandomWalk;
+# impl Proposal<Scalar> for RandomWalk {
+#     fn propose<R: Rng + ?Sized>(&self, c: &Scalar, r: &mut R) -> Scalar {
+#         Scalar(c.0 + r.random_range(-1.0..1.0))
+#     }
+# }
+fn main() -> Result<(), McmcError> {
+    let mut rng = StdRng::seed_from_u64(42);
+    let chain = Chain::new(Scalar(0.0), &Normal)?;
+    let mut sampler = Sampler::new(chain, &Normal, &RandomWalk, &mut rng);
+    let mut energy = |state: &Scalar| 0.5 * state.0 * state.0;
+
+    let measurements: SampleBuffer<f64> = sampler.run_observing(10_000, &mut energy)?;
+    assert_eq!(measurements.len(), 10_000);
     Ok(())
 }
 ```

--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -1,0 +1,361 @@
+//! Criterion benchmarks for core Metropolis-Hastings stepping paths.
+
+use core::convert::Infallible;
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use markov_chain_monte_carlo::prelude::by_value::Proposal;
+use markov_chain_monte_carlo::prelude::delayed::DelayedProposal;
+use markov_chain_monte_carlo::prelude::in_place::ProposalMut;
+use markov_chain_monte_carlo::prelude::{Chain, Sampler, Target};
+use rand::rngs::StdRng;
+use rand::{Rng, RngExt, SeedableRng};
+
+const SEED: u64 = 42;
+const BULK_STEPS: usize = 100;
+const SPIN_COUNT: usize = 256;
+
+#[derive(Clone, Copy)]
+struct Scalar(f64);
+
+struct Normal;
+
+impl Target<Scalar> for Normal {
+    fn log_prob(&self, state: &Scalar) -> f64 {
+        -0.5 * state.0 * state.0
+    }
+}
+
+struct FlatTarget;
+
+impl<T> Target<T> for FlatTarget {
+    fn log_prob(&self, _state: &T) -> f64 {
+        0.0
+    }
+}
+
+struct RandomWalk {
+    width: f64,
+}
+
+impl Proposal<Scalar> for RandomWalk {
+    fn propose<R: Rng + ?Sized>(&self, current: &Scalar, rng: &mut R) -> Scalar {
+        let delta = rng.random_range(-self.width..self.width);
+        Scalar(current.0 + delta)
+    }
+}
+
+struct SpinChain {
+    spins: Vec<i8>,
+}
+
+struct Alignment {
+    beta: f64,
+}
+
+impl Target<SpinChain> for Alignment {
+    fn log_prob(&self, state: &SpinChain) -> f64 {
+        self.beta
+            * state
+                .spins
+                .windows(2)
+                .map(|pair| f64::from(pair[0]) * f64::from(pair[1]))
+                .sum::<f64>()
+    }
+}
+
+struct SpinFlip;
+
+impl ProposalMut<SpinChain> for SpinFlip {
+    type Undo = usize;
+
+    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+        if state.spins.is_empty() {
+            return None;
+        }
+        let idx = rng.random_range(0..state.spins.len());
+        state.spins[idx] *= -1;
+        Some(idx)
+    }
+
+    fn undo(&self, state: &mut SpinChain, idx: usize) {
+        state.spins[idx] *= -1;
+    }
+}
+
+struct DelayedWalk {
+    delta: f64,
+}
+
+impl DelayedProposal<Scalar> for DelayedWalk {
+    type Plan = f64;
+    type Info = ();
+    type Error = Infallible;
+
+    fn propose_plan<R: Rng + ?Sized>(
+        &mut self,
+        _state: &Scalar,
+        _rng: &mut R,
+    ) -> Result<Option<f64>, Self::Error> {
+        Ok(Some(self.delta))
+    }
+
+    fn proposed_log_prob<T: Target<Scalar>>(
+        &self,
+        state: &Scalar,
+        plan: &f64,
+        target: &T,
+    ) -> Result<f64, Self::Error> {
+        Ok(target.log_prob(&Scalar(state.0 + *plan)))
+    }
+
+    fn info(&self, _plan: &f64) {}
+
+    fn commit<R: Rng + ?Sized>(
+        &mut self,
+        state: &mut Scalar,
+        plan: f64,
+        _rng: &mut R,
+    ) -> Result<(), Self::Error> {
+        state.0 += plan;
+        Ok(())
+    }
+}
+
+struct NoDelayedPlan;
+
+impl DelayedProposal<Scalar> for NoDelayedPlan {
+    type Plan = f64;
+    type Info = ();
+    type Error = Infallible;
+
+    fn propose_plan<R: Rng + ?Sized>(
+        &mut self,
+        _state: &Scalar,
+        _rng: &mut R,
+    ) -> Result<Option<f64>, Self::Error> {
+        Ok(None)
+    }
+
+    fn proposed_log_prob<T: Target<Scalar>>(
+        &self,
+        _state: &Scalar,
+        _plan: &f64,
+        _target: &T,
+    ) -> Result<f64, Self::Error> {
+        unreachable!("no-plan proposals should not be scored")
+    }
+
+    fn info(&self, _plan: &f64) {}
+
+    fn commit<R: Rng + ?Sized>(
+        &mut self,
+        _state: &mut Scalar,
+        _plan: f64,
+        _rng: &mut R,
+    ) -> Result<(), Self::Error> {
+        unreachable!("no-plan proposals should not be committed")
+    }
+}
+
+/// Build a scalar chain with a valid cached log-probability for scalar benches.
+fn scalar_chain(target: &impl Target<Scalar>) -> Chain<Scalar> {
+    Chain::new(Scalar(0.0), target).expect("valid scalar benchmark state")
+}
+
+/// Build a non-`Clone` spin-chain state used to exercise in-place rollback.
+fn spin_chain(target: &Alignment) -> Chain<SpinChain> {
+    let state = SpinChain {
+        spins: vec![1; SPIN_COUNT],
+    };
+    Chain::new(state, target).expect("valid spin benchmark state")
+}
+
+/// Register single-step chain benchmarks for by-value, in-place, and rollback paths.
+fn bench_chain_steps(c: &mut Criterion) {
+    let target = Normal;
+    let flat = FlatTarget;
+    let proposal = RandomWalk { width: 1.0 };
+    let spin_target = Alignment { beta: 8.0 };
+    let spin_proposal = SpinFlip;
+
+    c.bench_function("chain/step_by_value", |b| {
+        let mut chain = scalar_chain(&target);
+        let mut rng = StdRng::seed_from_u64(SEED);
+
+        b.iter(|| {
+            chain.step(&target, &proposal, &mut rng).unwrap();
+            black_box(chain.state().0);
+        });
+    });
+
+    c.bench_function("chain/step_mut_accept", |b| {
+        let mut chain = spin_chain(&Alignment { beta: 0.0 });
+        let mut rng = StdRng::seed_from_u64(SEED);
+
+        b.iter(|| {
+            black_box(chain.step_mut(&flat, &spin_proposal, &mut rng).unwrap());
+            black_box(chain.state().spins[0]);
+        });
+    });
+
+    c.bench_function("chain/step_mut_reject_rollback", |b| {
+        let mut chain = spin_chain(&spin_target);
+        let mut rng = StdRng::seed_from_u64(SEED);
+
+        b.iter(|| {
+            black_box(
+                chain
+                    .step_mut(&spin_target, &spin_proposal, &mut rng)
+                    .unwrap(),
+            );
+            black_box(chain.state().spins[0]);
+        });
+    });
+}
+
+/// Register delayed-step benchmarks for accepted, rejected, and no-plan paths.
+fn bench_delayed_steps(c: &mut Criterion) {
+    let normal = Normal;
+    let flat = FlatTarget;
+
+    c.bench_function("chain/step_delayed_accept_commit", |b| {
+        let mut chain = scalar_chain(&flat);
+        let mut proposal = DelayedWalk { delta: 1.0 };
+        let mut rng = StdRng::seed_from_u64(SEED);
+
+        b.iter(|| {
+            let step = chain.step_delayed(&flat, &mut proposal, &mut rng).unwrap();
+            black_box(step.accepted);
+            black_box(chain.state().0);
+        });
+    });
+
+    c.bench_function("chain/step_delayed_reject_plan", |b| {
+        let mut chain = scalar_chain(&normal);
+        let mut proposal = DelayedWalk { delta: 100.0 };
+        let mut rng = StdRng::seed_from_u64(SEED);
+
+        b.iter(|| {
+            let step = chain
+                .step_delayed(&normal, &mut proposal, &mut rng)
+                .unwrap();
+            black_box(step.accepted);
+            black_box(chain.state().0);
+        });
+    });
+
+    c.bench_function("chain/step_delayed_no_plan", |b| {
+        let mut chain = scalar_chain(&normal);
+        let mut proposal = NoDelayedPlan;
+        let mut rng = StdRng::seed_from_u64(SEED);
+
+        b.iter(|| {
+            let step = chain
+                .step_delayed(&normal, &mut proposal, &mut rng)
+                .unwrap();
+            black_box(step.proposed);
+            black_box(chain.rejected());
+        });
+    });
+}
+
+/// Register bulk sampler benchmarks to watch wrapper overhead across workflows.
+fn bench_sampler_runs(c: &mut Criterion) {
+    let target = Normal;
+    let proposal = RandomWalk { width: 1.0 };
+    let flat = FlatTarget;
+    let spin_proposal = SpinFlip;
+
+    c.bench_function("sampler/run_by_value_100", |b| {
+        b.iter_batched(
+            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
+            |(chain, mut rng)| {
+                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
+                sampler.run(black_box(BULK_STEPS)).unwrap();
+                black_box(sampler.chain_ref().state().0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("sampler/run_mut_100", |b| {
+        b.iter_batched(
+            || {
+                (
+                    spin_chain(&Alignment { beta: 0.0 }),
+                    StdRng::seed_from_u64(SEED),
+                )
+            },
+            |(chain, mut rng)| {
+                let mut sampler = Sampler::new(chain, &flat, &spin_proposal, &mut rng);
+                sampler.run_mut(black_box(BULK_STEPS)).unwrap();
+                black_box(sampler.chain_ref().state().spins[0]);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("sampler/run_delayed_100", |b| {
+        b.iter_batched(
+            || {
+                (
+                    scalar_chain(&flat),
+                    DelayedWalk { delta: 1.0 },
+                    StdRng::seed_from_u64(SEED),
+                )
+            },
+            |(chain, mut delayed, mut rng)| {
+                let mut sampler = Sampler::new(chain, &flat, &mut delayed, &mut rng);
+                sampler.run_delayed(black_box(BULK_STEPS)).unwrap();
+                black_box(sampler.chain_ref().state().0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Register observing benchmarks to compare collection and online accumulation.
+fn bench_observing(c: &mut Criterion) {
+    let target = Normal;
+    let proposal = RandomWalk { width: 1.0 };
+
+    c.bench_function("observing/run_observing_buffer_100", |b| {
+        b.iter_batched(
+            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
+            |(chain, mut rng)| {
+                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
+                let mut square = |state: &Scalar| state.0 * state.0;
+                let observations = sampler
+                    .run_observing(black_box(BULK_STEPS), &mut square)
+                    .unwrap();
+                black_box(observations.as_slice());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("observing/manual_online_sum_100", |b| {
+        b.iter_batched(
+            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
+            |(mut chain, mut rng)| {
+                let mut sum = 0.0;
+                for _ in 0..black_box(BULK_STEPS) {
+                    chain.step(&target, &proposal, &mut rng).unwrap();
+                    sum += chain.state().0 * chain.state().0;
+                }
+                black_box(sum);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_chain_steps,
+    bench_delayed_steps,
+    bench_sampler_runs,
+    bench_observing
+);
+criterion_main!(benches);

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -84,8 +84,9 @@ just ci
 just publish-check
 ```
 
-`just ci` covers formatting, Clippy, docs, tests, examples, example output
-validation, YAML, TOML, spelling, GitHub Actions, and Semgrep checks.
+`just ci` covers formatting, Clippy, benchmark harness compilation, docs,
+tests, examples, example output validation, YAML, TOML, spelling, GitHub
+Actions, and Semgrep checks.
 `just publish-check` validates crates.io metadata and runs
 `cargo publish --locked --allow-dirty --dry-run`.
 
@@ -144,4 +145,3 @@ cargo publish --locked
   add changelog automation as a separate tooling issue.
 - Run `just ci` before handing off a release PR.
 - Run `just publish-check` before publishing.
-

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -10,6 +10,8 @@ public API starts in `src/lib.rs`.
 
 ```text
 markov-chain-monte-carlo/
+├── benches/
+│   └── stepping.rs
 ├── .github/
 │   ├── CODEOWNERS
 │   ├── dependabot.yml
@@ -95,6 +97,8 @@ Defines user extension points:
 - `Target<S>` for target distributions through `log_prob(&S) -> f64`
 - `Proposal<S>` for by-value proposals
 - `ProposalMut<S>` for in-place proposals with rollback through an undo token
+- `DelayedProposal<S>` for accept-before-mutation workflows whose plans describe
+  concrete transitions and whose commits must be failure-atomic on error
 
 This is the right place for small, fundamental traits that users implement for
 their own state spaces. Prefer borrowed parameters by default.
@@ -143,6 +147,13 @@ Keep examples deterministic when possible. The `validate-examples` recipe checks
 for expected output markers, so example output should remain stable enough for
 CI validation.
 
+## Benchmarks
+
+Benchmarks live in `benches/` and use Criterion.  Keep them deterministic and
+focused on library invariants rather than distribution convergence.  The
+stepping suite covers by-value, in-place rollback, delayed accepted/rejected/no
+plan, sampler bulk loops, and observing overhead.
+
 ## Tests
 
 Tests are split by scope:
@@ -160,8 +171,8 @@ property tests.
 The main local workflows are defined in `justfile`:
 
 - `just check` runs the non-mutating validation gate.
-- `just ci` runs checks, documentation, tests, examples, and example output
-  validation.
+- `just ci` runs checks, benchmark harness compilation, documentation, tests,
+  examples, and example output validation.
 - `just fix` applies formatting fixes.
 - `just publish-check` validates crates.io metadata and runs
   `cargo publish --dry-run`.

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -33,6 +33,7 @@ markov-chain-monte-carlo/
 │   ├── chain.rs
 │   ├── error.rs
 │   ├── lib.rs
+│   ├── observable.rs
 │   ├── sampler.rs
 │   └── traits.rs
 ├── tests/
@@ -72,6 +73,21 @@ proposal ratios.
 Add new variants conservatively. `McmcError` is `#[non_exhaustive]`, but error
 changes still affect user matching and documentation.
 
+### `src/observable.rs`
+
+Defines measurement APIs and collection helpers:
+
+- `Observable<S>` for infallible measurements
+- `TryObservable<S>` for fallible measurements
+- `ObservedStepError<StepError, ObservationError>` to keep sampling failures
+  and measurement failures orthogonal
+- `SampleBuffer<T>` for simple in-memory observation collection
+
+Observables are shared across proposal workflows, so the core observable traits
+and buffer belong in the shared prelude. Workflow-specific result aliases should
+stay at the crate root unless a prelude needs them for ordinary examples or
+doctests.
+
 ### `src/traits.rs`
 
 Defines user extension points:
@@ -108,6 +124,7 @@ This module owns:
 
 - single-step forwarding methods
 - bulk `run` and `run_mut` loops
+- observing variants that measure derived quantities after sampling steps
 - by-value `Iterator` support
 - access to the bundled `Chain`
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -13,6 +13,8 @@ just lint             # All lint groups
 just setup            # Install/verify external dev tools
 just test             # Lib + doc tests
 just test-all         # Lib + doc + integration tests
+just bench-compile    # Compile Criterion benchmarks without measuring
+just bench            # Criterion benchmarks
 just examples         # Run all examples
 ```
 
@@ -38,8 +40,8 @@ lint aliases:
 - `just lint-config` - JSON, TOML, YAML, and GitHub Actions validation
 - `just lint-docs` - spellcheck
 
-`just ci` runs `just check`, documentation, tests, examples, and deterministic
-example-output validation.
+`just ci` runs `just check`, benchmark harness compilation, documentation,
+tests, examples, and deterministic example-output validation.
 
 ## Setup
 
@@ -64,6 +66,26 @@ The setup recipe uses Homebrew when available, Cargo for Rust tools, and
 - Integration tests: `just test-integration`
 - Single test by name filter: `cargo test chain_samples_near_mode`
 - Examples: `just examples`
+
+## Benchmarks
+
+Benchmarks use Criterion and are intentionally deterministic.  Run all
+benchmarks with:
+
+```bash
+just bench
+```
+
+The full CI simulation (`just ci`) compiles benchmark harnesses with
+`just bench-compile`, but it does not run Criterion measurements.
+
+The initial `benches/stepping.rs` suite protects core transition costs:
+
+- by-value `Chain::step`
+- in-place `Chain::step_mut` acceptance and rollback paths
+- delayed `Chain::step_delayed` accepted, rejected, and no-plan paths
+- bulk `Sampler` run loops
+- observing with `SampleBuffer` versus manual online accumulation
 
 ## Coverage
 

--- a/justfile
+++ b/justfile
@@ -71,6 +71,14 @@ action-lint: _ensure-actionlint
 build:
     cargo build
 
+# Benchmarks
+bench:
+    cargo bench --bench stepping
+
+# Compile benchmark harnesses without running Criterion measurements.
+bench-compile:
+    cargo bench --no-run
+
 # Non-mutating validation gate
 check: fmt-check clippy yaml-lint action-lint toml-fmt-check toml-lint spell-check semgrep semgrep-test
     @echo "✅ Checks complete!"
@@ -80,7 +88,7 @@ check-fast:
     cargo check
 
 # CI simulation: comprehensive validation
-ci: check doc test examples validate-examples
+ci: check bench-compile doc test examples validate-examples
     @echo "🎯 CI checks complete!"
 
 # Clean build artifacts
@@ -140,7 +148,7 @@ help-workflows:
     @echo "Common Just workflows:"
     @echo "  just check          # Run lint/validators (non-mutating)"
     @echo "  just check-fast     # Fast compile check (cargo check)"
-    @echo "  just ci             # Full CI simulation (check + docs + tests + examples)"
+    @echo "  just ci             # Full CI simulation, including benchmark compile"
     @echo "  just fix            # Apply formatters/auto-fixes (mutating)"
     @echo "  just setup          # Install/verify external dev tools"
     @echo ""
@@ -153,6 +161,8 @@ help-workflows:
     @echo "Testing:"
     @echo "  just test           # Lib + doc tests"
     @echo "  just test-all       # Lib + doc + integration tests"
+    @echo "  just bench          # Run Criterion benchmarks"
+    @echo "  just bench-compile  # Compile benchmarks without measuring"
     @echo "  just coverage       # Generate and open HTML coverage report"
     @echo "  just coverage-ci    # Generate Cobertura XML coverage report"
     @echo "  just examples       # Run all examples"

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -219,7 +219,7 @@ impl<S> Chain<S> {
     /// for the proposed state is NaN or +∞, [`McmcError::NanLogQRatio`] or
     /// [`McmcError::InfiniteLogQRatio`] if the proposal's log q-ratio is
     /// NaN or +∞.
-    pub fn step<T: Target<S>, P: Proposal<S>, R: Rng + ?Sized>(
+    pub fn step<T: Target<S>, P: Proposal<S> + ?Sized, R: Rng + ?Sized>(
         &mut self,
         target: &T,
         proposal: &P,
@@ -283,7 +283,7 @@ impl<S> Chain<S> {
     /// Returns [`McmcError::NanProposedLogProb`],
     /// [`McmcError::InfiniteProposedLogProb`], [`McmcError::NanLogQRatio`],
     /// or [`McmcError::InfiniteLogQRatio`] after rolling back the state.
-    pub fn step_mut<T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized>(
+    pub fn step_mut<T: Target<S>, P: ProposalMut<S> + ?Sized, R: Rng + ?Sized>(
         &mut self,
         target: &T,
         proposal: &P,
@@ -322,9 +322,20 @@ impl<S> Chain<S> {
 
     /// Perform a single delayed-commit Metropolis-Hastings step.
     ///
-    /// The proposal first returns a move plan without mutating the state.
-    /// `Chain` evaluates the Metropolis-Hastings accept/reject decision and
-    /// calls [`DelayedProposal::commit`] only after acceptance.
+    /// The proposal first returns a concrete move plan without mutating the
+    /// state.  `Chain` evaluates the Metropolis-Hastings accept/reject decision
+    /// for that exact transition and calls [`DelayedProposal::commit`] only
+    /// after acceptance.
+    ///
+    /// A delayed plan should already identify the local site or handle needed
+    /// to apply the move.  If no valid site exists, the proposal should return
+    /// `Ok(None)` from [`DelayedProposal::propose_plan`], which `Chain` records
+    /// as a rejection without calling scoring or commit hooks.
+    ///
+    /// `commit` must be failure-atomic: if it returns an error, it must leave
+    /// `state` exactly as it was before the commit attempt.  `Chain` keeps a
+    /// cached log-probability and cannot restore an arbitrary partially
+    /// applied domain-specific move on its own.
     ///
     /// ```
     /// use core::convert::Infallible;
@@ -395,7 +406,7 @@ impl<S> Chain<S> {
     /// evaluation fails, [`DelayedStepError::Mcmc`] on invalid
     /// log-probability or log q-ratio values, and [`DelayedStepError::Commit`]
     /// if applying an accepted move fails.
-    pub fn step_delayed<T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized>(
+    pub fn step_delayed<T: Target<S>, P: DelayedProposal<S> + ?Sized, R: Rng + ?Sized>(
         &mut self,
         target: &T,
         proposal: &mut P,
@@ -481,9 +492,10 @@ impl<S> Chain<S> {
     ///
     /// # Errors
     ///
-    /// Returns [`McmcError::NanInitialLogProb`] or
-    /// [`McmcError::InfiniteInitialLogProb`] if the target's log-probability
-    /// for `new_state` is NaN or +∞ (the chain is unchanged on error).
+    /// Returns [`McmcError::NanReplacementLogProb`] or
+    /// [`McmcError::InfiniteReplacementLogProb`] if the target's
+    /// log-probability for `new_state` is NaN or +∞ (the chain is unchanged on
+    /// error).
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::*;
@@ -503,10 +515,10 @@ impl<S> Chain<S> {
     ) -> Result<(), McmcError> {
         let lp = target.log_prob(&new_state);
         if lp.is_nan() {
-            return Err(McmcError::NanInitialLogProb);
+            return Err(McmcError::NanReplacementLogProb);
         }
         if lp == f64::INFINITY {
-            return Err(McmcError::InfiniteInitialLogProb);
+            return Err(McmcError::InfiniteReplacementLogProb);
         }
         self.state = new_state;
         self.log_prob = lp;
@@ -1708,6 +1720,42 @@ mod tests {
     }
 
     #[test]
+    fn delayed_error_sources() {
+        let mcmc: DelayedStepError<DelayedFixtureError> = McmcError::NanLogQRatio.into();
+        assert!(matches!(
+            mcmc,
+            DelayedStepError::Mcmc(McmcError::NanLogQRatio)
+        ));
+        assert_eq!(
+            mcmc.source().map(ToString::to_string),
+            Some("proposal returned NaN log q-ratio".to_owned())
+        );
+
+        let cases = [
+            (DelayedStepError::Plan(DelayedFixtureError::Plan), "Plan"),
+            (
+                DelayedStepError::ProposedLogProb(DelayedFixtureError::Score),
+                "Score",
+            ),
+            (
+                DelayedStepError::LogQRatio(DelayedFixtureError::Ratio),
+                "Ratio",
+            ),
+            (
+                DelayedStepError::Commit(DelayedFixtureError::Commit),
+                "Commit",
+            ),
+        ];
+
+        for (err, source) in cases {
+            assert_eq!(
+                err.source().map(ToString::to_string),
+                Some(source.to_owned())
+            );
+        }
+    }
+
+    #[test]
     fn delayed_commit_error_is_atomic() {
         let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let log_prob = chain.log_prob();
@@ -1715,6 +1763,66 @@ mod tests {
             commit_error: Some(DelayedFixtureError::Commit),
             ..FixedDelayedProposal::new(0.0)
         };
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
+
+        assert!(matches!(
+            result,
+            Err(DelayedStepError::Commit(DelayedFixtureError::Commit))
+        ));
+        assert_eq!(chain.state, MutScalar(2.0));
+        assert!((chain.log_prob() - log_prob).abs() < f64::EPSILON);
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 0);
+    }
+
+    #[test]
+    fn delayed_commit_error_may_restore_after_mutating() {
+        struct RestoringCommitError;
+
+        impl DelayedProposal<MutScalar> for RestoringCommitError {
+            type Plan = f64;
+            type Info = f64;
+            type Error = DelayedFixtureError;
+
+            fn propose_plan<R: Rng + ?Sized>(
+                &mut self,
+                _state: &MutScalar,
+                _rng: &mut R,
+            ) -> Result<Option<f64>, Self::Error> {
+                Ok(Some(0.0))
+            }
+
+            fn proposed_log_prob<T: Target<MutScalar>>(
+                &self,
+                _state: &MutScalar,
+                plan: &f64,
+                target: &T,
+            ) -> Result<f64, Self::Error> {
+                Ok(target.log_prob(&MutScalar(*plan)))
+            }
+
+            fn info(&self, plan: &f64) -> f64 {
+                *plan
+            }
+
+            fn commit<R: Rng + ?Sized>(
+                &mut self,
+                state: &mut MutScalar,
+                plan: f64,
+                _rng: &mut R,
+            ) -> Result<(), Self::Error> {
+                let old = state.0;
+                state.0 = plan;
+                state.0 = old;
+                Err(DelayedFixtureError::Commit)
+            }
+        }
+
+        let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let log_prob = chain.log_prob();
+        let mut proposal = RestoringCommitError;
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
@@ -1752,7 +1860,7 @@ mod tests {
         }
         let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
         let result = chain.replace_state(Scalar(0.0), &NanTarget);
-        assert!(matches!(result, Err(McmcError::NanInitialLogProb)));
+        assert!(matches!(result, Err(McmcError::NanReplacementLogProb)));
         // State should be unchanged on error
         assert_eq!(chain.state, Scalar(1.0));
     }
@@ -1767,7 +1875,7 @@ mod tests {
         }
         let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
         let result = chain.replace_state(Scalar(0.0), &InfTarget);
-        assert!(matches!(result, Err(McmcError::InfiniteInitialLogProb)));
+        assert!(matches!(result, Err(McmcError::InfiniteReplacementLogProb)));
         assert_eq!(chain.state, Scalar(1.0));
     }
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -219,12 +219,12 @@ impl<S> Chain<S> {
     /// for the proposed state is NaN or +∞, [`McmcError::NanLogQRatio`] or
     /// [`McmcError::InfiniteLogQRatio`] if the proposal's log q-ratio is
     /// NaN or +∞.
-    pub fn step<T, P, R>(&mut self, target: &T, proposal: &P, rng: &mut R) -> Result<(), McmcError>
-    where
-        T: Target<S>,
-        P: Proposal<S>,
-        R: Rng + ?Sized,
-    {
+    pub fn step<T: Target<S>, P: Proposal<S>, R: Rng + ?Sized>(
+        &mut self,
+        target: &T,
+        proposal: &P,
+        rng: &mut R,
+    ) -> Result<(), McmcError> {
         let proposed = proposal.propose(&self.state, rng);
         let log_prob_new = target.log_prob(&proposed);
         check_proposed_log_prob(log_prob_new)?;
@@ -283,17 +283,12 @@ impl<S> Chain<S> {
     /// Returns [`McmcError::NanProposedLogProb`],
     /// [`McmcError::InfiniteProposedLogProb`], [`McmcError::NanLogQRatio`],
     /// or [`McmcError::InfiniteLogQRatio`] after rolling back the state.
-    pub fn step_mut<T, P, R>(
+    pub fn step_mut<T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized>(
         &mut self,
         target: &T,
         proposal: &P,
         rng: &mut R,
-    ) -> Result<bool, McmcError>
-    where
-        T: Target<S>,
-        P: ProposalMut<S>,
-        R: Rng + ?Sized,
-    {
+    ) -> Result<bool, McmcError> {
         let Some(token) = proposal.propose_mut(&mut self.state, rng) else {
             self.rejected += 1;
             return Ok(false);
@@ -400,17 +395,12 @@ impl<S> Chain<S> {
     /// evaluation fails, [`DelayedStepError::Mcmc`] on invalid
     /// log-probability or log q-ratio values, and [`DelayedStepError::Commit`]
     /// if applying an accepted move fails.
-    pub fn step_delayed<T, P, R>(
+    pub fn step_delayed<T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized>(
         &mut self,
         target: &T,
         proposal: &mut P,
         rng: &mut R,
-    ) -> Result<DelayedStep<P::Info>, DelayedStepError<P::Error>>
-    where
-        T: Target<S>,
-        P: DelayedProposal<S>,
-        R: Rng + ?Sized,
-    {
+    ) -> Result<DelayedStep<P::Info>, DelayedStepError<P::Error>> {
         let log_prob_before = self.log_prob;
         let Some(plan) = proposal
             .propose_plan(&self.state, rng)
@@ -847,7 +837,7 @@ mod tests {
     }
 
     #[test]
-    fn step_rejects_nan_proposed_log_prob() {
+    fn step_rejects_nan_proposal() {
         struct NanAtOrigin;
         impl Target<Scalar> for NanAtOrigin {
             fn log_prob(&self, state: &Scalar) -> f64 {
@@ -897,7 +887,7 @@ mod tests {
     }
 
     #[test]
-    fn step_rejects_inf_proposed_log_prob() {
+    fn step_rejects_inf_proposal() {
         struct InfAtOrigin;
         impl Target<Scalar> for InfAtOrigin {
             fn log_prob(&self, state: &Scalar) -> f64 {
@@ -1878,7 +1868,7 @@ mod tests {
     }
 
     #[test]
-    fn positive_log_q_promotes_acceptance() {
+    fn positive_log_q_accepts() {
         // From x=0 (log_prob=0) to x=1 (log_prob=-0.5).
         // Without asymmetry: log_alpha = -0.5, might reject.
         // With large positive log_q: log_alpha = -0.5 + 100 = 99.5, always accept.

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,8 @@ pub enum McmcError {
     NanProposedLogProb,
     /// Proposal returned NaN log q-ratio.
     NanLogQRatio,
+    /// Target returned NaN log-probability for a replacement state.
+    NanReplacementLogProb,
     /// Target returned +∞ log-probability for the initial state.
     ///
     /// This indicates infinite probability, which is invalid for any
@@ -30,6 +32,11 @@ pub enum McmcError {
     /// probability is zero (yet a state was somehow proposed), almost
     /// certainly a bug in the proposal implementation.
     InfiniteLogQRatio,
+    /// Target returned +∞ log-probability for a replacement state.
+    ///
+    /// This indicates infinite probability, which is invalid for any
+    /// proper (normalizable) distribution.
+    InfiniteReplacementLogProb,
 }
 
 impl fmt::Display for McmcError {
@@ -48,6 +55,12 @@ impl fmt::Display for McmcError {
                 )
             }
             Self::NanLogQRatio => write!(f, "proposal returned NaN log q-ratio"),
+            Self::NanReplacementLogProb => {
+                write!(
+                    f,
+                    "target returned NaN log-probability for a replacement state"
+                )
+            }
             Self::InfiniteInitialLogProb => {
                 write!(
                     f,
@@ -61,6 +74,12 @@ impl fmt::Display for McmcError {
                 )
             }
             Self::InfiniteLogQRatio => write!(f, "proposal returned +inf log q-ratio"),
+            Self::InfiniteReplacementLogProb => {
+                write!(
+                    f,
+                    "target returned +inf log-probability for a replacement state"
+                )
+            }
         }
     }
 }
@@ -96,6 +115,15 @@ mod tests {
     }
 
     #[test]
+    fn display_nan_replacement_log_prob() {
+        let msg = McmcError::NanReplacementLogProb.to_string();
+        assert_eq!(
+            msg,
+            "target returned NaN log-probability for a replacement state"
+        );
+    }
+
+    #[test]
     fn display_infinite_initial_log_prob() {
         let msg = McmcError::InfiniteInitialLogProb.to_string();
         assert_eq!(
@@ -117,6 +145,15 @@ mod tests {
     fn display_infinite_log_q_ratio() {
         let msg = McmcError::InfiniteLogQRatio.to_string();
         assert_eq!(msg, "proposal returned +inf log q-ratio");
+    }
+
+    #[test]
+    fn display_infinite_replacement_log_prob() {
+        let msg = McmcError::InfiniteReplacementLogProb.to_string();
+        assert_eq!(
+            msg,
+            "target returned +inf log-probability for a replacement state"
+        );
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,7 +105,7 @@ mod tests {
     }
 
     #[test]
-    fn display_infinite_proposed_log_prob() {
+    fn display_inf_proposed_log_prob() {
         let msg = McmcError::InfiniteProposedLogProb.to_string();
         assert_eq!(
             msg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,18 @@
 //! - acceptance ratios that become `NaN` during arithmetic, such as
 //!   `-∞ - (-∞)`, are treated as rejection
 //!
+//! # Long runs and parallelism
+//!
+//! `Chain`, `Sampler`, proposal values, and RNGs are ordinary per-instance
+//! values; the crate does not use global mutable state.  Run independent chains
+//! in parallel by giving each worker its own chain, proposal state, and RNG
+//! stream.  This keeps reproducibility and RNG stream splitting under caller
+//! control.
+//!
+//! Bulk observing methods return a [`SampleBuffer`], which stores one output
+//! per step.  For production runs with many samples, use compact observables or
+//! single-step observing loops when retaining every measurement is unnecessary.
+//!
 //! # Example
 //!
 //! Sample from a standard normal distribution using Metropolis–Hastings:
@@ -127,6 +139,12 @@
 //! Use [`DelayedProposal`] with [`Chain::step_delayed`] when a proposal can
 //! plan and score a move before mutating the state, then commit only after the
 //! Metropolis-Hastings decision accepts it.
+//!
+//! The plan should describe a concrete transition, such as a move kind plus the
+//! local site or handle needed to apply it.  If no valid site can be selected,
+//! return `Ok(None)` from [`DelayedProposal::propose_plan`]; that is an ordinary
+//! rejection, while [`DelayedProposal::commit`] errors are reserved for
+//! exceptional failures applying an already accepted concrete move.
 //!
 //! ```
 //! use core::convert::Infallible;
@@ -282,14 +300,19 @@ pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 /// ```
 ///
 /// Workflow-specific preludes are available when tests, examples, or
-/// benchmarks should import only one proposal API:
+/// benchmarks should import only one proposal API.  Modules that exercise
+/// several workflows can import shared types from the top-level prelude and
+/// individual proposal traits from workflow preludes:
 ///
 /// ```
-/// use markov_chain_monte_carlo::prelude::by_value::*;
+/// use markov_chain_monte_carlo::prelude::{Chain, Sampler, Target};
+/// use markov_chain_monte_carlo::prelude::by_value::Proposal;
 /// use markov_chain_monte_carlo::prelude::delayed as delayed_prelude;
 /// use markov_chain_monte_carlo::prelude::in_place as in_place_prelude;
 ///
 /// fn needs_by_value<T: Target<f64>, P: Proposal<f64>>(_: &T, _: &P) {}
+/// fn accepts_chain(_: &Chain<f64>) {}
+/// fn accepts_sampler<T, P, R: ?Sized>(_: &Sampler<'_, f64, T, P, R>) {}
 /// fn needs_in_place<
 ///     T: in_place_prelude::Target<f64>,
 ///     P: in_place_prelude::ProposalMut<f64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,15 +224,51 @@
 //! assert!(sampler.chain_ref().acceptance_rate() > 0.0);
 //! # Ok::<(), McmcError>(())
 //! ```
+//!
+//! # Observables and measurements
+//!
+//! Use [`Observable`] or a closure with [`Sampler::run_observing`] to compute
+//! derived quantities during sampling without storing full state histories:
+//!
+//! ```
+//! use markov_chain_monte_carlo::prelude::by_value::*;
+//! use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+//!
+//! # #[derive(Clone)] struct Scalar(f64);
+//! # struct Normal;
+//! # impl Target<Scalar> for Normal {
+//! #     fn log_prob(&self, s: &Scalar) -> f64 { -0.5 * s.0 * s.0 }
+//! # }
+//! # struct Walk;
+//! # impl Proposal<Scalar> for Walk {
+//! #     fn propose<R: Rng + ?Sized>(&self, c: &Scalar, r: &mut R) -> Scalar {
+//! #         Scalar(c.0 + r.random_range(-1.0..1.0))
+//! #     }
+//! # }
+//! let mut rng = StdRng::seed_from_u64(42);
+//! let chain = Chain::new(Scalar(0.0), &Normal)?;
+//! let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng);
+//! let mut energy = |state: &Scalar| 0.5 * state.0 * state.0;
+//!
+//! let samples: SampleBuffer<f64> = sampler.run_observing(256, &mut energy)?;
+//! assert_eq!(samples.len(), 256);
+//! # Ok::<(), McmcError>(())
+//! ```
 
 mod chain;
 mod error;
+mod observable;
 mod sampler;
 mod traits;
 
 pub use chain::{Chain, DelayedStep, DelayedStepError, Step};
 pub use error::McmcError;
-pub use sampler::Sampler;
+pub use observable::{Observable, ObservedStepError, SampleBuffer, TryObservable};
+pub use sampler::{
+    ObservedDelayedStep, ObservedDelayedStepResult, Sampler, TryObservedDelayedRunResult,
+    TryObservedDelayedStepResult, TryObservedMutStepResult, TryObservedRunResult,
+    TryObservedStepResult,
+};
 pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 
 /// Convenience re-exports for common usage.
@@ -264,22 +300,31 @@ pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 /// >(_: &T, _: &P) {}
 /// ```
 pub mod prelude {
-    pub use crate::{Chain, McmcError, Sampler, Target};
+    pub use crate::{
+        Chain, McmcError, Observable, ObservedStepError, SampleBuffer, Sampler, Target,
+        TryObservable,
+    };
 
     /// Prelude for by-value proposals.
     ///
-    /// This imports the shared sampling types plus [`Proposal`], without
+    /// This imports the shared sampling types plus [`crate::Proposal`], without
     /// importing the in-place or delayed proposal traits.
     pub mod by_value {
-        pub use crate::{Chain, McmcError, Proposal, Sampler, Target};
+        pub use crate::{
+            Chain, McmcError, Observable, ObservedStepError, Proposal, SampleBuffer, Sampler,
+            Target, TryObservable,
+        };
     }
 
     /// Prelude for in-place proposals with rollback.
     ///
-    /// This imports the shared sampling types plus [`ProposalMut`], without
+    /// This imports the shared sampling types plus [`crate::ProposalMut`], without
     /// importing the by-value or delayed proposal traits.
     pub mod in_place {
-        pub use crate::{Chain, McmcError, ProposalMut, Sampler, Target};
+        pub use crate::{
+            Chain, McmcError, Observable, ObservedStepError, ProposalMut, SampleBuffer, Sampler,
+            Target, TryObservable,
+        };
     }
 
     /// Prelude for delayed-commit proposals.
@@ -287,6 +332,10 @@ pub mod prelude {
     /// This imports the shared sampling types plus delayed-step telemetry and
     /// errors, without importing the by-value or in-place proposal traits.
     pub mod delayed {
-        pub use crate::{Chain, DelayedProposal, DelayedStep, DelayedStepError, Sampler, Target};
+        pub use crate::{
+            Chain, DelayedProposal, DelayedStep, DelayedStepError, Observable, ObservedDelayedStep,
+            ObservedDelayedStepResult, ObservedStepError, SampleBuffer, Sampler, Target,
+            TryObservable,
+        };
     }
 }

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -11,6 +11,10 @@ use std::vec;
 /// order parameters, or correlation functions without storing full state
 /// histories.  The observable is mutable so implementations can keep internal
 /// scratch space, counters, or online statistics state.
+///
+/// For very long runs, prefer an observable that updates compact internal
+/// state, or call single-step observing methods directly, when retaining every
+/// measurement in a [`SampleBuffer`] would dominate memory use.
 pub trait Observable<S> {
     /// Measurement value produced by this observable.
     type Output;

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1,0 +1,397 @@
+//! Observable measurements and sample buffers.
+
+use std::error::Error;
+use std::fmt;
+use std::slice;
+use std::vec;
+
+/// Measurement computed from the current chain state.
+///
+/// Observables let sampling code record derived quantities such as energies,
+/// order parameters, or correlation functions without storing full state
+/// histories.  The observable is mutable so implementations can keep internal
+/// scratch space, counters, or online statistics state.
+pub trait Observable<S> {
+    /// Measurement value produced by this observable.
+    type Output;
+
+    /// Compute a measurement from `state`.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::Observable;
+    ///
+    /// let mut squared = |x: &f64| x * x;
+    ///
+    /// assert_eq!(Observable::observe(&mut squared, &3.0), 9.0);
+    /// ```
+    fn observe(&mut self, state: &S) -> Self::Output;
+}
+
+impl<S, O, F: FnMut(&S) -> O> Observable<S> for F {
+    type Output = O;
+
+    fn observe(&mut self, state: &S) -> Self::Output {
+        self(state)
+    }
+}
+
+/// Fallible measurement computed from the current chain state.
+///
+/// Use this when measurement itself can fail independently of the
+/// Metropolis-Hastings step, for example when a domain-specific observable
+/// validates invariants or delegates to a fallible analysis routine.
+pub trait TryObservable<S> {
+    /// Measurement value produced by this observable.
+    type Output;
+    /// Measurement-specific error type.
+    type Error;
+
+    /// Compute a fallible measurement from `state`.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::TryObservable;
+    ///
+    /// let mut reciprocal = |x: &f64| {
+    ///     if *x == 0.0 { Err("zero") } else { Ok(1.0 / *x) }
+    /// };
+    ///
+    /// assert_eq!(TryObservable::try_observe(&mut reciprocal, &2.0)?, 0.5);
+    /// # Ok::<(), &'static str>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when the observable cannot compute a valid
+    /// measurement for `state`.
+    fn try_observe(&mut self, state: &S) -> Result<Self::Output, Self::Error>;
+}
+
+impl<S, O, E, F: FnMut(&S) -> Result<O, E>> TryObservable<S> for F {
+    type Output = O;
+    type Error = E;
+
+    fn try_observe(&mut self, state: &S) -> Result<Self::Output, Self::Error> {
+        self(state)
+    }
+}
+
+/// Error from a sampling step paired with a fallible observation.
+///
+/// The two variants keep transition failures and measurement failures
+/// orthogonal.  A [`Step`](Self::Step) error means the observable was not
+/// invoked.  An [`Observation`](Self::Observation) error means the sampling
+/// step already completed successfully, then the measurement failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ObservedStepError<S, O> {
+    /// The sampling step failed before observation.
+    Step(S),
+    /// The sampling step succeeded, but observation failed.
+    Observation(O),
+}
+
+impl<S: fmt::Display, O: fmt::Display> fmt::Display for ObservedStepError<S, O> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Step(err) => write!(f, "sampling step failed before observation: {err}"),
+            Self::Observation(err) => {
+                write!(
+                    f,
+                    "observable measurement failed after a successful sampling step: {err}"
+                )
+            }
+        }
+    }
+}
+
+impl<S: Error + 'static, O: Error + 'static> Error for ObservedStepError<S, O> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Step(err) => Some(err),
+            Self::Observation(err) => Some(err),
+        }
+    }
+}
+
+/// In-memory collection of observation outputs.
+///
+/// `SampleBuffer` is intentionally a thin wrapper around `Vec<T>` so callers
+/// can start with a simple collection and later replace it with an online
+/// accumulator when they do not need to retain every measurement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub struct SampleBuffer<T> {
+    samples: Vec<T>,
+}
+
+impl<T> SampleBuffer<T> {
+    /// Create an empty buffer.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::SampleBuffer;
+    ///
+    /// let buffer = SampleBuffer::<f64>::new();
+    /// assert!(buffer.is_empty());
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            samples: Vec::new(),
+        }
+    }
+
+    /// Create an empty buffer with space for at least `capacity` samples.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::SampleBuffer;
+    ///
+    /// let buffer = SampleBuffer::<usize>::with_capacity(128);
+    /// assert_eq!(buffer.len(), 0);
+    /// ```
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            samples: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Append one observation.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::SampleBuffer;
+    ///
+    /// let mut buffer = SampleBuffer::new();
+    /// buffer.push(1.5);
+    /// assert_eq!(buffer.as_slice(), &[1.5]);
+    /// ```
+    pub fn push(&mut self, sample: T) {
+        self.samples.push(sample);
+    }
+
+    /// Number of observations in the buffer.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::SampleBuffer;
+    ///
+    /// let buffer: SampleBuffer<_> = [1, 2, 3].into_iter().collect();
+    /// assert_eq!(buffer.len(), 3);
+    /// ```
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// Whether the buffer contains no observations.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::SampleBuffer;
+    ///
+    /// let mut buffer = SampleBuffer::new();
+    /// assert!(buffer.is_empty());
+    /// buffer.push("measurement");
+    /// assert!(!buffer.is_empty());
+    /// ```
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.samples.is_empty()
+    }
+
+    /// Remove all observations while retaining allocated capacity.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::SampleBuffer;
+    ///
+    /// let mut buffer: SampleBuffer<_> = [1, 2].into_iter().collect();
+    /// buffer.clear();
+    /// assert!(buffer.is_empty());
+    /// ```
+    pub fn clear(&mut self) {
+        self.samples.clear();
+    }
+
+    /// Borrow observations as a slice.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::SampleBuffer;
+    ///
+    /// let buffer: SampleBuffer<_> = [0.25, 0.5].into_iter().collect();
+    /// assert_eq!(buffer.as_slice(), &[0.25, 0.5]);
+    /// ```
+    #[must_use]
+    pub const fn as_slice(&self) -> &[T] {
+        self.samples.as_slice()
+    }
+
+    /// Iterate over observations.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::SampleBuffer;
+    ///
+    /// let buffer: SampleBuffer<_> = [1, 2, 3].into_iter().collect();
+    /// let total: i32 = buffer.iter().sum();
+    /// assert_eq!(total, 6);
+    /// ```
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        self.samples.iter()
+    }
+
+    /// Consume the buffer and return the underlying vector.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::SampleBuffer;
+    ///
+    /// let buffer: SampleBuffer<_> = [1, 2, 3].into_iter().collect();
+    /// assert_eq!(buffer.into_vec(), vec![1, 2, 3]);
+    /// ```
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.samples
+    }
+}
+
+impl<T> Default for SampleBuffer<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Extend<T> for SampleBuffer<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.samples.extend(iter);
+    }
+}
+
+impl<T> FromIterator<T> for SampleBuffer<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self {
+            samples: Vec::from_iter(iter),
+        }
+    }
+}
+
+impl<T> IntoIterator for SampleBuffer<T> {
+    type Item = T;
+    type IntoIter = vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.samples.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SampleBuffer<T> {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum MeasurementError {
+        Domain,
+    }
+
+    impl fmt::Display for MeasurementError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::Domain => write!(f, "domain-specific measurement failed"),
+            }
+        }
+    }
+
+    impl Error for MeasurementError {}
+
+    #[test]
+    fn closure_observable_measures_state() {
+        let mut squared = |state: &f64| state * state;
+
+        assert!((squared.observe(&3.0) - 9.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn try_closure_reports_error() {
+        let mut positive_only = |state: &f64| {
+            if *state > 0.0 {
+                Ok(*state)
+            } else {
+                Err(MeasurementError::Domain)
+            }
+        };
+
+        assert_eq!(positive_only.try_observe(&2.0), Ok(2.0));
+        assert_eq!(
+            positive_only.try_observe(&0.0),
+            Err(MeasurementError::Domain)
+        );
+    }
+
+    #[test]
+    fn observed_error_messages() {
+        type Error = ObservedStepError<MeasurementError, MeasurementError>;
+
+        let step = Error::Step(MeasurementError::Domain);
+        let observation = Error::Observation(MeasurementError::Domain);
+
+        assert_eq!(
+            step.to_string(),
+            "sampling step failed before observation: domain-specific measurement failed"
+        );
+        assert_eq!(
+            observation.to_string(),
+            "observable measurement failed after a successful sampling step: domain-specific measurement failed"
+        );
+    }
+
+    #[test]
+    fn observed_error_sources() {
+        type Error = ObservedStepError<MeasurementError, MeasurementError>;
+
+        let step = Error::Step(MeasurementError::Domain);
+        let observation = Error::Observation(MeasurementError::Domain);
+
+        assert_eq!(
+            step.source().map(ToString::to_string),
+            Some("domain-specific measurement failed".to_owned())
+        );
+        assert_eq!(
+            observation.source().map(ToString::to_string),
+            Some("domain-specific measurement failed".to_owned())
+        );
+    }
+
+    #[test]
+    fn sample_buffer_collects_outputs() {
+        let mut buffer = SampleBuffer::with_capacity(2);
+        buffer.push(1);
+        buffer.extend([2, 3]);
+
+        assert_eq!(buffer.len(), 3);
+        assert_eq!(buffer.as_slice(), &[1, 2, 3]);
+        assert_eq!(buffer.into_vec(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn sample_buffer_adapters() {
+        let mut buffer = SampleBuffer::new();
+        assert!(buffer.is_empty());
+
+        buffer.extend([1, 2, 3]);
+        assert!(!buffer.is_empty());
+
+        let borrowed: Vec<_> = (&buffer).into_iter().copied().collect();
+        assert_eq!(borrowed, vec![1, 2, 3]);
+
+        buffer.clear();
+        assert!(buffer.is_empty());
+
+        let defaulted = SampleBuffer::<i32>::default();
+        assert!(defaulted.is_empty());
+
+        let collected: SampleBuffer<_> = [4, 5].into_iter().collect();
+        let owned: Vec<_> = collected.into_iter().collect();
+        assert_eq!(owned, vec![4, 5]);
+    }
+}

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -5,8 +5,33 @@ use std::fmt;
 use rand::Rng;
 
 use crate::{
-    Chain, DelayedProposal, DelayedStep, DelayedStepError, McmcError, Proposal, ProposalMut, Target,
+    Chain, DelayedProposal, DelayedStep, DelayedStepError, McmcError, Observable,
+    ObservedStepError, Proposal, ProposalMut, SampleBuffer, Target, TryObservable,
 };
+
+/// Delayed-step telemetry paired with a measurement from the resulting state.
+pub type ObservedDelayedStep<I, O> = (DelayedStep<I>, O);
+
+/// Result returned by delayed observing steps.
+pub type ObservedDelayedStepResult<I, O, E> =
+    Result<ObservedDelayedStep<I, O>, DelayedStepError<E>>;
+
+/// Result returned by fallible by-value observing steps.
+pub type TryObservedStepResult<O, E> = Result<O, ObservedStepError<McmcError, E>>;
+
+/// Result returned by fallible in-place observing steps.
+pub type TryObservedMutStepResult<O, E> = Result<(bool, O), ObservedStepError<McmcError, E>>;
+
+/// Result returned by fallible by-value or in-place observing runs.
+pub type TryObservedRunResult<O, E> = Result<SampleBuffer<O>, ObservedStepError<McmcError, E>>;
+
+/// Result returned by fallible delayed observing steps.
+pub type TryObservedDelayedStepResult<I, O, P, E> =
+    Result<ObservedDelayedStep<I, O>, ObservedStepError<DelayedStepError<P>, E>>;
+
+/// Result returned by fallible delayed observing runs.
+pub type TryObservedDelayedRunResult<O, P, E> =
+    Result<SampleBuffer<O>, ObservedStepError<DelayedStepError<P>, E>>;
 
 /// Bundles a [`Chain`] with its target, proposal, and RNG for ergonomic
 /// sampling.
@@ -242,12 +267,7 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
 
 // --- By-value stepping ---
 
-impl<S, T, P, R> Sampler<'_, S, T, P, R>
-where
-    T: Target<S>,
-    P: Proposal<S>,
-    R: Rng + ?Sized,
-{
+impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// Perform a single by-value Metropolis–Hastings step.
     ///
     /// Delegates to [`Chain::step`].
@@ -315,16 +335,176 @@ where
         }
         Ok(())
     }
+
+    /// Perform one by-value step and observe the resulting chain state.
+    ///
+    /// The observable is invoked after the step completes, including rejected
+    /// proposals, so the returned value always corresponds to the current chain
+    /// state after one counted Metropolis-Hastings step.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut energy = |state: &f64| 0.5 * state * state;
+    ///
+    /// let measurement = sampler.step_observing(&mut energy)?;
+    /// assert!(measurement >= 0.0);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`McmcError`] if the step fails.  In that case the observable is
+    /// not invoked.
+    pub fn step_observing<O: Observable<S> + ?Sized>(
+        &mut self,
+        observable: &mut O,
+    ) -> Result<O::Output, McmcError> {
+        self.step()?;
+        Ok(observable.observe(self.chain.state()))
+    }
+
+    /// Run by-value steps and collect one observation after each step.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+    ///
+    /// # #[derive(Clone)] struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl Proposal<S> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, c: &S, r: &mut R) -> S {
+    /// #         S(c.0 + r.random_range(-1.0..1.0))
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut coordinate = |state: &S| state.0;
+    ///
+    /// let samples = sampler.run_observing(128, &mut coordinate)?;
+    /// assert_eq!(samples.len(), 128);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`McmcError`] on the first step that fails.
+    pub fn run_observing<O: Observable<S> + ?Sized>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+    ) -> Result<SampleBuffer<O::Output>, McmcError> {
+        let mut samples = SampleBuffer::with_capacity(steps);
+        for _ in 0..steps {
+            samples.push(self.step_observing(observable)?);
+        }
+        Ok(samples)
+    }
+
+    /// Perform one by-value step and fallibly observe the resulting state.
+    ///
+    /// Step failures are returned as [`ObservedStepError::Step`]. Measurement
+    /// failures are returned as [`ObservedStepError::Observation`] after the
+    /// chain has completed the step.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T).map_err(ObservedStepError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut finite = |state: &f64| {
+    ///     if state.is_finite() { Ok(*state) } else { Err("non-finite") }
+    /// };
+    ///
+    /// let sample = sampler.try_step_observing(&mut finite)?;
+    /// assert!(sample.is_finite());
+    /// # Ok::<(), ObservedStepError<McmcError, &'static str>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStepError`] when either the sampling step or the
+    /// observable fails.
+    pub fn try_step_observing<O: TryObservable<S> + ?Sized>(
+        &mut self,
+        observable: &mut O,
+    ) -> TryObservedStepResult<O::Output, O::Error> {
+        self.step().map_err(ObservedStepError::Step)?;
+        observable
+            .try_observe(self.chain.state())
+            .map_err(ObservedStepError::Observation)
+    }
+
+    /// Run by-value steps and collect fallible observations.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T).map_err(ObservedStepError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut nonnegative = |state: &f64| {
+    ///     if *state >= 0.0 { Ok(*state) } else { Err("negative state") }
+    /// };
+    ///
+    /// let samples = sampler.try_run_observing(2, &mut nonnegative)?;
+    /// assert_eq!(samples.len(), 2);
+    /// # Ok::<(), ObservedStepError<McmcError, &'static str>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStepError`] on the first step or observation failure.
+    pub fn try_run_observing<O: TryObservable<S> + ?Sized>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+    ) -> TryObservedRunResult<O::Output, O::Error> {
+        let mut samples = SampleBuffer::with_capacity(steps);
+        for _ in 0..steps {
+            samples.push(self.try_step_observing(observable)?);
+        }
+        Ok(samples)
+    }
 }
 
 // --- In-place stepping ---
 
-impl<S, T, P, R> Sampler<'_, S, T, P, R>
-where
-    T: Target<S>,
-    P: ProposalMut<S>,
-    R: Rng + ?Sized,
-{
+impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// Perform a single in-place Metropolis–Hastings step with rollback.
     ///
     /// Delegates to [`Chain::step_mut`].  Returns `Ok(true)` if accepted,
@@ -402,16 +582,184 @@ where
         }
         Ok(())
     }
+
+    /// Perform one in-place step and observe the resulting chain state.
+    ///
+    /// Returns the step acceptance flag together with the measurement.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl ProposalMut<S> for P {
+    /// #     type Undo = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #         let old = s.0; s.0 += 1.0; Some(old)
+    /// #     }
+    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut coordinate = |state: &S| state.0;
+    ///
+    /// let (_accepted, sample) = sampler.step_mut_observing(&mut coordinate)?;
+    /// assert!(sample >= 0.0);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`McmcError`] if the step fails.  In that case the observable is
+    /// not invoked.
+    pub fn step_mut_observing<O: Observable<S> + ?Sized>(
+        &mut self,
+        observable: &mut O,
+    ) -> Result<(bool, O::Output), McmcError> {
+        let accepted = self.step_mut()?;
+        Ok((accepted, observable.observe(self.chain.state())))
+    }
+
+    /// Run in-place steps and collect one observation after each step.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl ProposalMut<S> for P {
+    /// #     type Undo = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #         let old = s.0; s.0 += 1.0; Some(old)
+    /// #     }
+    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut coordinate = |state: &S| state.0;
+    ///
+    /// let samples = sampler.run_mut_observing(16, &mut coordinate)?;
+    /// assert_eq!(samples.len(), 16);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`McmcError`] on the first step that fails.
+    pub fn run_mut_observing<O: Observable<S> + ?Sized>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+    ) -> Result<SampleBuffer<O::Output>, McmcError> {
+        let mut samples = SampleBuffer::with_capacity(steps);
+        for _ in 0..steps {
+            let (_, sample) = self.step_mut_observing(observable)?;
+            samples.push(sample);
+        }
+        Ok(samples)
+    }
+
+    /// Perform one in-place step and fallibly observe the resulting state.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl ProposalMut<S> for P {
+    /// #     type Undo = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #         let old = s.0; s.0 += 1.0; Some(old)
+    /// #     }
+    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStepError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut finite = |state: &S| {
+    ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
+    /// };
+    ///
+    /// let (_accepted, sample) = sampler.try_step_mut_observing(&mut finite)?;
+    /// assert!(sample.is_finite());
+    /// # Ok::<(), ObservedStepError<McmcError, &'static str>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStepError`] when either the sampling step or the
+    /// observable fails.
+    pub fn try_step_mut_observing<O: TryObservable<S> + ?Sized>(
+        &mut self,
+        observable: &mut O,
+    ) -> TryObservedMutStepResult<O::Output, O::Error> {
+        let accepted = self.step_mut().map_err(ObservedStepError::Step)?;
+        let sample = observable
+            .try_observe(self.chain.state())
+            .map_err(ObservedStepError::Observation)?;
+        Ok((accepted, sample))
+    }
+
+    /// Run in-place steps and collect fallible observations.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl ProposalMut<S> for P {
+    /// #     type Undo = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #         let old = s.0; s.0 += 1.0; Some(old)
+    /// #     }
+    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStepError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut finite = |state: &S| {
+    ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
+    /// };
+    ///
+    /// let samples = sampler.try_run_mut_observing(2, &mut finite)?;
+    /// assert_eq!(samples.len(), 2);
+    /// # Ok::<(), ObservedStepError<McmcError, &'static str>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStepError`] on the first step or observation failure.
+    pub fn try_run_mut_observing<O: TryObservable<S> + ?Sized>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+    ) -> TryObservedRunResult<O::Output, O::Error> {
+        let mut samples = SampleBuffer::with_capacity(steps);
+        for _ in 0..steps {
+            let (_, sample) = self.try_step_mut_observing(observable)?;
+            samples.push(sample);
+        }
+        Ok(samples)
+    }
 }
 
 // --- Delayed-commit stepping ---
 
-impl<S, T, P, R> Sampler<'_, S, T, P, R>
-where
-    T: Target<S>,
-    P: DelayedProposal<S>,
-    R: Rng + ?Sized,
-{
+impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// Perform a single delayed-commit Metropolis-Hastings step.
     ///
     /// Delegates to [`Chain::step_delayed`].
@@ -553,16 +901,233 @@ where
         }
         Ok(())
     }
+
+    /// Perform one delayed-commit step and observe the resulting chain state.
+    ///
+    /// Returns delayed-step telemetry together with the measurement.
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct Flat;
+    /// # impl Target<i32> for Flat { fn log_prob(&self, _: &i32) -> f64 { 0.0 } }
+    /// # struct Increment;
+    /// # impl DelayedProposal<i32> for Increment {
+    /// #     type Plan = i32;
+    /// #     type Info = i32;
+    /// #     type Error = Infallible;
+    /// #     fn propose_plan<R: Rng + ?Sized>(&mut self, _: &i32, _: &mut R) -> Result<Option<i32>, Self::Error> { Ok(Some(1)) }
+    /// #     fn proposed_log_prob<T: Target<i32>>(&self, s: &i32, p: &i32, t: &T) -> Result<f64, Self::Error> { Ok(t.log_prob(&(*s + *p))) }
+    /// #     fn info(&self, plan: &i32) -> i32 { *plan }
+    /// #     fn commit<R: Rng + ?Sized>(&mut self, state: &mut i32, plan: i32, _: &mut R) -> Result<(), Self::Error> { *state += plan; Ok(()) }
+    /// # }
+    /// let target = Flat;
+    /// let mut proposal = Increment;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &target)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut coordinate = |state: &i32| *state;
+    ///
+    /// let (_step, sample) = sampler.step_delayed_observing(&mut coordinate)?;
+    /// assert_eq!(sample, 1);
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DelayedStepError`] if the step fails.  In that case the
+    /// observable is not invoked.
+    pub fn step_delayed_observing<O: Observable<S> + ?Sized>(
+        &mut self,
+        observable: &mut O,
+    ) -> ObservedDelayedStepResult<P::Info, O::Output, P::Error> {
+        let step = self.step_delayed()?;
+        Ok((step, observable.observe(self.chain.state())))
+    }
+
+    /// Run delayed-commit steps and collect one observation after each step.
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct Flat;
+    /// impl Target<i32> for Flat {
+    ///     fn log_prob(&self, _: &i32) -> f64 { 0.0 }
+    /// }
+    ///
+    /// struct Increment;
+    /// impl DelayedProposal<i32> for Increment {
+    ///     type Plan = i32;
+    ///     type Info = i32;
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _state: &i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<Option<i32>, Self::Error> {
+    ///         Ok(Some(1))
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<i32>>(
+    ///         &self,
+    ///         state: &i32,
+    ///         plan: &i32,
+    ///         target: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         Ok(target.log_prob(&(*state + *plan)))
+    ///     }
+    ///
+    ///     fn info(&self, plan: &i32) -> i32 { *plan }
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         state: &mut i32,
+    ///         plan: i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         *state += plan;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let target = Flat;
+    /// let mut proposal = Increment;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &target)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut coordinate = |state: &i32| *state;
+    ///
+    /// let samples = sampler.run_delayed_observing(3, &mut coordinate)?;
+    /// assert_eq!(samples.as_slice(), &[1, 2, 3]);
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DelayedStepError`] on the first step that fails.
+    pub fn run_delayed_observing<O: Observable<S> + ?Sized>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+    ) -> Result<SampleBuffer<O::Output>, DelayedStepError<P::Error>> {
+        let mut samples = SampleBuffer::with_capacity(steps);
+        for _ in 0..steps {
+            let (_, sample) = self.step_delayed_observing(observable)?;
+            samples.push(sample);
+        }
+        Ok(samples)
+    }
+
+    /// Perform one delayed-commit step and fallibly observe the resulting state.
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct Flat;
+    /// # impl Target<i32> for Flat { fn log_prob(&self, _: &i32) -> f64 { 0.0 } }
+    /// # struct Increment;
+    /// # impl DelayedProposal<i32> for Increment {
+    /// #     type Plan = i32;
+    /// #     type Info = i32;
+    /// #     type Error = Infallible;
+    /// #     fn propose_plan<R: Rng + ?Sized>(&mut self, _: &i32, _: &mut R) -> Result<Option<i32>, Self::Error> { Ok(Some(1)) }
+    /// #     fn proposed_log_prob<T: Target<i32>>(&self, s: &i32, p: &i32, t: &T) -> Result<f64, Self::Error> { Ok(t.log_prob(&(*s + *p))) }
+    /// #     fn info(&self, plan: &i32) -> i32 { *plan }
+    /// #     fn commit<R: Rng + ?Sized>(&mut self, state: &mut i32, plan: i32, _: &mut R) -> Result<(), Self::Error> { *state += plan; Ok(()) }
+    /// # }
+    /// let target = Flat;
+    /// let mut proposal = Increment;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &target)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStepError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut positive = |state: &i32| {
+    ///     if *state > 0 { Ok(*state) } else { Err("not positive") }
+    /// };
+    ///
+    /// let (_step, sample) = sampler.try_step_delayed_observing(&mut positive)?;
+    /// assert_eq!(sample, 1);
+    /// # Ok::<(), ObservedStepError<DelayedStepError<Infallible>, &'static str>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStepError`] when either the delayed sampling step or
+    /// the observable fails.
+    pub fn try_step_delayed_observing<O: TryObservable<S> + ?Sized>(
+        &mut self,
+        observable: &mut O,
+    ) -> TryObservedDelayedStepResult<P::Info, O::Output, P::Error, O::Error> {
+        let step = self.step_delayed().map_err(ObservedStepError::Step)?;
+        let sample = observable
+            .try_observe(self.chain.state())
+            .map_err(ObservedStepError::Observation)?;
+        Ok((step, sample))
+    }
+
+    /// Run delayed-commit steps and collect fallible observations.
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct Flat;
+    /// # impl Target<i32> for Flat { fn log_prob(&self, _: &i32) -> f64 { 0.0 } }
+    /// # struct Increment;
+    /// # impl DelayedProposal<i32> for Increment {
+    /// #     type Plan = i32;
+    /// #     type Info = i32;
+    /// #     type Error = Infallible;
+    /// #     fn propose_plan<R: Rng + ?Sized>(&mut self, _: &i32, _: &mut R) -> Result<Option<i32>, Self::Error> { Ok(Some(1)) }
+    /// #     fn proposed_log_prob<T: Target<i32>>(&self, s: &i32, p: &i32, t: &T) -> Result<f64, Self::Error> { Ok(t.log_prob(&(*s + *p))) }
+    /// #     fn info(&self, plan: &i32) -> i32 { *plan }
+    /// #     fn commit<R: Rng + ?Sized>(&mut self, state: &mut i32, plan: i32, _: &mut R) -> Result<(), Self::Error> { *state += plan; Ok(()) }
+    /// # }
+    /// let target = Flat;
+    /// let mut proposal = Increment;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &target)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStepError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut positive = |state: &i32| {
+    ///     if *state > 0 { Ok(*state) } else { Err("not positive") }
+    /// };
+    ///
+    /// let samples = sampler.try_run_delayed_observing(2, &mut positive)?;
+    /// assert_eq!(samples.as_slice(), &[1, 2]);
+    /// # Ok::<(), ObservedStepError<DelayedStepError<Infallible>, &'static str>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStepError`] on the first step or observation failure.
+    pub fn try_run_delayed_observing<O: TryObservable<S> + ?Sized>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+    ) -> TryObservedDelayedRunResult<O::Output, P::Error, O::Error> {
+        let mut samples = SampleBuffer::with_capacity(steps);
+        for _ in 0..steps {
+            let (_, sample) = self.try_step_delayed_observing(observable)?;
+            samples.push(sample);
+        }
+        Ok(samples)
+    }
 }
 
 // --- Iterator (by-value proposal path only) ---
 
-impl<S, T, P, R> Iterator for Sampler<'_, S, T, P, R>
-where
-    T: Target<S>,
-    P: Proposal<S>,
-    R: Rng + ?Sized,
-{
+impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Iterator for Sampler<'_, S, T, P, R> {
     type Item = Result<(), McmcError>;
 
     /// Perform one by-value step and yield the result.
@@ -655,6 +1220,11 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ObservationFailure {
+        Failed,
+    }
+
     // --- Construction ---
 
     #[test]
@@ -700,6 +1270,75 @@ mod tests {
         assert_eq!(sampler.chain_ref().total_steps(), 500);
     }
 
+    #[test]
+    fn run_observing_collects() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut energy = |state: &Scalar| 0.5 * state.0 * state.0;
+
+        let measurements = sampler.run_observing(25, &mut energy).unwrap();
+
+        assert_eq!(measurements.len(), 25);
+        assert_eq!(sampler.chain_ref().total_steps(), 25);
+        assert!(measurements.iter().all(|value| *value >= 0.0));
+    }
+
+    #[test]
+    fn try_run_observing_reports_error() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut calls = 0;
+        let mut observable = |state: &Scalar| {
+            calls += 1;
+            if calls == 2 {
+                Err(ObservationFailure::Failed)
+            } else {
+                Ok(state.0)
+            }
+        };
+
+        let result = sampler.try_run_observing(3, &mut observable);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStepError::Observation(ObservationFailure::Failed))
+        ));
+        assert_eq!(sampler.chain_ref().total_steps(), 2);
+    }
+
+    #[test]
+    fn try_step_observing_skips_error() {
+        struct NanProposal;
+        impl Proposal<Scalar> for NanProposal {
+            fn propose<R: Rng + ?Sized>(&self, _current: &Scalar, _rng: &mut R) -> Scalar {
+                Scalar(0.0)
+            }
+
+            fn log_q_ratio(&self, _current: &Scalar, _proposed: &Scalar) -> f64 {
+                f64::NAN
+            }
+        }
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &NanProposal, &mut rng);
+        let mut observed = false;
+        let mut observable = |state: &Scalar| {
+            observed = true;
+            Ok::<f64, ObservationFailure>(state.0)
+        };
+
+        let result = sampler.try_step_observing(&mut observable);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStepError::Step(McmcError::NanLogQRatio))
+        ));
+        assert!(!observed);
+    }
+
     // --- In-place: step_mut and run_mut ---
 
     #[test]
@@ -720,6 +1359,35 @@ mod tests {
 
         sampler.run_mut(500).unwrap();
         assert_eq!(sampler.chain_ref().total_steps(), 500);
+    }
+
+    #[test]
+    fn run_mut_observing_collects() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut coordinate = |state: &MutScalar| state.0;
+
+        let measurements = sampler.run_mut_observing(25, &mut coordinate).unwrap();
+
+        assert_eq!(measurements.len(), 25);
+        assert_eq!(sampler.chain_ref().total_steps(), 25);
+    }
+
+    #[test]
+    fn try_run_mut_observing_errors() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut observable = |_state: &MutScalar| Err::<f64, _>(ObservationFailure::Failed);
+
+        let result = sampler.try_run_mut_observing(1, &mut observable);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStepError::Observation(ObservationFailure::Failed))
+        ));
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
 
     // --- Delayed commit: step_delayed and run_delayed ---
@@ -787,6 +1455,37 @@ mod tests {
 
         assert_eq!(sampler.chain_ref().state(), &MutScalar(0.0));
         assert_eq!(sampler.chain_ref().total_steps(), 10);
+    }
+
+    #[test]
+    fn run_delayed_observing_collects() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = DelayedToZero;
+        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut coordinate = |state: &MutScalar| state.0;
+
+        let measurements = sampler.run_delayed_observing(5, &mut coordinate).unwrap();
+
+        assert_eq!(measurements.as_slice(), &[0.0; 5]);
+        assert_eq!(sampler.chain_ref().total_steps(), 5);
+    }
+
+    #[test]
+    fn try_run_delayed_observing_errors() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = DelayedToZero;
+        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut observable = |_state: &MutScalar| Err::<f64, _>(ObservationFailure::Failed);
+
+        let result = sampler.try_run_delayed_observing(1, &mut observable);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStepError::Observation(ObservationFailure::Failed))
+        ));
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1236,6 +1236,24 @@ mod tests {
         assert_eq!(chain.state, Scalar(1.0));
     }
 
+    #[test]
+    fn accessors_expose_components() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, Walk { width: 1.0 }, &mut rng);
+
+        assert_eq!(sampler.chain_ref().state(), &Scalar(1.0));
+        sampler
+            .chain_mut()
+            .replace_state(Scalar(2.0), &Normal)
+            .unwrap();
+        assert_eq!(sampler.chain_ref().state(), &Scalar(2.0));
+
+        assert!((sampler.proposal_ref().width - 1.0).abs() < f64::EPSILON);
+        sampler.proposal_mut().width = 0.5;
+        assert!((sampler.proposal_ref().width - 0.5).abs() < f64::EPSILON);
+    }
+
     // --- Debug ---
 
     #[test]
@@ -1375,6 +1393,19 @@ mod tests {
     }
 
     #[test]
+    fn try_step_mut_observing_collects() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
+
+        let (_accepted, sample) = sampler.try_step_mut_observing(&mut coordinate).unwrap();
+
+        assert!(sample.is_finite());
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
+    }
+
+    #[test]
     fn try_run_mut_observing_errors() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
@@ -1469,6 +1500,22 @@ mod tests {
 
         assert_eq!(measurements.as_slice(), &[0.0; 5]);
         assert_eq!(sampler.chain_ref().total_steps(), 5);
+    }
+
+    #[test]
+    fn try_run_delayed_observing_collects() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = DelayedToZero;
+        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
+
+        let measurements = sampler
+            .try_run_delayed_observing(3, &mut coordinate)
+            .unwrap();
+
+        assert_eq!(measurements.as_slice(), &[0.0; 3]);
+        assert_eq!(sampler.chain_ref().total_steps(), 3);
     }
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -88,6 +88,12 @@ pub trait ProposalMut<S> {
 
     /// Log proposal ratio for the in-place move.
     ///
+    /// `state` is the already-mutated proposed state.  Implementations that
+    /// need the previous state to compute an asymmetric proposal ratio should
+    /// store that information in [`Undo`](ProposalMut::Undo).  This keeps the
+    /// normal in-place path allocation-free while still allowing exact
+    /// forward/reverse proposal accounting.
+    ///
     /// Defaults to 0 for symmetric proposals.
     fn log_q_ratio(&self, _state: &S, _token: &Self::Undo) -> f64 {
         0.0
@@ -131,30 +137,38 @@ impl<S, P: ProposalMut<S> + ?Sized> ProposalMut<S> for &mut P {
 /// `DelayedProposal` separates planning, Metropolis-Hastings evaluation, and
 /// mutation:
 ///
-/// 1. [`propose_plan`](Self::propose_plan) chooses a move descriptor without
-///    mutating the state.
+/// 1. [`propose_plan`](Self::propose_plan) chooses a concrete transition
+///    descriptor without mutating the state.
 /// 2. [`proposed_log_prob`](Self::proposed_log_prob) evaluates the proposed
 ///    state's log-probability from that descriptor.
 /// 3. [`crate::Chain::step_delayed`] performs the accept/reject draw.
 /// 4. [`commit`](Self::commit) mutates the state only after acceptance.
 ///
+/// The plan should identify the actual proposed transition, not just a move
+/// class.  For example, a triangulation proposal should choose the move kind
+/// and the concrete facet, vertex, or handle needed to apply it.  If no valid
+/// site exists, return `Ok(None)` from [`propose_plan`](Self::propose_plan)
+/// instead of accepting first and discovering that absence during
+/// [`commit`](Self::commit).
+///
 /// This is useful for combinatorial state spaces where the log-probability
-/// delta is cheap to compute from a move descriptor, but applying the move may
-/// require searching for a valid local site.  If `commit` returns an error, it
-/// must be failure-atomic: either the accepted move is applied completely, or
-/// `state` is restored before returning `Err`.
+/// delta is cheap to compute from a concrete move descriptor.  If `commit`
+/// returns an error, it must be failure-atomic: either the accepted move is
+/// applied completely, or `state` is restored before returning `Err`.
 pub trait DelayedProposal<S> {
-    /// Move descriptor produced before the Metropolis-Hastings decision.
+    /// Concrete move descriptor produced before the Metropolis-Hastings decision.
     type Plan;
     /// User-facing metadata returned in delayed-step telemetry.
     type Info;
     /// Proposal-specific error type.
     type Error;
 
-    /// Propose a move descriptor without mutating `state`.
+    /// Propose a concrete move descriptor without mutating `state`.
     ///
     /// Return `Ok(None)` when no valid move can be proposed from the current
     /// state.  That is counted as a rejection by [`crate::Chain::step_delayed`].
+    /// Ordinary proposal absence, such as failing to find a valid local site,
+    /// should use this path rather than a later commit error.
     ///
     /// # Errors
     ///
@@ -165,7 +179,8 @@ pub trait DelayedProposal<S> {
         rng: &mut R,
     ) -> Result<Option<Self::Plan>, Self::Error>;
 
-    /// Compute the proposed state's log-probability without mutating `state`.
+    /// Compute the concrete proposed state's log-probability without mutating
+    /// `state`.
     ///
     /// The returned value has the same numerical contract as
     /// [`Target::log_prob`]: finite values and `f64::NEG_INFINITY` are valid,
@@ -184,6 +199,11 @@ pub trait DelayedProposal<S> {
     /// Log proposal ratio:
     /// log(q(current | proposed) / q(proposed | current)).
     ///
+    /// This ratio must correspond to the same concrete transition represented
+    /// by [`Plan`](DelayedProposal::Plan).  Include proposal asymmetries such
+    /// as move-kind weights, site multiplicities, or reverse-move counts when
+    /// they affect the forward/reverse transition probabilities.
+    ///
     /// Defaults to 0 for symmetric proposals.
     ///
     /// # Errors
@@ -196,16 +216,22 @@ pub trait DelayedProposal<S> {
     /// Produce telemetry metadata for `plan`.
     fn info(&self, plan: &Self::Plan) -> Self::Info;
 
-    /// Apply an accepted move to `state`.
+    /// Apply an accepted concrete move to `state`.
     ///
     /// This method is called only after the Metropolis-Hastings decision has
     /// accepted `plan`.  On error, implementations must restore `state` before
     /// returning so the chain's state and cached log-probability remain
-    /// synchronized.
+    /// synchronized.  [`crate::Chain`] cannot repair a partially applied
+    /// failed commit without an implementation-provided rollback token, so
+    /// failure atomicity is part of this trait's correctness contract.
     ///
     /// # Errors
     ///
-    /// Returns `Self::Error` when the accepted move cannot be committed.
+    /// Returns `Self::Error` when a concrete accepted move cannot be committed
+    /// because of an exceptional proposal, backend, or invariant failure.
+    /// Absence of a valid site is ordinary proposal absence and should normally
+    /// be reported by [`propose_plan`](DelayedProposal::propose_plan) as
+    /// `Ok(None)`.
     fn commit<R: Rng + ?Sized>(
         &mut self,
         state: &mut S,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -259,6 +259,7 @@ mod tests {
     use core::convert::Infallible;
 
     use super::*;
+    use rand::rng;
 
     // --- Fixtures ---
 
@@ -300,6 +301,44 @@ mod tests {
     }
 
     #[test]
+    fn proposal_ref_forwards() {
+        let proposal = SymmetricProposal;
+        let shared = &proposal;
+        let proposed = shared.propose(&Scalar(2.0), &mut rng());
+
+        assert!((proposed.0 - 3.0).abs() < f64::EPSILON);
+        assert!(shared.log_q_ratio(&Scalar(2.0), &proposed).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn shared_mut_proposal_forwards() {
+        let proposal = SymmetricMutProposal;
+        let shared = &proposal;
+        let mut state = Scalar(2.0);
+        let token = shared.propose_mut(&mut state, &mut rng()).unwrap();
+
+        assert!((state.0 - 3.0).abs() < f64::EPSILON);
+        assert!(shared.log_q_ratio(&state, &token).abs() < f64::EPSILON);
+
+        shared.undo(&mut state, token);
+        assert!((state.0 - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn mut_ref_mut_proposal_forwards() {
+        let mut proposal = SymmetricMutProposal;
+        let shared = &mut proposal;
+        let mut state = Scalar(2.0);
+        let token = shared.propose_mut(&mut state, &mut rng()).unwrap();
+
+        assert!((state.0 - 3.0).abs() < f64::EPSILON);
+        assert!(shared.log_q_ratio(&state, &token).abs() < f64::EPSILON);
+
+        shared.undo(&mut state, token);
+        assert!((state.0 - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
     fn proposal_mut_default_log_q_zero() {
         let p = SymmetricMutProposal;
         let ratio = p.log_q_ratio(&Scalar(1.0), &0.0_f64);
@@ -307,6 +346,16 @@ mod tests {
             ratio.abs() < f64::EPSILON,
             "Default ProposalMut::log_q_ratio should be 0.0"
         );
+    }
+
+    #[test]
+    fn mut_ref_proposal_forwards() {
+        let mut proposal = SymmetricProposal;
+        let shared = &mut proposal;
+        let proposed = shared.propose(&Scalar(2.0), &mut rng());
+
+        assert!((proposed.0 - 3.0).abs() < f64::EPSILON);
+        assert!(shared.log_q_ratio(&Scalar(2.0), &proposed).abs() < f64::EPSILON);
     }
 
     struct SymmetricDelayedProposal;
@@ -355,5 +404,36 @@ mod tests {
             ratio.abs() < f64::EPSILON,
             "Default DelayedProposal::log_q_ratio should be 0.0"
         );
+    }
+
+    #[test]
+    fn delayed_mut_ref_forwards() {
+        struct ZeroTarget;
+        impl Target<Scalar> for ZeroTarget {
+            fn log_prob(&self, state: &Scalar) -> f64 {
+                -state.0.abs()
+            }
+        }
+
+        let mut proposal = SymmetricDelayedProposal;
+        let shared = &mut proposal;
+        let state = Scalar(0.0);
+        let plan = shared.propose_plan(&state, &mut rng()).unwrap().unwrap();
+
+        assert!((plan - 1.0).abs() < f64::EPSILON);
+        assert!(
+            (shared
+                .proposed_log_prob(&state, &plan, &ZeroTarget)
+                .unwrap()
+                + 1.0)
+                .abs()
+                < f64::EPSILON
+        );
+        assert!(shared.log_q_ratio(&state, &plan).unwrap().abs() < f64::EPSILON);
+        assert!((shared.info(&plan) - 1.0).abs() < f64::EPSILON);
+
+        let mut committed = Scalar(0.0);
+        shared.commit(&mut committed, plan, &mut rng()).unwrap();
+        assert!((committed.0 - 1.0).abs() < f64::EPSILON);
     }
 }

--- a/tests/proptest_chain.rs
+++ b/tests/proptest_chain.rs
@@ -60,7 +60,7 @@ proptest! {
     /// evaluated at the current state.  This catches bugs where `log_prob`
     /// is not updated on acceptance or is corrupted during rollback.
     #[test]
-    fn log_prob_consistent_after_step_mut(
+    fn step_mut_preserves_log_prob(
         initial in -10.0f64..10.0,
         width in 0.1f64..5.0,
         steps in 1u32..500,

--- a/tests/proptest_chain.rs
+++ b/tests/proptest_chain.rs
@@ -3,8 +3,12 @@
 //! These tests verify mathematical properties of Metropolis–Hastings that must
 //! hold for *all* inputs, not just specific test cases.
 
-use markov_chain_monte_carlo::prelude::by_value::*;
+use core::convert::Infallible;
+
+use markov_chain_monte_carlo::prelude::by_value::Proposal;
+use markov_chain_monte_carlo::prelude::delayed::DelayedProposal;
 use markov_chain_monte_carlo::prelude::in_place::ProposalMut;
+use markov_chain_monte_carlo::prelude::{Chain, Sampler, Target};
 use proptest::prelude::*;
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
@@ -48,6 +52,48 @@ impl ProposalMut<Scalar> for MutWalk {
     }
     fn undo(&self, state: &mut Scalar, old: f64) {
         state.0 = old;
+    }
+}
+
+/// Accept-before-mutation random walk proposal equivalent to `CloneWalk`.
+struct DelayedWalk {
+    width: f64,
+}
+
+impl DelayedProposal<Scalar> for DelayedWalk {
+    type Plan = f64;
+    type Info = f64;
+    type Error = Infallible;
+
+    fn propose_plan<R: Rng + ?Sized>(
+        &mut self,
+        _state: &Scalar,
+        rng: &mut R,
+    ) -> Result<Option<f64>, Self::Error> {
+        Ok(Some(rng.random_range(-self.width..self.width)))
+    }
+
+    fn proposed_log_prob<T: Target<Scalar>>(
+        &self,
+        state: &Scalar,
+        plan: &f64,
+        target: &T,
+    ) -> Result<f64, Self::Error> {
+        Ok(target.log_prob(&Scalar(state.0 + *plan)))
+    }
+
+    fn info(&self, plan: &f64) -> f64 {
+        *plan
+    }
+
+    fn commit<R: Rng + ?Sized>(
+        &mut self,
+        state: &mut Scalar,
+        plan: f64,
+        _rng: &mut R,
+    ) -> Result<(), Self::Error> {
+        state.0 += plan;
+        Ok(())
     }
 }
 
@@ -141,6 +187,44 @@ proptest! {
         );
         prop_assert_eq!(chain_clone.accepted(), chain_mut.accepted());
         prop_assert_eq!(chain_clone.rejected(), chain_mut.rejected());
+    }
+
+    /// `step` and `step_delayed` must produce identical results when the
+    /// delayed plan describes the same proposed state as the by-value path.
+    #[test]
+    fn step_and_step_delayed_are_equivalent(
+        initial in -10.0f64..10.0,
+        width in 0.1f64..5.0,
+        steps in 1u32..200,
+        seed in any::<u64>(),
+    ) {
+        let clone_proposal = CloneWalk { width };
+        let mut delayed_proposal = DelayedWalk { width };
+
+        let mut chain_clone = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut rng_clone = StdRng::seed_from_u64(seed);
+
+        let mut chain_delayed = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut rng_delayed = StdRng::seed_from_u64(seed);
+
+        for _ in 0..steps {
+            chain_clone.step(&Normal, &clone_proposal, &mut rng_clone).unwrap();
+            let _ = chain_delayed
+                .step_delayed(&Normal, &mut delayed_proposal, &mut rng_delayed)
+                .unwrap();
+        }
+
+        prop_assert_eq!(
+            chain_clone.state(), chain_delayed.state(),
+            "Final states diverged after {} steps", steps,
+        );
+        prop_assert!(
+            (chain_clone.log_prob() - chain_delayed.log_prob()).abs() < 1e-12,
+            "log_prob diverged: clone={:.15}, delayed={:.15}",
+            chain_clone.log_prob(), chain_delayed.log_prob(),
+        );
+        prop_assert_eq!(chain_clone.accepted(), chain_delayed.accepted());
+        prop_assert_eq!(chain_clone.rejected(), chain_delayed.rejected());
     }
 
     /// accepted + rejected must always equal the number of steps taken.

--- a/tests/semgrep/examples/deep_import.rs
+++ b/tests/semgrep/examples/deep_import.rs
@@ -1,3 +1,5 @@
+use std::any::type_name;
+
 // ruleid: mcmc.rust.prefer-prelude-imports-in-examples
 use markov_chain_monte_carlo::chain::Chain;
 
@@ -5,6 +7,6 @@ use markov_chain_monte_carlo::chain::Chain;
 use markov_chain_monte_carlo::prelude::Sampler;
 
 fn main() {
-    let _ = std::any::type_name::<Chain<f64>>();
-    let _ = std::any::type_name::<Sampler<'static, f64, (), (), ()>>();
+    let _ = type_name::<Chain<f64>>();
+    let _ = type_name::<Sampler<'static, f64, (), (), ()>>();
 }


### PR DESCRIPTION
Closes #16

- add Observable and TryObservable traits for infallible and fallible measurements
- add ObservedStepError to keep sampling and observation failures orthogonal
- add SampleBuffer for collected observation outputs
- integrate observing APIs across by-value, in-place, and delayed Sampler paths
- expose minimal workflow preludes for by-value, in-place, and delayed usage
- add doctests, unit tests, and documentation for the new measurement APIs
- simplify bounds, imports, and test names across touched code