### PR TITLE
feat: add streaming statistics and error bars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /coverage
 /.venv
+/.codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `OnlineStats`, `BinningAnalysis`, and `BinningEstimate` for streaming means,
+  variance estimates, and autocorrelation-aware MCMC error bars.
+- Fallible streaming accumulation support through `TryAccumulator` and
+  `TryObservable`.
+- Sampler observing APIs that stream measurements directly into accumulators,
+  including delayed-commit variants.
+- Prelude exports and documentation for ordinary streaming result aliases.
+
+### Changed
+
+- Binning updates now stage fallible pushes atomically, preserving prior
+  accumulator state when invalid samples or non-finite intermediate values are
+  rejected.
+
 ## [0.2.1] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ For long sampler runs, stream measurements directly into an accumulator instead
 of collecting a `SampleBuffer`:
 
 ```rust
-use core::convert::Infallible;
 use markov_chain_monte_carlo::prelude::by_value::*;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
@@ -184,7 +183,7 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 #         current + 1.0
 #     }
 # }
-fn main() -> Result<(), ObservedStreamError<McmcError, Infallible, StatisticsError>> {
+fn main() -> ObservedIntoRunResult<McmcError, StatisticsError> {
     let mut rng = StdRng::seed_from_u64(42);
     let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
     let mut sampler = Sampler::new(chain, &T, &P, &mut rng);

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This crate provides:
 - `Chain<S>` with `step` (by-value), `step_mut` (in-place), and `step_delayed` (accept-before-mutation) methods
 - `Sampler<S, T, P, R>` — ergonomic wrapper that bundles a chain with its target, proposal, and RNG; supports `run(n)` / `run_mut(n)` for bulk sampling and implements `Iterator`
 - `Observable<S>` and `SampleBuffer<T>` for computing and collecting derived measurements during sampling
+- `OnlineStats` and `BinningAnalysis` for streaming means, variances, and autocorrelation-corrected error estimates
 - NaN and +∞ detection with automatic state rollback on error
 - Chain statistics: `acceptance_rate()`, `total_steps()`, `reset_counters()`
 - Seeded RNG support for reproducible simulations
@@ -145,6 +146,53 @@ fn main() -> Result<(), McmcError> {
 
     let measurements: SampleBuffer<f64> = sampler.run_observing(10_000, &mut energy)?;
     assert_eq!(measurements.len(), 10_000);
+    Ok(())
+}
+```
+
+### Streaming statistics and error bars
+
+```rust
+use markov_chain_monte_carlo::prelude::*;
+
+fn main() {
+    let measurements = [1.0, 2.0, 3.0, 4.0];
+
+    let mut stats = OnlineStats::new();
+    stats.extend(measurements);
+    assert_eq!(stats.mean(), Some(2.5));
+
+    let mut bins = BinningAnalysis::new();
+    bins.extend(measurements);
+    assert!(bins.standard_error().is_some());
+}
+```
+
+For long sampler runs, stream measurements directly into an accumulator instead
+of collecting a `SampleBuffer`:
+
+```rust
+use core::convert::Infallible;
+use markov_chain_monte_carlo::prelude::by_value::*;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+# struct T;
+# impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+# struct P;
+# impl Proposal<f64> for P {
+#     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+#         current + 1.0
+#     }
+# }
+fn main() -> Result<(), ObservedStreamError<McmcError, Infallible, StatisticsError>> {
+    let mut rng = StdRng::seed_from_u64(42);
+    let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
+    let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    let mut coordinate = |state: &f64| *state;
+    let mut stats = OnlineStats::new();
+
+    sampler.run_observing_into(10_000, &mut coordinate, &mut stats)?;
+    assert_eq!(stats.count(), 10_000);
     Ok(())
 }
 ```

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -30,6 +30,12 @@ implemented in this crate.
    *A Guide to Monte Carlo Simulations in Statistical Physics*. 4th ed.
    Cambridge: Cambridge University Press, 2014.
    DOI: [10.1017/CBO9781139696463](https://doi.org/10.1017/CBO9781139696463)
+6. Welford, B. P. "Note on a Method for Calculating Corrected Sums of Squares and Products."
+   *Technometrics* 4, no. 3 (1962): 419-420.
+   DOI: [10.1080/00401706.1962.10490022](https://doi.org/10.1080/00401706.1962.10490022)
+7. Flyvbjerg, H., and H. G. Petersen. "Error Estimates on Averages of Correlated Data."
+   *The Journal of Chemical Physics* 91, no. 1 (1989): 461-466.
+   DOI: [10.1063/1.457480](https://doi.org/10.1063/1.457480)
 
 ## Related crates
 

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -85,10 +85,10 @@ Defines measurement APIs and collection helpers:
   and measurement failures orthogonal
 - `SampleBuffer<T>` for simple in-memory observation collection
 
-Observables are shared across proposal workflows, so the core observable traits
-and buffer belong in the shared prelude. Workflow-specific result aliases should
-stay at the crate root unless a prelude needs them for ordinary examples or
-doctests.
+Observables are shared across proposal workflows, so the core observable traits,
+buffer, and ordinary streaming result aliases belong in the shared prelude.
+Highly specialized workflow result aliases should stay at the crate root unless
+a prelude needs them for ordinary examples or doctests.
 
 ### `src/traits.rs`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "markov-chain-monte-carlo-tooling"
-version = "0.0.0"
+version = "0.2.1"
 requires-python = ">=3.12"
 
 [dependency-groups]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@
 //! Bulk observing methods return a [`SampleBuffer`], which stores one output
 //! per step.  For production runs with many samples, use compact observables or
 //! single-step observing loops when retaining every measurement is unnecessary.
+//! [`OnlineStats`] and [`BinningAnalysis`] provide constant-memory statistics
+//! for those streaming measurement loops.
 //!
 //! # Example
 //!
@@ -272,21 +274,70 @@
 //! assert_eq!(samples.len(), 256);
 //! # Ok::<(), McmcError>(())
 //! ```
+//!
+//! # Streaming statistics
+//!
+//! Use [`OnlineStats`] for Welford mean and variance updates, and
+//! [`BinningAnalysis`] for autocorrelation-aware standard-error estimates:
+//!
+//! ```
+//! use markov_chain_monte_carlo::prelude::*;
+//!
+//! let mut energy = OnlineStats::new();
+//! energy.extend([1.0, 2.0, 3.0, 4.0]);
+//!
+//! assert_eq!(energy.mean(), Some(2.5));
+//!
+//! let mut bins = BinningAnalysis::new();
+//! bins.extend([1.0, 2.0, 3.0, 4.0]);
+//! assert!(bins.standard_error().is_some());
+//! ```
+//!
+//! `Sampler` can also stream observations directly into these accumulators:
+//!
+//! ```
+//! use core::convert::Infallible;
+//! use markov_chain_monte_carlo::prelude::by_value::*;
+//! use rand::{Rng, SeedableRng, rngs::StdRng};
+//!
+//! # struct T;
+//! # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+//! # struct P;
+//! # impl Proposal<f64> for P {
+//! #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+//! #         current + 1.0
+//! #     }
+//! # }
+//! let mut rng = StdRng::seed_from_u64(42);
+//! let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
+//! let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+//! let mut coordinate = |state: &f64| *state;
+//! let mut stats = OnlineStats::new();
+//!
+//! sampler.run_observing_into(4, &mut coordinate, &mut stats)?;
+//! assert_eq!(stats.count(), 4);
+//! # Ok::<(), ObservedStreamError<McmcError, Infallible, StatisticsError>>(())
+//! ```
 
 mod chain;
 mod error;
 mod observable;
 mod sampler;
+mod statistics;
 mod traits;
 
 pub use chain::{Chain, DelayedStep, DelayedStepError, Step};
 pub use error::McmcError;
-pub use observable::{Observable, ObservedStepError, SampleBuffer, TryObservable};
-pub use sampler::{
-    ObservedDelayedStep, ObservedDelayedStepResult, Sampler, TryObservedDelayedRunResult,
-    TryObservedDelayedStepResult, TryObservedMutStepResult, TryObservedRunResult,
-    TryObservedStepResult,
+pub use observable::{
+    Observable, ObservedStepError, ObservedStreamError, SampleBuffer, TryAccumulator, TryObservable,
 };
+pub use sampler::{
+    ObservedDelayedIntoRunResult, ObservedDelayedStep, ObservedDelayedStepResult,
+    ObservedIntoRunResult, Sampler, TryObservedDelayedIntoRunResult, TryObservedDelayedRunResult,
+    TryObservedDelayedStepResult, TryObservedIntoRunResult, TryObservedMutStepResult,
+    TryObservedRunResult, TryObservedStepResult,
+};
+pub use statistics::{BinningAnalysis, BinningEstimate, OnlineStats, StatisticsError};
 pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 
 /// Convenience re-exports for common usage.
@@ -297,6 +348,8 @@ pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 /// use markov_chain_monte_carlo::prelude::*;
 ///
 /// fn accepts_target<T: Target<f64>>(_: &T) {}
+/// fn accepts_stats(_: OnlineStats, _: BinningAnalysis) {}
+/// fn accepts_stream_result(_: ObservedIntoRunResult<McmcError, StatisticsError>) {}
 /// ```
 ///
 /// Workflow-specific preludes are available when tests, examples, or
@@ -324,8 +377,9 @@ pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 /// ```
 pub mod prelude {
     pub use crate::{
-        Chain, McmcError, Observable, ObservedStepError, SampleBuffer, Sampler, Target,
-        TryObservable,
+        BinningAnalysis, BinningEstimate, Chain, McmcError, Observable, ObservedIntoRunResult,
+        ObservedStepError, ObservedStreamError, OnlineStats, SampleBuffer, Sampler,
+        StatisticsError, Target, TryAccumulator, TryObservable, TryObservedIntoRunResult,
     };
 
     /// Prelude for by-value proposals.
@@ -334,8 +388,9 @@ pub mod prelude {
     /// importing the in-place or delayed proposal traits.
     pub mod by_value {
         pub use crate::{
-            Chain, McmcError, Observable, ObservedStepError, Proposal, SampleBuffer, Sampler,
-            Target, TryObservable,
+            BinningAnalysis, BinningEstimate, Chain, McmcError, Observable, ObservedIntoRunResult,
+            ObservedStepError, ObservedStreamError, OnlineStats, Proposal, SampleBuffer, Sampler,
+            StatisticsError, Target, TryAccumulator, TryObservable, TryObservedIntoRunResult,
         };
     }
 
@@ -345,8 +400,10 @@ pub mod prelude {
     /// importing the by-value or delayed proposal traits.
     pub mod in_place {
         pub use crate::{
-            Chain, McmcError, Observable, ObservedStepError, ProposalMut, SampleBuffer, Sampler,
-            Target, TryObservable,
+            BinningAnalysis, BinningEstimate, Chain, McmcError, Observable, ObservedIntoRunResult,
+            ObservedStepError, ObservedStreamError, OnlineStats, ProposalMut, SampleBuffer,
+            Sampler, StatisticsError, Target, TryAccumulator, TryObservable,
+            TryObservedIntoRunResult,
         };
     }
 
@@ -356,9 +413,11 @@ pub mod prelude {
     /// errors, without importing the by-value or in-place proposal traits.
     pub mod delayed {
         pub use crate::{
-            Chain, DelayedProposal, DelayedStep, DelayedStepError, Observable, ObservedDelayedStep,
-            ObservedDelayedStepResult, ObservedStepError, SampleBuffer, Sampler, Target,
-            TryObservable,
+            BinningAnalysis, BinningEstimate, Chain, DelayedProposal, DelayedStep,
+            DelayedStepError, Observable, ObservedDelayedIntoRunResult, ObservedDelayedStep,
+            ObservedDelayedStepResult, ObservedStepError, ObservedStreamError, OnlineStats,
+            SampleBuffer, Sampler, StatisticsError, Target, TryAccumulator, TryObservable,
+            TryObservedDelayedIntoRunResult,
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,6 @@
 //! `Sampler` can also stream observations directly into these accumulators:
 //!
 //! ```
-//! use core::convert::Infallible;
 //! use markov_chain_monte_carlo::prelude::by_value::*;
 //! use rand::{Rng, SeedableRng, rngs::StdRng};
 //!
@@ -309,14 +308,14 @@
 //! #     }
 //! # }
 //! let mut rng = StdRng::seed_from_u64(42);
-//! let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
+//! let chain = Chain::new(0.0, &T)?;
 //! let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
 //! let mut coordinate = |state: &f64| *state;
 //! let mut stats = OnlineStats::new();
 //!
 //! sampler.run_observing_into(4, &mut coordinate, &mut stats)?;
 //! assert_eq!(stats.count(), 4);
-//! # Ok::<(), ObservedStreamError<McmcError, Infallible, StatisticsError>>(())
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
 mod chain;
@@ -419,5 +418,104 @@ pub mod prelude {
             SampleBuffer, Sampler, StatisticsError, Target, TryAccumulator, TryObservable,
             TryObservedDelayedIntoRunResult,
         };
+    }
+}
+
+#[cfg(test)]
+mod public_api_smoke_tests {
+    use core::convert::Infallible;
+
+    use rand::{Rng, rngs::StdRng};
+
+    use super::{
+        BinningEstimate, Chain, DelayedStep, McmcError, Observable, ObservedDelayedStep,
+        OnlineStats, Proposal, ProposalMut, SampleBuffer, Sampler, StatisticsError, Step, Target,
+        prelude::{self, by_value, delayed, in_place},
+    };
+
+    struct Smoke;
+
+    impl Target<f64> for Smoke {
+        fn log_prob(&self, _: &f64) -> f64 {
+            0.0
+        }
+    }
+
+    impl Proposal<f64> for Smoke {
+        fn propose<R: Rng + ?Sized>(&self, current: &f64, _: &mut R) -> f64 {
+            *current
+        }
+    }
+
+    impl ProposalMut<f64> for Smoke {
+        type Undo = ();
+
+        fn propose_mut<R: Rng + ?Sized>(&self, _: &mut f64, _: &mut R) -> Option<Self::Undo> {
+            Some(())
+        }
+
+        fn undo(&self, _: &mut f64, (): Self::Undo) {}
+    }
+
+    impl delayed::DelayedProposal<f64> for Smoke {
+        type Plan = ();
+        type Info = ();
+        type Error = Infallible;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            _: &f64,
+            _: &mut R,
+        ) -> Result<Option<Self::Plan>, Self::Error> {
+            Ok(Some(()))
+        }
+
+        fn proposed_log_prob<T: delayed::Target<f64>>(
+            &self,
+            state: &f64,
+            (): &Self::Plan,
+            target: &T,
+        ) -> Result<f64, Self::Error> {
+            Ok(target.log_prob(state))
+        }
+
+        fn info(&self, (): &Self::Plan) -> Self::Info {}
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            _: &mut f64,
+            (): Self::Plan,
+            _: &mut R,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn public_reexports_compile() {
+        fn needs_target<T: prelude::Target<f64>>() {}
+        fn needs_by_value<P: by_value::Proposal<f64>>() {}
+        fn needs_in_place<P: in_place::ProposalMut<f64>>() {}
+        fn needs_delayed<P: delayed::DelayedProposal<f64>>() {}
+        fn needs_observable<O: Observable<f64, Output = f64>>(_: &mut O) {}
+
+        needs_target::<Smoke>();
+        needs_by_value::<Smoke>();
+        needs_in_place::<Smoke>();
+        needs_delayed::<Smoke>();
+
+        let mut observable = |state: &f64| *state;
+        needs_observable(&mut observable);
+
+        let _: Option<Chain<f64>> = None;
+        let _: Option<Step<()>> = None;
+        let _: Option<DelayedStep<()>> = None;
+        let _: Option<McmcError> = None;
+        let _: Option<SampleBuffer<f64>> = None;
+        let _: Option<Sampler<'_, f64, Smoke, Smoke, StdRng>> = None;
+        let _: Option<ObservedDelayedStep<(), f64>> = None;
+        let _: Option<BinningEstimate> = None;
+        let _: Option<OnlineStats> = None;
+        let _: Option<StatisticsError> = None;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,11 +344,16 @@ pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 /// The top-level prelude contains only the shared sampling foundation:
 ///
 /// ```
+/// use std::convert::Infallible;
+///
 /// use markov_chain_monte_carlo::prelude::*;
 ///
 /// fn accepts_target<T: Target<f64>>(_: &T) {}
 /// fn accepts_stats(_: OnlineStats, _: BinningAnalysis) {}
 /// fn accepts_stream_result(_: ObservedIntoRunResult<McmcError, StatisticsError>) {}
+/// fn accepts_delayed_stream_result(
+///     _: TryObservedDelayedIntoRunResult<Infallible, StatisticsError, StatisticsError>,
+/// ) {}
 /// ```
 ///
 /// Workflow-specific preludes are available when tests, examples, or
@@ -378,7 +383,8 @@ pub mod prelude {
     pub use crate::{
         BinningAnalysis, BinningEstimate, Chain, McmcError, Observable, ObservedIntoRunResult,
         ObservedStepError, ObservedStreamError, OnlineStats, SampleBuffer, Sampler,
-        StatisticsError, Target, TryAccumulator, TryObservable, TryObservedIntoRunResult,
+        StatisticsError, Target, TryAccumulator, TryObservable, TryObservedDelayedIntoRunResult,
+        TryObservedIntoRunResult,
     };
 
     /// Prelude for by-value proposals.
@@ -389,7 +395,8 @@ pub mod prelude {
         pub use crate::{
             BinningAnalysis, BinningEstimate, Chain, McmcError, Observable, ObservedIntoRunResult,
             ObservedStepError, ObservedStreamError, OnlineStats, Proposal, SampleBuffer, Sampler,
-            StatisticsError, Target, TryAccumulator, TryObservable, TryObservedIntoRunResult,
+            StatisticsError, Target, TryAccumulator, TryObservable,
+            TryObservedDelayedIntoRunResult, TryObservedIntoRunResult,
         };
     }
 
@@ -402,7 +409,7 @@ pub mod prelude {
             BinningAnalysis, BinningEstimate, Chain, McmcError, Observable, ObservedIntoRunResult,
             ObservedStepError, ObservedStreamError, OnlineStats, ProposalMut, SampleBuffer,
             Sampler, StatisticsError, Target, TryAccumulator, TryObservable,
-            TryObservedIntoRunResult,
+            TryObservedDelayedIntoRunResult, TryObservedIntoRunResult,
         };
     }
 
@@ -428,8 +435,9 @@ mod public_api_smoke_tests {
     use rand::{Rng, rngs::StdRng};
 
     use super::{
-        BinningEstimate, Chain, DelayedStep, McmcError, Observable, ObservedDelayedStep,
-        OnlineStats, Proposal, ProposalMut, SampleBuffer, Sampler, StatisticsError, Step, Target,
+        BinningAnalysis, BinningEstimate, Chain, DelayedStep, McmcError, Observable,
+        ObservedDelayedStep, OnlineStats, Proposal, ProposalMut, SampleBuffer, Sampler,
+        StatisticsError, Step, Target,
         prelude::{self, by_value, delayed, in_place},
     };
 
@@ -514,8 +522,21 @@ mod public_api_smoke_tests {
         let _: Option<SampleBuffer<f64>> = None;
         let _: Option<Sampler<'_, f64, Smoke, Smoke, StdRng>> = None;
         let _: Option<ObservedDelayedStep<(), f64>> = None;
+        let _: Option<BinningAnalysis> = None;
         let _: Option<BinningEstimate> = None;
         let _: Option<OnlineStats> = None;
         let _: Option<StatisticsError> = None;
+        let _: Option<
+            prelude::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
+        > = None;
+        let _: Option<
+            by_value::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
+        > = None;
+        let _: Option<
+            in_place::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
+        > = None;
+        let _: Option<
+            delayed::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
+        > = None;
     }
 }

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1,5 +1,6 @@
 //! Observable measurements and sample buffers.
 
+use core::convert::Infallible;
 use std::error::Error;
 use std::fmt;
 use std::slice;
@@ -115,6 +116,88 @@ impl<S: Error + 'static, O: Error + 'static> Error for ObservedStepError<S, O> {
             Self::Observation(err) => Some(err),
         }
     }
+}
+
+/// Error from a sampling step, observation, or accumulation sink.
+///
+/// Streaming observation methods keep the three stages orthogonal:
+///
+/// - [`Step`](Self::Step): the sampler failed before observing
+/// - [`Observation`](Self::Observation): the sampler advanced, then measuring failed
+/// - [`Accumulation`](Self::Accumulation): the sampler advanced and measuring
+///   succeeded, then storing or updating the measurement failed
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ObservedStreamError<S, O, A> {
+    /// The sampling step failed before observation.
+    Step(S),
+    /// The sampling step succeeded, but observation failed.
+    Observation(O),
+    /// The sampling step and observation succeeded, but accumulation failed.
+    Accumulation(A),
+}
+
+impl<S: fmt::Display, O: fmt::Display, A: fmt::Display> fmt::Display
+    for ObservedStreamError<S, O, A>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Step(err) => write!(f, "sampling step failed before observation: {err}"),
+            Self::Observation(err) => {
+                write!(
+                    f,
+                    "observable measurement failed after a successful sampling step: {err}"
+                )
+            }
+            Self::Accumulation(err) => {
+                write!(
+                    f,
+                    "observation accumulation failed after a successful sampling step and observation: {err}"
+                )
+            }
+        }
+    }
+}
+
+impl<S: Error + 'static, O: Error + 'static, A: Error + 'static> Error
+    for ObservedStreamError<S, O, A>
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Step(err) => Some(err),
+            Self::Observation(err) => Some(err),
+            Self::Accumulation(err) => Some(err),
+        }
+    }
+}
+
+/// Fallible sink for streaming observation outputs.
+///
+/// Use this when observations should be consumed without retaining a full
+/// [`SampleBuffer`].  Infallible sinks such as [`Vec`] and [`SampleBuffer`]
+/// use [`Infallible`] as their error type, while statistical accumulators can
+/// reject invalid numeric measurements with domain-specific errors.
+pub trait TryAccumulator<T> {
+    /// Accumulation-specific error type.
+    type Error;
+
+    /// Store or update one observation output.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{OnlineStats, TryAccumulator};
+    ///
+    /// let mut stats = OnlineStats::new();
+    /// TryAccumulator::try_push(&mut stats, 1.0)?;
+    /// TryAccumulator::try_push(&mut stats, 3.0)?;
+    ///
+    /// assert_eq!(stats.mean(), Some(2.0));
+    /// # Ok::<(), markov_chain_monte_carlo::StatisticsError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` when the observation cannot be accumulated.
+    fn try_push(&mut self, sample: T) -> Result<(), Self::Error>;
 }
 
 /// In-memory collection of observation outputs.
@@ -263,6 +346,24 @@ impl<T> Extend<T> for SampleBuffer<T> {
     }
 }
 
+impl<T> TryAccumulator<T> for SampleBuffer<T> {
+    type Error = Infallible;
+
+    fn try_push(&mut self, sample: T) -> Result<(), Self::Error> {
+        self.push(sample);
+        Ok(())
+    }
+}
+
+impl<T> TryAccumulator<T> for Vec<T> {
+    type Error = Infallible;
+
+    fn try_push(&mut self, sample: T) -> Result<(), Self::Error> {
+        self.push(sample);
+        Ok(())
+    }
+}
+
 impl<T> FromIterator<T> for SampleBuffer<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         Self {
@@ -367,6 +468,44 @@ mod tests {
     }
 
     #[test]
+    fn observed_stream_error_messages() {
+        type Error = ObservedStreamError<MeasurementError, MeasurementError, MeasurementError>;
+
+        let step = Error::Step(MeasurementError::Domain);
+        let observation = Error::Observation(MeasurementError::Domain);
+        let accumulation = Error::Accumulation(MeasurementError::Domain);
+
+        assert_eq!(
+            step.to_string(),
+            "sampling step failed before observation: domain-specific measurement failed"
+        );
+        assert_eq!(
+            observation.to_string(),
+            "observable measurement failed after a successful sampling step: domain-specific measurement failed"
+        );
+        assert_eq!(
+            accumulation.to_string(),
+            "observation accumulation failed after a successful sampling step and observation: domain-specific measurement failed"
+        );
+    }
+
+    #[test]
+    fn observed_stream_error_sources() {
+        type Error = ObservedStreamError<MeasurementError, MeasurementError, MeasurementError>;
+
+        for err in [
+            Error::Step(MeasurementError::Domain),
+            Error::Observation(MeasurementError::Domain),
+            Error::Accumulation(MeasurementError::Domain),
+        ] {
+            assert_eq!(
+                err.source().map(ToString::to_string),
+                Some("domain-specific measurement failed".to_owned())
+            );
+        }
+    }
+
+    #[test]
     fn sample_buffer_collects_outputs() {
         let mut buffer = SampleBuffer::with_capacity(2);
         buffer.push(1);
@@ -397,5 +536,16 @@ mod tests {
         let collected: SampleBuffer<_> = [4, 5].into_iter().collect();
         let owned: Vec<_> = collected.into_iter().collect();
         assert_eq!(owned, vec![4, 5]);
+    }
+
+    #[test]
+    fn infallible_accumulators_accept_samples() {
+        let mut buffer = SampleBuffer::new();
+        buffer.try_push(1).unwrap();
+        assert_eq!(buffer.as_slice(), &[1]);
+
+        let mut vec = Vec::new();
+        vec.try_push(2).unwrap();
+        assert_eq!(vec, vec![2]);
     }
 }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,12 +1,14 @@
 //! Ergonomic sampling wrapper that bundles a chain with its components.
 
+use core::convert::Infallible;
 use std::fmt;
 
 use rand::Rng;
 
 use crate::{
     Chain, DelayedProposal, DelayedStep, DelayedStepError, McmcError, Observable,
-    ObservedStepError, Proposal, ProposalMut, SampleBuffer, Target, TryObservable,
+    ObservedStepError, ObservedStreamError, Proposal, ProposalMut, SampleBuffer, Target,
+    TryAccumulator, TryObservable,
 };
 
 /// Delayed-step telemetry paired with a measurement from the resulting state.
@@ -32,6 +34,30 @@ pub type TryObservedDelayedStepResult<I, O, P, E> =
 /// Result returned by fallible delayed observing runs.
 pub type TryObservedDelayedRunResult<O, P, E> =
     Result<SampleBuffer<O>, ObservedStepError<DelayedStepError<P>, E>>;
+
+/// Result returned by infallible-observation streaming runs.
+pub type ObservedIntoRunResult<S, A> = Result<(), ObservedStreamError<S, Infallible, A>>;
+
+/// Result returned by fallible-observation streaming runs.
+pub type TryObservedIntoRunResult<S, O, A> = Result<(), ObservedStreamError<S, O, A>>;
+
+/// Result returned by infallible-observation delayed streaming runs.
+pub type ObservedDelayedIntoRunResult<P, A> = ObservedIntoRunResult<DelayedStepError<P>, A>;
+
+/// Result returned by fallible-observation delayed streaming runs.
+pub type TryObservedDelayedIntoRunResult<P, O, A> =
+    TryObservedIntoRunResult<DelayedStepError<P>, O, A>;
+
+/// Lift a step/observation error into the streaming error type.
+///
+/// Streaming methods add an accumulation stage, so this helper preserves the
+/// original step-vs-observation distinction while widening the error type.
+fn stream_observed_error<S, O, A>(err: ObservedStepError<S, O>) -> ObservedStreamError<S, O, A> {
+    match err {
+        ObservedStepError::Step(err) => ObservedStreamError::Step(err),
+        ObservedStepError::Observation(err) => ObservedStreamError::Observation(err),
+    }
+}
 
 /// Bundles a [`Chain`] with its target, proposal, and RNG for ergonomic
 /// sampling.
@@ -416,6 +442,65 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
         Ok(samples)
     }
 
+    /// Run by-value steps and stream observations into an accumulator.
+    ///
+    /// This is the constant-memory counterpart to
+    /// [`run_observing`](Self::run_observing).  The accumulator may be an
+    /// [`OnlineStats`](crate::OnlineStats), [`BinningAnalysis`](crate::BinningAnalysis),
+    /// [`Vec`], [`SampleBuffer`], or any other type implementing
+    /// [`TryAccumulator<O::Output>`].
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+    ///
+    /// # #[derive(Clone)] struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl Proposal<S> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, c: &S, r: &mut R) -> S {
+    /// #         S(c.0 + r.random_range(-1.0..1.0))
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut coordinate = |state: &S| state.0;
+    /// let mut stats = OnlineStats::new();
+    ///
+    /// sampler.run_observing_into(128, &mut coordinate, &mut stats)?;
+    /// assert_eq!(stats.count(), 128);
+    /// # Ok::<(), ObservedStreamError<McmcError, Infallible, StatisticsError>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStreamError::Step`] on the first step failure, or
+    /// [`ObservedStreamError::Accumulation`] when the accumulator rejects a
+    /// measurement.
+    pub fn run_observing_into<O, A>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+        accumulator: &mut A,
+    ) -> ObservedIntoRunResult<McmcError, A::Error>
+    where
+        O: Observable<S> + ?Sized,
+        A: TryAccumulator<O::Output> + ?Sized,
+    {
+        for _ in 0..steps {
+            let sample = self
+                .step_observing(observable)
+                .map_err(ObservedStreamError::Step)?;
+            accumulator
+                .try_push(sample)
+                .map_err(ObservedStreamError::Accumulation)?;
+        }
+        Ok(())
+    }
+
     /// Perform one by-value step and fallibly observe the resulting state.
     ///
     /// Step failures are returned as [`ObservedStepError::Step`]. Measurement
