### PR TITLE
feat: add serde checkpointing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,8 @@ dependencies = [
  "criterion",
  "proptest",
  "rand 0.10.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,15 @@ categories = [ "science", "mathematics", "algorithms" ]
 
 [dependencies]
 rand = "0.10.1"
+serde = { version = "1.0.228", features = [ "derive" ], optional = true }
+
+[features]
+serde = [ "dep:serde" ]
 
 [dev-dependencies]
 criterion = "0.8.2"
 proptest = "1.11.0"
+serde_json = "1.0.145"
 
 [[bench]]
 name = "stepping"

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ The long-term architecture separates:
 - [ ] Parallel chains
 - [ ] Additional diagnostics (ESS, R-hat, autocorrelation reports)
 - [ ] Learned proposals (ML integration)
-- [ ] `serde` feature for chain checkpointing
+- [x] `serde` feature for chain checkpointing
 
 ## Contributing
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -138,6 +138,7 @@ impl<E: Error + 'static> Error for DelayedStepError<E> {
 }
 
 /// A single MCMC chain.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug)]
 #[must_use]
 pub struct Chain<S> {
@@ -709,6 +710,7 @@ mod tests {
 
     // --- Test fixtures ---
 
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
     #[derive(Clone, Debug, PartialEq)]
     struct Scalar(f64);
 
@@ -762,6 +764,48 @@ mod tests {
             (chain2.log_prob() - (-0.5)).abs() < 1e-12,
             "log_prob at 1 should be -0.5"
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_checkpoint_resumes_sampling() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
+        chain.step(&Normal, &FixedProposal(0.0), &mut rng).unwrap();
+
+        let checkpoint = serde_json::to_string(&chain).unwrap();
+        let mut restored: Chain<Scalar> = serde_json::from_str(&checkpoint).unwrap();
+
+        assert_eq!(restored.state(), &Scalar(0.0));
+        assert!((restored.log_prob() - Normal.log_prob(restored.state())).abs() < 1e-12);
+        assert_eq!(restored.accepted(), 1);
+        assert_eq!(restored.rejected(), 0);
+        assert_eq!(restored.total_steps(), 1);
+
+        restored
+            .step(&Normal, &FixedProposal(100.0), &mut rng)
+            .unwrap();
+
+        assert_eq!(restored.total_steps(), 2);
+        assert!((restored.log_prob() - Normal.log_prob(restored.state())).abs() < 1e-12);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_allows_nonserializable_state() {
+        struct NonSerializableState(f64);
+
+        struct NonSerializableTarget;
+        impl Target<NonSerializableState> for NonSerializableTarget {
+            fn log_prob(&self, state: &NonSerializableState) -> f64 {
+                -0.5 * state.0 * state.0
+            }
+        }
+
+        let chain = Chain::new(NonSerializableState(1.0), &NonSerializableTarget).unwrap();
+
+        assert!((chain.log_prob() - (-0.5)).abs() < 1e-12);
+        assert_eq!(chain.total_steps(), 0);
     }
 
     // --- acceptance_rate ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,29 @@
 //! `*_with_thinning` variants to collect cloned states or measurements only
 //! every k-th completed step while still advancing the chain on every step.
 //!
+//! Enable the optional `serde` feature to serialize and deserialize
+//! [`Chain<S>`] when `S` implements serde's traits.  [`Sampler`] also derives
+//! serialization when all stored handles support it, but the portable
+//! checkpoint for resuming a run is the owned [`Chain<S>`]; targets, proposals,
+//! and RNG streams are reconstructed by the caller.
+//!
+//! ```
+//! # #[cfg(feature = "serde")] {
+//! use markov_chain_monte_carlo::prelude::*;
+//!
+//! struct Normal;
+//! impl Target<f64> for Normal {
+//!     fn log_prob(&self, state: &f64) -> f64 { -0.5 * state * state }
+//! }
+//!
+//! let chain = Chain::new(1.0, &Normal)?;
+//! let checkpoint = serde_json::to_string(&chain)?;
+//! let restored: Chain<f64> = serde_json::from_str(&checkpoint)?;
+//! assert!((restored.log_prob() - Normal.log_prob(restored.state())).abs() < 1e-12);
+//! # }
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
 //! # Example
 //!
 //! Sample from a standard normal distribution using Metropolis–Hastings:
@@ -445,6 +468,8 @@ mod public_api_smoke_tests {
     use core::convert::Infallible;
 
     use rand::{Rng, rngs::StdRng};
+    #[cfg(feature = "serde")]
+    use serde_json::{Error as JsonError, json, to_value};
 
     use super::{
         BinningAnalysis, BinningEstimate, Chain, DelayedStep, McmcError, Observable,
@@ -453,6 +478,7 @@ mod public_api_smoke_tests {
         prelude::{self, by_value, delayed, in_place},
     };
 
+    #[cfg_attr(feature = "serde", derive(serde::Serialize))]
     struct Smoke;
 
     impl Target<f64> for Smoke {
@@ -558,5 +584,28 @@ mod public_api_smoke_tests {
         let _: Option<
             delayed::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
         > = None;
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn sampler_serializes_handles() -> Result<(), JsonError> {
+        let target = Smoke;
+        let proposal = Smoke;
+        let mut rng = Smoke;
+        let Ok(chain) = Chain::new(1.0, &target) else {
+            unreachable!("Smoke target always returns a finite log-probability");
+        };
+        let sampler = Sampler::new(chain, &target, proposal, &mut rng);
+
+        let checkpoint = to_value(&sampler)?;
+
+        assert_eq!(checkpoint["chain"]["state"], json!(1.0));
+        assert_eq!(checkpoint["chain"]["log_prob"], json!(0.0));
+        assert_eq!(checkpoint["chain"]["accepted"], json!(0));
+        assert_eq!(checkpoint["chain"]["rejected"], json!(0));
+        assert!(checkpoint.get("target").is_some());
+        assert!(checkpoint.get("proposal").is_some());
+        assert!(checkpoint.get("rng").is_some());
+        Ok(())
     }
 }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -178,6 +178,7 @@ fn thinned_capacity<E>(steps: usize, thin_interval: usize) -> Result<usize, Thin
 /// assert!(sampler.chain_ref().acceptance_rate() > 0.0);
 /// # Ok::<(), McmcError>(())
 /// ```
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[must_use]
 pub struct Sampler<'a, S, T, P, R: ?Sized> {
     /// The MCMC chain being sampled.


### PR DESCRIPTION
- Add optional `serde` feature and derive serialization for `Chain<S>`
- Derive `Serialize` for `Sampler` when stored handles support it
- Document chain checkpointing as the portable resume path
- Add serde-gated tests for checkpoint roundtrip, resumed sampling, sampler serialization, and non-serializable state construction
- Mark serde checkpointing as complete in the README

Closes #15 