@@ -499,6 +584,58 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
             samples.push(self.try_step_observing(observable)?);
         }
         Ok(samples)
+    }
+
+    /// Run by-value steps and stream fallible observations into an accumulator.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut nonnegative = |state: &f64| {
+    ///     if *state >= 0.0 { Ok(*state) } else { Err("negative state") }
+    /// };
+    /// let mut stats = OnlineStats::new();
+    ///
+    /// sampler.try_run_observing_into(2, &mut nonnegative, &mut stats)?;
+    /// assert_eq!(stats.count(), 2);
+    /// # Ok::<(), ObservedStreamError<McmcError, &'static str, StatisticsError>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStreamError`] on the first step, observation, or
+    /// accumulation failure.
+    pub fn try_run_observing_into<O, A>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+        accumulator: &mut A,
+    ) -> TryObservedIntoRunResult<McmcError, O::Error, A::Error>
+    where
+        O: TryObservable<S> + ?Sized,
+        A: TryAccumulator<O::Output> + ?Sized,
+    {
+        for _ in 0..steps {
+            let sample = self
+                .try_step_observing(observable)
+                .map_err(stream_observed_error)?;
+            accumulator
+                .try_push(sample)
+                .map_err(ObservedStreamError::Accumulation)?;
+        }
+        Ok(())
     }
 }
 
@@ -667,6 +804,64 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
         Ok(samples)
     }
 
+    /// Run in-place steps and stream observations into an accumulator.
+    ///
+    /// This is the constant-memory counterpart to
+    /// [`run_mut_observing`](Self::run_mut_observing).
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl ProposalMut<S> for P {
+    /// #     type Undo = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #         let old = s.0; s.0 += 1.0; Some(old)
+    /// #     }
+    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut coordinate = |state: &S| state.0;
+    /// let mut bins = BinningAnalysis::new();
+    ///
+    /// sampler.run_mut_observing_into(16, &mut coordinate, &mut bins)?;
+    /// assert_eq!(bins.count(), 16);
+    /// # Ok::<(), ObservedStreamError<McmcError, Infallible, StatisticsError>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStreamError::Step`] on the first step failure, or
+    /// [`ObservedStreamError::Accumulation`] when the accumulator rejects a
+    /// measurement.
+    pub fn run_mut_observing_into<O, A>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+        accumulator: &mut A,
+    ) -> ObservedIntoRunResult<McmcError, A::Error>
+    where
+        O: Observable<S> + ?Sized,
+        A: TryAccumulator<O::Output> + ?Sized,
+    {
+        for _ in 0..steps {
+            let (_, sample) = self
+                .step_mut_observing(observable)
+                .map_err(ObservedStreamError::Step)?;
+            accumulator
+                .try_push(sample)
+                .map_err(ObservedStreamError::Accumulation)?;
+        }
+        Ok(())
+    }
+
     /// Perform one in-place step and fallibly observe the resulting state.
     ///
     /// ```
@@ -754,6 +949,61 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
             samples.push(sample);
         }
         Ok(samples)
+    }
+
+    /// Run in-place steps and stream fallible observations into an accumulator.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct S(f64);
+    /// # struct T;
+    /// # impl Target<S> for T { fn log_prob(&self, s: &S) -> f64 { -0.5 * s.0 * s.0 } }
+    /// # struct P;
+    /// # impl ProposalMut<S> for P {
+    /// #     type Undo = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #         let old = s.0; s.0 += 1.0; Some(old)
+    /// #     }
+    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut finite = |state: &S| {
+    ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
+    /// };
+    /// let mut stats = OnlineStats::new();
+    ///
+    /// sampler.try_run_mut_observing_into(2, &mut finite, &mut stats)?;
+    /// assert_eq!(stats.count(), 2);
+    /// # Ok::<(), ObservedStreamError<McmcError, &'static str, StatisticsError>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStreamError`] on the first step, observation, or
+    /// accumulation failure.
+    pub fn try_run_mut_observing_into<O, A>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+        accumulator: &mut A,
+    ) -> TryObservedIntoRunResult<McmcError, O::Error, A::Error>
+    where
+        O: TryObservable<S> + ?Sized,
+        A: TryAccumulator<O::Output> + ?Sized,
+    {
+        for _ in 0..steps {
+            let (_, sample) = self
+                .try_step_mut_observing(observable)
+                .map_err(stream_observed_error)?;
+            accumulator
+                .try_push(sample)
+                .map_err(ObservedStreamError::Accumulation)?;
+        }
+        Ok(())
     }
 }
 
@@ -884,7 +1134,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let target = Flat;
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &target)?;
+    /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
     ///
     /// sampler.run_delayed(3)?;
@@ -926,7 +1176,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let target = Flat;
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &target)?;
+    /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
     /// let mut coordinate = |state: &i32| *state;
     ///
@@ -998,7 +1248,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let target = Flat;
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &target)?;
+    /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
     /// let mut coordinate = |state: &i32| *state;
     ///
@@ -1021,6 +1271,69 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
             samples.push(sample);
         }
         Ok(samples)
+    }
+
+    /// Run delayed-commit steps and stream observations into an accumulator.
+    ///
+    /// This is the constant-memory counterpart to
+    /// [`run_delayed_observing`](Self::run_delayed_observing).
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct Flat;
+    /// # impl Target<i32> for Flat { fn log_prob(&self, _: &i32) -> f64 { 0.0 } }
+    /// # struct Increment;
+    /// # impl DelayedProposal<i32> for Increment {
+    /// #     type Plan = i32;
+    /// #     type Info = i32;
+    /// #     type Error = Infallible;
+    /// #     fn propose_plan<R: Rng + ?Sized>(&mut self, _: &i32, _: &mut R) -> Result<Option<i32>, Self::Error> { Ok(Some(1)) }
+    /// #     fn proposed_log_prob<T: Target<i32>>(&self, s: &i32, p: &i32, t: &T) -> Result<f64, Self::Error> { Ok(t.log_prob(&(*s + *p))) }
+    /// #     fn info(&self, plan: &i32) -> i32 { *plan }
+    /// #     fn commit<R: Rng + ?Sized>(&mut self, state: &mut i32, plan: i32, _: &mut R) -> Result<(), Self::Error> { *state += plan; Ok(()) }
+    /// # }
+    /// let target = Flat;
+    /// let mut proposal = Increment;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &target)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStreamError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut coordinate = |state: &i32| f64::from(*state);
+    /// let mut stats = OnlineStats::new();
+    ///
+    /// sampler.run_delayed_observing_into(3, &mut coordinate, &mut stats)?;
+    /// assert_eq!(stats.count(), 3);
+    /// # Ok::<(), ObservedStreamError<DelayedStepError<Infallible>, Infallible, StatisticsError>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStreamError::Step`] on the first step failure, or
+    /// [`ObservedStreamError::Accumulation`] when the accumulator rejects a
+    /// measurement.
+    pub fn run_delayed_observing_into<O, A>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+        accumulator: &mut A,
+    ) -> ObservedDelayedIntoRunResult<P::Error, A::Error>
+    where
+        O: Observable<S> + ?Sized,
+        A: TryAccumulator<O::Output> + ?Sized,
+    {
+        for _ in 0..steps {
+            let (_, sample) = self
+                .step_delayed_observing(observable)
+                .map_err(ObservedStreamError::Step)?;
+            accumulator
+                .try_push(sample)
+                .map_err(ObservedStreamError::Accumulation)?;
+        }
+        Ok(())
     }
 
     /// Perform one delayed-commit step and fallibly observe the resulting state.
@@ -1123,6 +1436,67 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
         }
         Ok(samples)
     }
+
+    /// Run delayed-commit steps and stream fallible observations into an accumulator.
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct Flat;
+    /// # impl Target<i32> for Flat { fn log_prob(&self, _: &i32) -> f64 { 0.0 } }
+    /// # struct Increment;
+    /// # impl DelayedProposal<i32> for Increment {
+    /// #     type Plan = i32;
+    /// #     type Info = i32;
+    /// #     type Error = Infallible;
+    /// #     fn propose_plan<R: Rng + ?Sized>(&mut self, _: &i32, _: &mut R) -> Result<Option<i32>, Self::Error> { Ok(Some(1)) }
+    /// #     fn proposed_log_prob<T: Target<i32>>(&self, s: &i32, p: &i32, t: &T) -> Result<f64, Self::Error> { Ok(t.log_prob(&(*s + *p))) }
+    /// #     fn info(&self, plan: &i32) -> i32 { *plan }
+    /// #     fn commit<R: Rng + ?Sized>(&mut self, state: &mut i32, plan: i32, _: &mut R) -> Result<(), Self::Error> { *state += plan; Ok(()) }
+    /// # }
+    /// let target = Flat;
+    /// let mut proposal = Increment;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &target)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStreamError::Step)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut positive = |state: &i32| {
+    ///     if *state > 0 { Ok(f64::from(*state)) } else { Err("not positive") }
+    /// };
+    /// let mut stats = OnlineStats::new();
+    ///
+    /// sampler.try_run_delayed_observing_into(2, &mut positive, &mut stats)?;
+    /// assert_eq!(stats.count(), 2);
+    /// # Ok::<(), ObservedStreamError<DelayedStepError<Infallible>, &'static str, StatisticsError>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservedStreamError`] on the first step, observation, or
+    /// accumulation failure.
+    pub fn try_run_delayed_observing_into<O, A>(
+        &mut self,
+        steps: usize,
+        observable: &mut O,
+        accumulator: &mut A,
+    ) -> TryObservedDelayedIntoRunResult<P::Error, O::Error, A::Error>
+    where
+        O: TryObservable<S> + ?Sized,
+        A: TryAccumulator<O::Output> + ?Sized,
+    {
+        for _ in 0..steps {
+            let (_, sample) = self
+                .try_step_delayed_observing(observable)
+                .map_err(stream_observed_error)?;
+            accumulator
+                .try_push(sample)
+                .map_err(ObservedStreamError::Accumulation)?;
+        }
+        Ok(())
+    }
 }
 
 // --- Iterator (by-value proposal path only) ---
@@ -1172,6 +1546,7 @@ mod tests {
     use core::convert::Infallible;
 
     use super::*;
+    use crate::{BinningAnalysis, OnlineStats, StatisticsError};
     use rand::{RngExt, SeedableRng, rngs::StdRng};
 
     // --- Shared fixtures ---
@@ -1192,6 +1567,17 @@ mod tests {
     impl Proposal<Scalar> for Walk {
         fn propose<R: Rng + ?Sized>(&self, c: &Scalar, rng: &mut R) -> Scalar {
             Scalar(c.0 + rng.random_range(-self.width..self.width))
+        }
+    }
+
+    struct NanLogQProposal;
+    impl Proposal<Scalar> for NanLogQProposal {
+        fn propose<R: Rng + ?Sized>(&self, current: &Scalar, _rng: &mut R) -> Scalar {
+            current.clone()
+        }
+
+        fn log_q_ratio(&self, _current: &Scalar, _proposed: &Scalar) -> f64 {
+            f64::NAN
         }
     }
 
@@ -1223,6 +1609,20 @@ mod tests {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum ObservationFailure {
         Failed,
+    }
+
+    #[derive(Default)]
+    struct CountingAccumulator {
+        pushes: usize,
+    }
+
+    impl TryAccumulator<f64> for CountingAccumulator {
+        type Error = Infallible;
+
+        fn try_push(&mut self, _sample: f64) -> Result<(), Self::Error> {
+            self.pushes += 1;
+            Ok(())
+        }
     }
 
     // --- Construction ---
@@ -1303,6 +1703,23 @@ mod tests {
     }
 
     #[test]
+    fn run_observing_into_streams_to_online_stats() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut coordinate = |state: &Scalar| state.0;
+        let mut stats = OnlineStats::new();
+
+        sampler
+            .run_observing_into(25, &mut coordinate, &mut stats)
+            .unwrap();
+
+        assert_eq!(stats.count(), 25);
+        assert_eq!(sampler.chain_ref().total_steps(), 25);
+        assert!(stats.mean().unwrap().is_finite());
+    }
+
+    #[test]
     fn try_run_observing_reports_error() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
@@ -1327,21 +1744,100 @@ mod tests {
     }
 
     #[test]
-    fn try_step_observing_skips_error() {
-        struct NanProposal;
-        impl Proposal<Scalar> for NanProposal {
-            fn propose<R: Rng + ?Sized>(&self, _current: &Scalar, _rng: &mut R) -> Scalar {
-                Scalar(0.0)
-            }
-
-            fn log_q_ratio(&self, _current: &Scalar, _proposed: &Scalar) -> f64 {
-                f64::NAN
-            }
-        }
-
+    fn try_run_observing_into_stops_on_observation_error() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &NanProposal, &mut rng);
+        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut calls = 0;
+        let mut observable = |state: &Scalar| {
+            calls += 1;
+            if calls == 2 {
+                Err(ObservationFailure::Failed)
+            } else {
+                Ok(state.0)
+            }
+        };
+        let mut stats = OnlineStats::new();
+
+        let result = sampler.try_run_observing_into(3, &mut observable, &mut stats);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStreamError::Observation(ObservationFailure::Failed))
+        ));
+        assert_eq!(stats.count(), 1);
+        assert_eq!(sampler.chain_ref().total_steps(), 2);
+    }
+
+    #[test]
+    fn run_observing_into_reports_accumulation_error() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut invalid = |_state: &Scalar| f64::NAN;
+        let mut stats = OnlineStats::new();
+
+        let result = sampler.run_observing_into(1, &mut invalid, &mut stats);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStreamError::Accumulation(
+                StatisticsError::NanSample
+            ))
+        ));
+        assert_eq!(stats.count(), 0);
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
+    }
+
+    #[test]
+    fn run_observing_into_reports_step_error_without_accumulating() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
+        let mut observed = false;
+        let mut observable = |state: &Scalar| {
+            observed = true;
+            state.0
+        };
+        let mut accumulator = CountingAccumulator::default();
+
+        let result = sampler.run_observing_into(1, &mut observable, &mut accumulator);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStreamError::Step(McmcError::NanLogQRatio))
+        ));
+        assert!(!observed);
+        assert_eq!(accumulator.pushes, 0);
+    }
+
+    #[test]
+    fn try_run_observing_into_reports_step_error_without_accumulating() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
+        let mut observed = false;
+        let mut observable = |state: &Scalar| {
+            observed = true;
+            Ok::<f64, ObservationFailure>(state.0)
+        };
+        let mut accumulator = CountingAccumulator::default();
+
+        let result = sampler.try_run_observing_into(1, &mut observable, &mut accumulator);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStreamError::Step(McmcError::NanLogQRatio))
+        ));
+        assert!(!observed);
+        assert_eq!(accumulator.pushes, 0);
+    }
+
+    #[test]
+    fn try_step_observing_skips_error() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
         let mut observed = false;
         let mut observable = |state: &Scalar| {
             observed = true;
@@ -1393,6 +1889,23 @@ mod tests {
     }
 
     #[test]
+    fn run_mut_observing_into_streams_to_binning_analysis() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut coordinate = |state: &MutScalar| state.0;
+        let mut bins = BinningAnalysis::new();
+
+        sampler
+            .run_mut_observing_into(32, &mut coordinate, &mut bins)
+            .unwrap();
+
+        assert_eq!(bins.count(), 32);
+        assert_eq!(sampler.chain_ref().total_steps(), 32);
+        assert!(bins.standard_error().is_some());
+    }
+
+    #[test]
     fn try_step_mut_observing_collects() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
@@ -1418,6 +1931,42 @@ mod tests {
             result,
             Err(ObservedStepError::Observation(ObservationFailure::Failed))
         ));
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
+    }
+
+    #[test]
+    fn try_run_mut_observing_into_streams_successes() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
+        let mut stats = OnlineStats::new();
+
+        sampler
+            .try_run_mut_observing_into(5, &mut coordinate, &mut stats)
+            .unwrap();
+
+        assert_eq!(stats.count(), 5);
+        assert_eq!(sampler.chain_ref().total_steps(), 5);
+    }
+
+    #[test]
+    fn try_run_mut_observing_into_reports_accumulation_error() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut invalid = |_state: &MutScalar| Ok::<f64, ObservationFailure>(f64::INFINITY);
+        let mut stats = OnlineStats::new();
+
+        let result = sampler.try_run_mut_observing_into(1, &mut invalid, &mut stats);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStreamError::Accumulation(
+                StatisticsError::InfiniteSample
+            ))
+        ));
+        assert_eq!(stats.count(), 0);
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
 
@@ -1503,6 +2052,24 @@ mod tests {
     }
 
     #[test]
+    fn run_delayed_observing_into_streams_to_online_stats() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = DelayedToZero;
+        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut coordinate = |state: &MutScalar| state.0;
+        let mut stats = OnlineStats::new();
+
+        sampler
+            .run_delayed_observing_into(5, &mut coordinate, &mut stats)
+            .unwrap();
+
+        assert_eq!(stats.count(), 5);
+        assert_eq!(stats.mean(), Some(0.0));
+        assert_eq!(sampler.chain_ref().total_steps(), 5);
+    }
+
+    #[test]
     fn try_run_delayed_observing_collects() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
@@ -1533,6 +2100,33 @@ mod tests {
             Err(ObservedStepError::Observation(ObservationFailure::Failed))
         ));
         assert_eq!(sampler.chain_ref().total_steps(), 1);
+    }
+
+    #[test]
+    fn try_run_delayed_observing_into_stops_on_observation_error() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = DelayedToZero;
+        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut calls = 0;
+        let mut observable = |state: &MutScalar| {
+            calls += 1;
+            if calls == 2 {
+                Err(ObservationFailure::Failed)
+            } else {
+                Ok(state.0)
+            }
+        };
+        let mut stats = OnlineStats::new();
+
+        let result = sampler.try_run_delayed_observing_into(3, &mut observable, &mut stats);
+
+        assert!(matches!(
+            result,
+            Err(ObservedStreamError::Observation(ObservationFailure::Failed))
+        ));
+        assert_eq!(stats.count(), 1);
+        assert_eq!(sampler.chain_ref().total_steps(), 2);
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,0 +1,1079 @@
+//! Streaming statistics for MCMC measurements.
+
+use std::error::Error;
+use std::fmt;
+use std::iter;
+
+use crate::TryAccumulator;
+
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "sample counts are expected to stay below the exact f64 integer range"
+)]
+/// Convert a sample count into the `f64` denominator used by online formulas.
+///
+/// This keeps the precision-loss lint scoped to the one place where the
+/// statistics API intentionally crosses from integer counts to floating-point
+/// arithmetic.
+const fn count_as_f64(count: usize) -> f64 {
+    count as f64
+}
+
+/// Errors from fallible statistical accumulation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StatisticsError {
+    /// A measurement sample was NaN.
+    NanSample,
+    /// A measurement sample was infinite.
+    InfiniteSample,
+    /// Updating the running mean produced NaN.
+    NanMean,
+    /// Updating the running mean produced infinity.
+    InfiniteMean,
+    /// Updating the variance accumulator produced NaN.
+    NanVarianceAccumulator,
+    /// Updating the variance accumulator produced infinity.
+    InfiniteVarianceAccumulator,
+}
+
+impl fmt::Display for StatisticsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NanSample => write!(f, "statistics sample was NaN"),
+            Self::InfiniteSample => write!(f, "statistics sample was infinite"),
+            Self::NanMean => write!(f, "online mean became NaN while updating statistics"),
+            Self::InfiniteMean => {
+                write!(f, "online mean became infinite while updating statistics")
+            }
+            Self::NanVarianceAccumulator => {
+                write!(
+                    f,
+                    "online variance accumulator became NaN while updating statistics"
+                )
+            }
+            Self::InfiniteVarianceAccumulator => {
+                write!(
+                    f,
+                    "online variance accumulator became infinite while updating statistics"
+                )
+            }
+        }
+    }
+}
+
+impl Error for StatisticsError {}
+
+/// Validate one input sample before fallible accumulation mutates state.
+///
+/// This exists so all statistical sinks report NaN and infinity with the same
+/// orthogonal error variants.
+const fn check_sample(sample: f64) -> Result<(), StatisticsError> {
+    if sample.is_nan() {
+        return Err(StatisticsError::NanSample);
+    }
+    if sample.is_infinite() {
+        return Err(StatisticsError::InfiniteSample);
+    }
+    Ok(())
+}
+
+/// Validate the floating-point state produced by one Welford update.
+///
+/// This separates bad input samples from arithmetic overflow or invalid
+/// accumulator state, which makes streaming errors more useful to debug.
+const fn check_stats(stats: &OnlineStats) -> Result<(), StatisticsError> {
+    if stats.mean.is_nan() {
+        return Err(StatisticsError::NanMean);
+    }
+    if stats.mean.is_infinite() {
+        return Err(StatisticsError::InfiniteMean);
+    }
+    if stats.m2.is_nan() {
+        return Err(StatisticsError::NanVarianceAccumulator);
+    }
+    if stats.m2.is_infinite() {
+        return Err(StatisticsError::InfiniteVarianceAccumulator);
+    }
+    Ok(())
+}
+
+/// Online mean and variance accumulator using Welford's algorithm.
+///
+/// `OnlineStats` updates in constant memory and is suitable for long
+/// production runs where retaining every measurement would be expensive.
+///
+/// ```
+/// use markov_chain_monte_carlo::OnlineStats;
+///
+/// let mut stats = OnlineStats::new();
+/// stats.extend([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]);
+///
+/// assert_eq!(stats.count(), 8);
+/// assert!((stats.mean().unwrap() - 5.0).abs() < 1e-12);
+/// assert!((stats.population_variance().unwrap() - 4.0).abs() < 1e-12);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[must_use]
+pub struct OnlineStats {
+    count: usize,
+    mean: f64,
+    m2: f64,
+}
+
+impl OnlineStats {
+    /// Create an empty accumulator.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let stats = OnlineStats::new();
+    /// assert!(stats.is_empty());
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            count: 0,
+            mean: 0.0,
+            m2: 0.0,
+        }
+    }
+
+    /// Add one sample to the accumulator.
+    ///
+    /// This method does not validate the sample.  Use [`try_push`](Self::try_push)
+    /// when non-finite measurements should be reported as errors instead of
+    /// becoming part of the accumulator state.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let mut stats = OnlineStats::new();
+    /// stats.push(1.0);
+    /// stats.push(3.0);
+    ///
+    /// assert_eq!(stats.mean(), Some(2.0));
+    /// ```
+    pub fn push(&mut self, sample: f64) {
+        self.push_unchecked(sample);
+    }
+
+    /// Apply one Welford update without validation.
+    ///
+    /// This is shared by infallible `push` and fallible `try_push`, where
+    /// `try_push` first updates a copy so it can remain atomic on error.
+    fn push_unchecked(&mut self, sample: f64) {
+        self.count += 1;
+        let delta = sample - self.mean;
+        self.mean += delta / count_as_f64(self.count);
+        let delta_after = sample - self.mean;
+        self.m2 += delta * delta_after;
+    }
+
+    /// Add one finite sample to the accumulator.
+    ///
+    /// The accumulator is unchanged on error.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
+    ///
+    /// let mut stats = OnlineStats::new();
+    /// assert_eq!(stats.try_push(f64::NAN), Err(StatisticsError::NanSample));
+    /// assert!(stats.is_empty());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StatisticsError`] if `sample` is NaN or infinite, or if the
+    /// online mean or variance accumulator becomes non-finite while updating.
+    pub fn try_push(&mut self, sample: f64) -> Result<(), StatisticsError> {
+        check_sample(sample)?;
+        let mut next = *self;
+        next.push_unchecked(sample);
+        check_stats(&next)?;
+        *self = next;
+        Ok(())
+    }
+
+    /// Add finite samples to the accumulator.
+    ///
+    /// The accumulator retains samples accepted before the first error.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
+    ///
+    /// let mut stats = OnlineStats::new();
+    /// let err = stats.try_extend([1.0, 2.0, f64::NAN, 4.0]);
+    ///
+    /// assert_eq!(err, Err(StatisticsError::NanSample));
+    /// assert_eq!(stats.count(), 2);
+    /// assert_eq!(stats.mean(), Some(1.5));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StatisticsError`] on the first invalid sample or non-finite
+    /// accumulator update.
+    pub fn try_extend<I: IntoIterator<Item = f64>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), StatisticsError> {
+        for sample in iter {
+            self.try_push(sample)?;
+        }
+        Ok(())
+    }
+
+    /// Remove all accumulated samples.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let mut stats: OnlineStats = [1.0, 2.0].into_iter().collect();
+    /// stats.clear();
+    /// assert_eq!(stats.count(), 0);
+    /// ```
+    pub const fn clear(&mut self) {
+        *self = Self::new();
+    }
+
+    /// Number of accumulated samples.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let stats: OnlineStats = [1.0, 2.0, 3.0].into_iter().collect();
+    /// assert_eq!(stats.count(), 3);
+    /// ```
+    #[must_use]
+    pub const fn count(&self) -> usize {
+        self.count
+    }
+
+    /// Whether the accumulator is empty.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let mut stats = OnlineStats::new();
+    /// assert!(stats.is_empty());
+    /// stats.push(1.0);
+    /// assert!(!stats.is_empty());
+    /// ```
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Current sample mean.
+    ///
+    /// Returns `None` until at least one sample has been added.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let stats: OnlineStats = [2.0, 4.0].into_iter().collect();
+    /// assert_eq!(stats.mean(), Some(3.0));
+    /// ```
+    #[must_use]
+    pub fn mean(&self) -> Option<f64> {
+        (self.count > 0).then_some(self.mean)
+    }
+
+    /// Population variance, using `n` in the denominator.
+    ///
+    /// Returns `None` until at least one sample has been added.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// assert_eq!(stats.population_variance(), Some(1.0));
+    /// ```
+    #[must_use]
+    pub fn population_variance(&self) -> Option<f64> {
+        (self.count > 0).then_some(self.m2 / count_as_f64(self.count))
+    }
+
+    /// Unbiased sample variance, using `n - 1` in the denominator.
+    ///
+    /// Returns `None` until at least two samples have been added.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// assert_eq!(stats.sample_variance(), Some(2.0));
+    /// ```
+    #[must_use]
+    pub fn sample_variance(&self) -> Option<f64> {
+        (self.count > 1).then(|| self.m2 / count_as_f64(self.count - 1))
+    }
+
+    /// Population standard deviation.
+    ///
+    /// Returns `None` until at least one sample has been added.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// assert_eq!(stats.population_std_dev(), Some(1.0));
+    /// ```
+    #[must_use]
+    pub fn population_std_dev(&self) -> Option<f64> {
+        self.population_variance().map(f64::sqrt)
+    }
+
+    /// Unbiased sample standard deviation.
+    ///
+    /// Returns `None` until at least two samples have been added.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// assert_eq!(stats.sample_std_dev(), Some(2.0_f64.sqrt()));
+    /// ```
+    #[must_use]
+    pub fn sample_std_dev(&self) -> Option<f64> {
+        self.sample_variance().map(f64::sqrt)
+    }
+
+    /// Naive standard error of the mean, ignoring autocorrelation.
+    ///
+    /// For autocorrelated MCMC measurements, prefer [`BinningAnalysis`] and
+    /// inspect the blocked standard-error estimates.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// assert_eq!(stats.standard_error(), Some(1.0));
+    /// ```
+    #[must_use]
+    pub fn standard_error(&self) -> Option<f64> {
+        self.sample_variance()
+            .map(|variance| (variance / count_as_f64(self.count)).sqrt())
+    }
+}
+
+impl Default for OnlineStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Extend<f64> for OnlineStats {
+    fn extend<I: IntoIterator<Item = f64>>(&mut self, iter: I) {
+        for sample in iter {
+            self.push(sample);
+        }
+    }
+}
+
+impl TryAccumulator<f64> for OnlineStats {
+    type Error = StatisticsError;
+
+    fn try_push(&mut self, sample: f64) -> Result<(), Self::Error> {
+        Self::try_push(self, sample)
+    }
+}
+
+impl FromIterator<f64> for OnlineStats {
+    fn from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Self {
+        let mut stats = Self::new();
+        stats.extend(iter);
+        stats
+    }
+}
+
+/// Standard-error estimate at one binning level.
+///
+/// A level stores the statistics of completed block means for a fixed block
+/// size.  The standard error is the standard deviation of those block means
+/// divided by the square root of the number of completed blocks.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[must_use]
+pub struct BinningEstimate {
+    block_size: usize,
+    block_count: usize,
+    mean: f64,
+    sample_variance: Option<f64>,
+    standard_error: Option<f64>,
+}
+
+impl BinningEstimate {
+    /// Number of original samples per block at this level.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// assert_eq!(bins.estimates().nth(1).unwrap().block_size(), 2);
+    /// ```
+    #[must_use]
+    pub const fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    /// Number of completed block means included in this estimate.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// assert_eq!(bins.estimates().next().unwrap().block_count(), 4);
+    /// ```
+    #[must_use]
+    pub const fn block_count(&self) -> usize {
+        self.block_count
+    }
+
+    /// Mean of the completed block means.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// assert_eq!(bins.estimates().next().unwrap().mean(), 2.5);
+    /// ```
+    #[must_use]
+    pub const fn mean(&self) -> f64 {
+        self.mean
+    }
+
+    /// Unbiased variance of the completed block means.
+    ///
+    /// Returns `None` until at least two completed blocks exist at this level.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// assert_eq!(bins.estimates().nth(2).unwrap().sample_variance(), None);
+    /// ```
+    #[must_use]
+    pub const fn sample_variance(&self) -> Option<f64> {
+        self.sample_variance
+    }
+
+    /// Estimated standard error of the overall mean at this block size.
+    ///
+    /// Returns `None` until at least two completed blocks exist at this level.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// assert!(bins.estimates().next().unwrap().standard_error().is_some());
+    /// ```
+    #[must_use]
+    pub const fn standard_error(&self) -> Option<f64> {
+        self.standard_error
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct BinningLevel {
+    block_size: usize,
+    stats: OnlineStats,
+    pending: Option<f64>,
+}
+
+impl BinningLevel {
+    /// Create one level for completed block means of `block_size` samples.
+    ///
+    /// The binning hierarchy grows lazily, so this is called only when a sample
+    /// first reaches a previously unused block size.
+    const fn new(block_size: usize) -> Self {
+        Self {
+            block_size,
+            stats: OnlineStats::new(),
+            pending: None,
+        }
+    }
+
+    /// Build the public estimate for this level when at least one block exists.
+    ///
+    /// `pending` is not added separately here because it has already been
+    /// included in this level's statistics.  It is only pending for pairing into
+    /// the next coarser level.
+    fn estimate(&self) -> Option<BinningEstimate> {
+        let mean = self.stats.mean()?;
+        let sample_variance = self.stats.sample_variance();
+        let standard_error =
+            sample_variance.map(|variance| (variance / count_as_f64(self.stats.count())).sqrt());
+
+        Some(BinningEstimate {
+            block_size: self.block_size,
+            block_count: self.stats.count(),
+            mean,
+            sample_variance,
+            standard_error,
+        })
+    }
+}
+
+/// Streaming binning analysis for autocorrelation-corrected error estimates.
+///
+/// Each pushed sample updates a hierarchy of power-of-two block means.  The
+/// level with block size 1 matches the naive standard error.  Coarser levels
+/// estimate the error after progressively averaging nearby correlated samples;
+/// once the estimates plateau, that value is the usual binning estimate for the
+/// standard error of an MCMC mean.
+///
+/// ```
+/// use markov_chain_monte_carlo::BinningAnalysis;
+///
+/// let mut bins = BinningAnalysis::new();
+/// bins.extend((1..=8).map(f64::from));
+///
+/// let estimates: Vec<_> = bins.estimates().collect();
+/// assert_eq!(estimates[0].block_size(), 1);
+/// assert_eq!(estimates[1].block_size(), 2);
+/// assert_eq!(estimates[2].block_size(), 4);
+/// assert_eq!(bins.mean(), Some(4.5));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[must_use]
+pub struct BinningAnalysis {
+    count: usize,
+    levels: Vec<BinningLevel>,
+}
+
+impl BinningAnalysis {
+    /// Create an empty binning analysis.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins = BinningAnalysis::new();
+    /// assert!(bins.is_empty());
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            count: 0,
+            levels: Vec::new(),
+        }
+    }
+
+    /// Add one measurement.
+    ///
+    /// This method does not validate the sample.  Use [`try_push`](Self::try_push)
+    /// when non-finite measurements should be reported as errors instead of
+    /// becoming part of the binning state.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let mut bins = BinningAnalysis::new();
+    /// bins.push(1.0);
+    /// bins.push(2.0);
+    ///
+    /// assert_eq!(bins.count(), 2);
+    /// ```
+    pub fn push(&mut self, sample: f64) {
+        self.push_unchecked(sample);
+    }
+
+    /// Add one measurement without validating it.
+    ///
+    /// This lets `try_push` validate by applying the update to a cloned analysis
+    /// before replacing the caller-visible state.
+    fn push_unchecked(&mut self, sample: f64) {
+        self.count += 1;
+        self.push_block(0, sample);
+    }
+
+    /// Add one finite measurement.
+    ///
+    /// The analysis is unchanged on error.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
+    ///
+    /// let mut bins = BinningAnalysis::new();
+    /// assert_eq!(bins.try_push(f64::INFINITY), Err(StatisticsError::InfiniteSample));
+    /// assert!(bins.is_empty());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StatisticsError`] if `sample` is NaN or infinite, or if any
+    /// online binning accumulator becomes non-finite while updating.
+    pub fn try_push(&mut self, sample: f64) -> Result<(), StatisticsError> {
+        check_sample(sample)?;
+        let mut next = self.clone();
+        next.push_unchecked(sample);
+        next.check_levels()?;
+        *self = next;
+        Ok(())
+    }
+
+    /// Add finite measurements to the analysis.
+    ///
+    /// The analysis retains samples accepted before the first error.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
+    ///
+    /// let mut bins = BinningAnalysis::new();
+    /// let err = bins.try_extend([1.0, 2.0, f64::INFINITY, 4.0]);
+    ///
+    /// assert_eq!(err, Err(StatisticsError::InfiniteSample));
+    /// assert_eq!(bins.count(), 2);
+    /// assert_eq!(bins.mean(), Some(1.5));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StatisticsError`] on the first invalid sample or non-finite
+    /// accumulator update.
+    pub fn try_extend<I: IntoIterator<Item = f64>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), StatisticsError> {
+        for sample in iter {
+            self.try_push(sample)?;
+        }
+        Ok(())
+    }
+
+    /// Remove all accumulated samples and bins.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let mut bins: BinningAnalysis = [1.0, 2.0].into_iter().collect();
+    /// bins.clear();
+    /// assert!(bins.is_empty());
+    /// ```
+    pub fn clear(&mut self) {
+        self.count = 0;
+        self.levels.clear();
+    }
+
+    /// Number of original measurements pushed into the analysis.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = [1.0, 2.0, 3.0].into_iter().collect();
+    /// assert_eq!(bins.count(), 3);
+    /// ```
+    #[must_use]
+    pub const fn count(&self) -> usize {
+        self.count
+    }
+
+    /// Whether the analysis contains no measurements.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let mut bins = BinningAnalysis::new();
+    /// assert!(bins.is_empty());
+    /// bins.push(1.0);
+    /// assert!(!bins.is_empty());
+    /// ```
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Mean of all original measurements.
+    ///
+    /// Returns `None` until at least one sample has been added.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = [1.0, 2.0, 3.0].into_iter().collect();
+    /// assert_eq!(bins.mean(), Some(2.0));
+    /// ```
+    #[must_use]
+    pub fn mean(&self) -> Option<f64> {
+        self.levels.first().and_then(|level| level.stats.mean())
+    }
+
+    /// Naive standard error from unblocked samples.
+    ///
+    /// This ignores autocorrelation and is equivalent to
+    /// [`OnlineStats::standard_error`] over the original measurements.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = [1.0, 3.0].into_iter().collect();
+    /// assert_eq!(bins.unblocked_standard_error(), Some(1.0));
+    /// ```
+    #[must_use]
+    pub fn unblocked_standard_error(&self) -> Option<f64> {
+        self.levels
+            .first()
+            .and_then(|level| level.stats.standard_error())
+    }
+
+    /// Coarsest available binning estimate with at least two completed blocks.
+    ///
+    /// This is a convenient single estimate for streaming use.  For production
+    /// analysis, inspect [`estimates`](Self::estimates) to confirm that the
+    /// standard error has stabilized across block sizes.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = (1..=8).map(f64::from).collect();
+    /// assert_eq!(bins.coarsest_estimate().unwrap().block_size(), 4);
+    /// ```
+    #[must_use]
+    pub fn coarsest_estimate(&self) -> Option<BinningEstimate> {
+        self.estimates()
+            .filter(|estimate| estimate.standard_error().is_some())
+            .last()
+    }
+
+    /// Coarsest available standard error from the binning hierarchy.
+    ///
+    /// Returns `None` until at least two completed blocks exist at some level.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// assert!(bins.standard_error().is_some());
+    /// ```
+    #[must_use]
+    pub fn standard_error(&self) -> Option<f64> {
+        self.coarsest_estimate()
+            .and_then(|estimate| estimate.standard_error())
+    }
+
+    /// Iterate over estimates from fine to coarse block sizes.
+    ///
+    /// The iterator includes levels with at least one completed block.  A
+    /// level's [`BinningEstimate::standard_error`] is `None` until two
+    /// completed blocks are available at that block size.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// let block_sizes: Vec<_> = bins.estimates().map(|estimate| estimate.block_size()).collect();
+    ///
+    /// assert_eq!(block_sizes, vec![1, 2, 4]);
+    /// ```
+    pub fn estimates(&self) -> impl Iterator<Item = BinningEstimate> + '_ {
+        self.levels.iter().filter_map(BinningLevel::estimate)
+    }
+
+    /// Propagate one completed block mean through the power-of-two hierarchy.
+    ///
+    /// Each level stores one pending block mean; when a second block arrives,
+    /// their average becomes one completed block at the next coarser level.
+    fn push_block(&mut self, mut level_index: usize, mut block_mean: f64) {
+        loop {
+            self.ensure_level(level_index);
+            let next_block_mean = {
+                let level = &mut self.levels[level_index];
+                level.stats.push(block_mean);
+                if let Some(previous) = level.pending.take() {
+                    Some(0.5_f64.mul_add(block_mean, 0.5 * previous))
+                } else {
+                    level.pending = Some(block_mean);
+                    None
+                }
+            };
+
+            if let Some(mean) = next_block_mean {
+                block_mean = mean;
+                level_index += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Ensure the hierarchy contains `level_index`.
+    ///
+    /// Levels are created lazily so short runs do not allocate unused coarse
+    /// block levels.
+    fn ensure_level(&mut self, level_index: usize) {
+        while self.levels.len() <= level_index {
+            let block_size = self
+                .levels
+                .last()
+                .map_or(1, |level| level.block_size.saturating_mul(2));
+            self.levels.push(BinningLevel::new(block_size));
+        }
+    }
+
+    /// Validate all completed and pending per-level statistics after a trial update.
+    ///
+    /// This lets `try_push` keep invalid arithmetic from becoming visible while
+    /// preserving precise error variants for the failed stage.
+    fn check_levels(&self) -> Result<(), StatisticsError> {
+        for level in &self.levels {
+            check_stats(&level.stats)?;
+            if let Some(pending) = level.pending {
+                check_sample(pending)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for BinningAnalysis {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Extend<f64> for BinningAnalysis {
+    fn extend<I: IntoIterator<Item = f64>>(&mut self, iter: I) {
+        for sample in iter {
+            self.push(sample);
+        }
+    }
+}
+
+impl TryAccumulator<f64> for BinningAnalysis {
+    type Error = StatisticsError;
+
+    fn try_push(&mut self, sample: f64) -> Result<(), Self::Error> {
+        Self::try_push(self, sample)
+    }
+}
+
+impl FromIterator<f64> for BinningAnalysis {
+    fn from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Self {
+        let mut analysis = Self::new();
+        analysis.extend(iter);
+        analysis
+    }
+}
+
+impl iter::Sum<f64> for OnlineStats {
+    fn sum<I: Iterator<Item = f64>>(iter: I) -> Self {
+        iter.collect()
+    }
+}
+
+impl iter::Sum<f64> for BinningAnalysis {
+    fn sum<I: Iterator<Item = f64>>(iter: I) -> Self {
+        iter.collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-12,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn statistics_error_messages() {
+        assert_eq!(
+            StatisticsError::NanSample.to_string(),
+            "statistics sample was NaN"
+        );
+        assert_eq!(
+            StatisticsError::InfiniteSample.to_string(),
+            "statistics sample was infinite"
+        );
+        assert_eq!(
+            StatisticsError::NanMean.to_string(),
+            "online mean became NaN while updating statistics"
+        );
+        assert_eq!(
+            StatisticsError::InfiniteMean.to_string(),
+            "online mean became infinite while updating statistics"
+        );
+        assert_eq!(
+            StatisticsError::NanVarianceAccumulator.to_string(),
+            "online variance accumulator became NaN while updating statistics"
+        );
+        assert_eq!(
+            StatisticsError::InfiniteVarianceAccumulator.to_string(),
+            "online variance accumulator became infinite while updating statistics"
+        );
+    }
+
+    #[test]
+    fn online_stats_reports_empty_state() {
+        let stats = OnlineStats::new();
+
+        assert!(stats.is_empty());
+        assert_eq!(stats.count(), 0);
+        assert_eq!(stats.mean(), None);
+        assert_eq!(stats.population_variance(), None);
+        assert_eq!(stats.sample_variance(), None);
+        assert_eq!(stats.standard_error(), None);
+    }
+
+    #[test]
+    fn online_stats_matches_known_values() {
+        let stats: OnlineStats = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+            .into_iter()
+            .collect();
+
+        assert_eq!(stats.count(), 8);
+        assert_close(stats.mean().unwrap(), 5.0);
+        assert_close(stats.population_variance().unwrap(), 4.0);
+        assert_close(stats.sample_variance().unwrap(), 32.0 / 7.0);
+        assert_close(stats.population_std_dev().unwrap(), 2.0);
+        assert_close(stats.standard_error().unwrap(), (4.0_f64 / 7.0).sqrt());
+    }
+
+    #[test]
+    fn online_stats_can_clear_and_reuse() {
+        let mut stats = OnlineStats::default();
+        stats.extend([1.0, 3.0]);
+        stats.clear();
+        stats.push(10.0);
+
+        assert_eq!(stats.count(), 1);
+        assert_eq!(stats.mean(), Some(10.0));
+        assert_eq!(stats.sample_variance(), None);
+    }
+
+    #[test]
+    fn online_stats_try_push_rejects_invalid_samples_atomically() {
+        let mut stats = OnlineStats::new();
+        stats.try_push(1.0).unwrap();
+
+        assert_eq!(stats.try_push(f64::NAN), Err(StatisticsError::NanSample));
+        assert_eq!(
+            stats.try_push(f64::NEG_INFINITY),
+            Err(StatisticsError::InfiniteSample)
+        );
+        assert_eq!(stats.count(), 1);
+        assert_eq!(stats.mean(), Some(1.0));
+    }
+
+    #[test]
+    fn online_stats_try_push_rejects_nonfinite_accumulator_atomically() {
+        let mut stats = OnlineStats::new();
+        stats.try_push(f64::MAX).unwrap();
+
+        assert_eq!(
+            stats.try_push(-f64::MAX),
+            Err(StatisticsError::InfiniteMean)
+        );
+        assert_eq!(stats.count(), 1);
+        assert_eq!(stats.mean(), Some(f64::MAX));
+    }
+
+    #[test]
+    fn binning_analysis_builds_power_of_two_levels() {
+        let bins: BinningAnalysis = (1..=8).map(f64::from).collect();
+        let estimates: Vec<_> = bins.estimates().collect();
+
+        assert_eq!(bins.count(), 8);
+        assert_eq!(bins.mean(), Some(4.5));
+        assert_eq!(estimates.len(), 4);
+        assert_eq!(estimates[0].block_size(), 1);
+        assert_eq!(estimates[0].block_count(), 8);
+        assert_eq!(estimates[1].block_size(), 2);
+        assert_eq!(estimates[1].block_count(), 4);
+        assert_eq!(estimates[2].block_size(), 4);
+        assert_eq!(estimates[2].block_count(), 2);
+        assert_eq!(estimates[3].block_size(), 8);
+        assert_eq!(estimates[3].block_count(), 1);
+    }
+
+    #[test]
+    fn binning_analysis_reports_blocked_errors() {
+        let bins: BinningAnalysis = (1..=8).map(f64::from).collect();
+        let estimates: Vec<_> = bins.estimates().collect();
+
+        assert_close(estimates[0].sample_variance().unwrap(), 6.0);
+        assert_close(
+            estimates[0].standard_error().unwrap(),
+            (6.0_f64 / 8.0).sqrt(),
+        );
+        assert_close(estimates[1].sample_variance().unwrap(), 20.0 / 3.0);
+        assert_close(
+            estimates[1].standard_error().unwrap(),
+            (20.0_f64 / 12.0).sqrt(),
+        );
+        assert_close(estimates[2].sample_variance().unwrap(), 8.0);
+        assert_close(estimates[2].standard_error().unwrap(), 2.0);
+        assert_eq!(estimates[3].sample_variance(), None);
+        assert_eq!(estimates[3].standard_error(), None);
+
+        let coarsest = bins.coarsest_estimate().unwrap();
+        assert_eq!(coarsest.block_size(), 4);
+        assert_eq!(bins.standard_error(), Some(2.0));
+    }
+
+    #[test]
+    fn binning_analysis_handles_partial_tail_blocks() {
+        let bins: BinningAnalysis = (1..=5).map(f64::from).collect();
+        let estimates: Vec<_> = bins.estimates().collect();
+
+        assert_eq!(bins.count(), 5);
+        assert_eq!(estimates.len(), 3);
+        assert_eq!(estimates[0].block_size(), 1);
+        assert_eq!(estimates[0].block_count(), 5);
+        assert_eq!(estimates[1].block_size(), 2);
+        assert_eq!(estimates[1].block_count(), 2);
+        assert_eq!(estimates[2].block_size(), 4);
+        assert_eq!(estimates[2].block_count(), 1);
+        assert_close(estimates[1].mean(), 2.5);
+    }
+
+    #[test]
+    fn binning_analysis_can_clear_and_reuse() {
+        let mut bins = BinningAnalysis::default();
+        bins.extend([1.0, 2.0, 3.0, 4.0]);
+        bins.clear();
+        bins.extend([10.0, 14.0]);
+
+        assert_eq!(bins.count(), 2);
+        assert_eq!(bins.mean(), Some(12.0));
+        assert_eq!(bins.estimates().count(), 2);
+    }
+
+    #[test]
+    fn binning_analysis_try_push_rejects_invalid_samples_atomically() {
+        let mut bins = BinningAnalysis::new();
+        bins.try_push(1.0).unwrap();
+
+        assert_eq!(bins.try_push(f64::NAN), Err(StatisticsError::NanSample));
+        assert_eq!(
+            bins.try_push(f64::INFINITY),
+            Err(StatisticsError::InfiniteSample)
+        );
+        assert_eq!(bins.count(), 1);
+        assert_eq!(bins.mean(), Some(1.0));
+    }
+
+    #[test]
+    fn binning_analysis_try_push_rejects_nonfinite_accumulator_atomically() {
+        let mut bins = BinningAnalysis::new();
+        bins.try_push(f64::MAX).unwrap();
+
+        assert_eq!(bins.try_push(-f64::MAX), Err(StatisticsError::InfiniteMean));
+        assert_eq!(bins.count(), 1);
+        assert_eq!(bins.mean(), Some(f64::MAX));
+        assert_eq!(bins.estimates().next().unwrap().block_count(), 1);
+    }
+
+    #[test]
+    fn binning_analysis_try_extend_keeps_prior_successes() {
+        let mut bins = BinningAnalysis::new();
+
+        assert_eq!(
+            bins.try_extend([1.0, 2.0, f64::NAN, 4.0]),
+            Err(StatisticsError::NanSample)
+        );
+        assert_eq!(bins.count(), 2);
+        assert_eq!(bins.mean(), Some(1.5));
+    }
+}

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -512,6 +512,32 @@ impl BinningLevel {
             standard_error,
         })
     }
+
+    /// Apply the per-level update shared by infallible and staged pushes.
+    ///
+    /// Returns a coarser block mean only when this level pairs the incoming block
+    /// with an existing pending block.
+    fn push_block_mean(&mut self, block_mean: f64) -> Option<f64> {
+        self.stats.push(block_mean);
+        if let Some(previous) = self.pending.take() {
+            Some(0.5_f64.mul_add(block_mean, 0.5 * previous))
+        } else {
+            self.pending = Some(block_mean);
+            None
+        }
+    }
+
+    /// Validate a staged level before it is committed to the visible analysis.
+    ///
+    /// This preserves `try_push` failure atomicity while reusing the same sample
+    /// and accumulator checks as the public fallible statistics APIs.
+    fn check(&self) -> Result<(), StatisticsError> {
+        check_stats(&self.stats)?;
+        if let Some(pending) = self.pending {
+            check_sample(pending)?;
+        }
+        Ok(())
+    }
 }
 
 /// Streaming binning analysis for autocorrelation-corrected error estimates.
@@ -577,9 +603,6 @@ impl BinningAnalysis {
     }
 
     /// Add one measurement without validating it.
-    ///
-    /// This lets `try_push` validate by applying the update to a cloned analysis
-    /// before replacing the caller-visible state.
     fn push_unchecked(&mut self, sample: f64) {
         self.count += 1;
         self.push_block(0, sample);
@@ -603,10 +626,16 @@ impl BinningAnalysis {
     /// online binning accumulator becomes non-finite while updating.
     pub fn try_push(&mut self, sample: f64) -> Result<(), StatisticsError> {
         check_sample(sample)?;
-        let mut next = self.clone();
-        next.push_unchecked(sample);
-        next.check_levels()?;
-        *self = next;
+        let staged_levels = self.staged_push(sample)?;
+
+        self.count += 1;
+        for (level_index, level) in staged_levels {
+            if level_index == self.levels.len() {
+                self.levels.push(level);
+            } else {
+                self.levels[level_index] = level;
+            }
+        }
         Ok(())
     }
 
@@ -774,16 +803,7 @@ impl BinningAnalysis {
     fn push_block(&mut self, mut level_index: usize, mut block_mean: f64) {
         loop {
             self.ensure_level(level_index);
-            let next_block_mean = {
-                let level = &mut self.levels[level_index];
-                level.stats.push(block_mean);
-                if let Some(previous) = level.pending.take() {
-                    Some(0.5_f64.mul_add(block_mean, 0.5 * previous))
-                } else {
-                    level.pending = Some(block_mean);
-                    None
-                }
-            };
+            let next_block_mean = self.levels[level_index].push_block_mean(block_mean);
 
             if let Some(mean) = next_block_mean {
                 block_mean = mean;
@@ -792,6 +812,57 @@ impl BinningAnalysis {
                 break;
             }
         }
+    }
+
+    /// Stage the exact levels changed by a fallible push.
+    ///
+    /// A single sample only touches a prefix of the binning hierarchy.  Staging
+    /// that prefix keeps `try_push` failure-atomic without cloning untouched
+    /// coarser levels.
+    fn staged_push(&self, sample: f64) -> Result<Vec<(usize, BinningLevel)>, StatisticsError> {
+        let mut staged_levels = Vec::new();
+        let mut level_index = 0;
+        let mut block_mean = sample;
+
+        loop {
+            let mut level = self
+                .levels
+                .get(level_index)
+                .cloned()
+                .unwrap_or_else(|| self.new_staged_level(level_index, &staged_levels));
+            let next_block_mean = level.push_block_mean(block_mean);
+            level.check()?;
+            staged_levels.push((level_index, level));
+
+            if let Some(mean) = next_block_mean {
+                block_mean = mean;
+                level_index += 1;
+            } else {
+                break;
+            }
+        }
+
+        Ok(staged_levels)
+    }
+
+    /// Create a lazily allocated level without mutating the visible hierarchy.
+    ///
+    /// This mirrors `ensure_level` for staged updates, deriving the next block
+    /// size from either the latest staged level or the existing hierarchy.
+    fn new_staged_level(
+        &self,
+        level_index: usize,
+        staged_levels: &[(usize, BinningLevel)],
+    ) -> BinningLevel {
+        let block_size = if level_index == 0 {
+            1
+        } else if let Some((_, previous)) = staged_levels.last() {
+            previous.block_size.saturating_mul(2)
+        } else {
+            self.levels[level_index - 1].block_size.saturating_mul(2)
+        };
+
+        BinningLevel::new(block_size)
     }
 
     /// Ensure the hierarchy contains `level_index`.
@@ -806,20 +877,6 @@ impl BinningAnalysis {
                 .map_or(1, |level| level.block_size.saturating_mul(2));
             self.levels.push(BinningLevel::new(block_size));
         }
-    }
-
-    /// Validate all completed and pending per-level statistics after a trial update.
-    ///
-    /// This lets `try_push` keep invalid arithmetic from becoming visible while
-    /// preserving precise error variants for the failed stage.
-    fn check_levels(&self) -> Result<(), StatisticsError> {
-        for level in &self.levels {
-            check_stats(&level.stats)?;
-            if let Some(pending) = level.pending {
-                check_sample(pending)?;
-            }
-        }
-        Ok(())
     }
 }
 
@@ -1063,6 +1120,36 @@ mod tests {
         assert_eq!(bins.count(), 1);
         assert_eq!(bins.mean(), Some(f64::MAX));
         assert_eq!(bins.estimates().next().unwrap().block_count(), 1);
+    }
+
+    #[test]
+    fn binning_analysis_try_push_matches_infallible_hierarchy() {
+        let samples = (1..=9).map(f64::from);
+        let mut fallible = BinningAnalysis::new();
+        let mut infallible = BinningAnalysis::new();
+
+        for sample in samples {
+            fallible.try_push(sample).unwrap();
+            infallible.push(sample);
+        }
+
+        assert_eq!(fallible, infallible);
+
+        let estimates: Vec<_> = fallible.estimates().collect();
+        assert_eq!(
+            estimates
+                .iter()
+                .map(BinningEstimate::block_size)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 4, 8]
+        );
+        assert_eq!(
+            estimates
+                .iter()
+                .map(BinningEstimate::block_count)
+                .collect::<Vec<_>>(),
+            vec![9, 4, 2, 1]
+        );
     }
 
     #[test]

--- a/uv.lock
+++ b/uv.lock
@@ -431,7 +431,7 @@ wheels = [
 
 [[package]]
 name = "markov-chain-monte-carlo-tooling"
-version = "0.0.0"
+version = "0.2.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- Add OnlineStats and BinningAnalysis for streaming mean, variance, standard error, and blocked autocorrelation-aware estimates
- Add StatisticsError variants for invalid samples and non-finite accumulator state
- Add TryAccumulator and ObservedStreamError for streaming observations into fallible sinks
- Add sampler APIs for streaming by-value, in-place, and delayed observations into accumulators
- Export new statistics and streaming types through minimal workflow preludes
- Document usage in README and doctests
- Ignore local .codex workspace metadata

Closes #17 