### PR TITLE
feat(testing): add detailed-balance proposal diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,15 +20,37 @@ When making changes in this repo, prioritize (in order):
 - Suggest git commands that modify version control state for the user to run manually
 - When suggesting branch names, prefer `{type}/{issue}-descriptor-or-two`, e.g. `fix/307-acceptance-rate`, `ci/312-rust-tooling`, or `doc/329-citation-notes`. If an environment requires an owner/tool prefix, keep this structure after the prefix, e.g. `codex/ci/312-rust-tooling`.
 
-### Commit Messages
+### Commit Message Generation
 
-When user requests commit message generation:
+When generating commit messages:
 
 1. Run `git --no-pager diff --cached --stat`
-2. Generate conventional commit format: `<type>: <brief summary>`
-3. Types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `style`, `ci`, `build`
-4. Include body with organized bullet points and test results
-5. Present in code block (no language) - user will commit manually
+2. Use conventional commits: `<type>: <summary>`
+3. Valid types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `style`, `ci`, `build`
+4. Include bullet-point body describing key changes
+5. Include test results
+6. Present inside a code block so the user can commit manually
+
+#### Changelog-Aware Body Text
+
+Commit subjects and bodies feed `CHANGELOG.md` through `git-cliff`. Write them as clean, readable release-note prose:
+
+- Keep the subject line concise; it becomes the primary changelog bullet.
+- The type determines the changelog section (`feat` -> Added, `fix` -> Fixed, `refactor`/`test`/`style` -> Changed, `perf` -> Performance, `docs` -> Documentation, `build`/`chore`/`ci` -> Maintenance).
+- Include PR references as `(#N)` in the subject when known; `git-cliff` auto-links them.
+- Body text appears as indented supporting detail under the changelog bullet.
+- Avoid Markdown headings `#` through `###` in the body because they conflict with changelog release and section headings. Use plain labels such as `Tests:` instead.
+- Keep body text as plain prose or simple bullet lists. Avoid deep nesting.
+- Include only release-note-worthy implementation details; avoid dumping internal command output.
+
+#### Breaking Changes
+
+Breaking changes must use one of these conventional commit markers so `git-cliff` can detect them:
+
+- Bang notation: `feat!: remove deprecated API`
+- Footer trailer: `BREAKING CHANGE: <description>`
+
+Examples of breaking changes include removing or renaming public API items, changing default behavior, bumping MSRV, altering serialized checkpoint formats, changing numerical semantics, or changing acceptance/error behavior.
 
 ### Code Quality
 
@@ -91,15 +113,18 @@ When creating or updating issues:
 ## Code structure (big picture)
 
 - This is a single Rust *library crate* (no `src/main.rs`). The crate root is `src/lib.rs`.
-- The MCMC framework is split across four modules, all re-exported from `src/lib.rs`:
+- The MCMC framework is split across focused modules, all re-exported from `src/lib.rs`:
   - `src/error.rs` — `McmcError`: error type for NaN/+∞ detection in log-probabilities and proposal ratios
+  - `src/observable.rs` — observation traits and buffers for measuring derived quantities while sampling
   - `src/traits.rs` — `Target<S>`, `Proposal<S>` (clone-based), `ProposalMut<S>` (in-place with rollback)
   - `src/chain.rs` — `Chain<S>`: Metropolis–Hastings chain with `step` (clone-based) and `step_mut` (in-place)
   - `src/sampler.rs` — `Sampler<S,T,P,R>`: ergonomic wrapper bundling a chain with its target, proposal, and RNG; provides `run`/`run_mut` for bulk sampling and implements `Iterator` for the clone-based path
+  - `src/statistics.rs` — streaming summary statistics and binning analysis helpers
+  - `src/testing.rs` — test-facing detailed-balance verification helpers
   - `prelude` module in `src/lib.rs`: convenience re-exports (`Chain`, `McmcError`, `Proposal`, `ProposalMut`, `Sampler`, `Target`)
 - Rust tests are inline `#[cfg(test)]` modules in each source file.
 - The `justfile` defines all dev workflows (see `just --list`).
-- Examples live in `examples/` (e.g. `normal_1d.rs`, `ising_1d.rs`).
+- Examples live in `examples/` (e.g. `normal_1d.rs`, `ising_1d.rs`, `detailed_balance.rs`).
 
 ## Publishing note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,38 +9,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add DelayedProposal for accept-before-mutation workflows
-- add Step/DelayedStep telemetry and orthogonal DelayedStepError variants
-- implement Chain::step_delayed with no-plan, rejection, acceptance, and commit-failure handling
-- extend Sampler with delayed stepping and generic proposal-handle storage
-- add focused by-value, in-place, and delayed prelude modules
-- update doctests, examples, README snippets, and property-test imports
-- add tests for delayed acceptance, rejection, no-plan, invalid numerics, proposal-stage errors, commit atomicity, and run_delayed error stopping
-- add Observable and TryObservable traits for infallible and fallible measurements
-- add ObservedStepError to keep sampling and observation failures orthogonal
-- add SampleBuffer for collected observation outputs
-- integrate observing APIs across by-value, in-place, and delayed Sampler paths
-- expose minimal workflow preludes for by-value, in-place, and delayed usage
-- add doctests, unit tests, and documentation for the new measurement APIs
-- simplify bounds, imports, and test names across touched code
-- Add OnlineStats and BinningAnalysis for streaming mean, variance, standard error, and blocked autocorrelation-aware estimates
-- Add StatisticsError variants for invalid samples and non-finite accumulator state
-- Add TryAccumulator and ObservedStreamError for streaming observations into fallible sinks
-- Add sampler APIs for streaming by-value, in-place, and delayed observations into accumulators
-- Export new statistics and streaming types through minimal workflow preludes
-- Document usage in README and doctests
-- Ignore local .codex workspace metadata
+- Add delayed-commit proposal API [#36](https://github.com/acgetchell/markov-chain-monte-carlo/pull/36) [`65445f4`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/65445f4e48143a47a217f573bc82c37421092a3d)
+
+  - add DelayedProposal for accept-before-mutation workflows
+  - add Step/DelayedStep telemetry and orthogonal DelayedStepError variants
+  - implement Chain::step_delayed with no-plan, rejection, acceptance, and commit-failure handling
+  - extend Sampler with delayed stepping and generic proposal-handle storage
+  - add focused by-value, in-place, and delayed prelude modules
+  - update doctests, examples, README snippets, and property-test imports
+  - add tests for delayed acceptance, rejection, no-plan, invalid numerics, proposal-stage errors, commit atomicity, and run_delayed error stopping
+- Add observable measurement framework [#37](https://github.com/acgetchell/markov-chain-monte-carlo/pull/37) [`82cbaf5`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/82cbaf58a71e1355e370eee43450d22f8c02df91)
+
+  - add Observable and TryObservable traits for infallible and fallible measurements
+  - add ObservedStepError to keep sampling and observation failures orthogonal
+  - add SampleBuffer for collected observation outputs
+  - integrate observing APIs across by-value, in-place, and delayed Sampler paths
+  - expose minimal workflow preludes for by-value, in-place, and delayed usage
+  - add doctests, unit tests, and documentation for the new measurement APIs
+  - simplify bounds, imports, and test names across touched code
+- Add streaming statistics and error bars [#38](https://github.com/acgetchell/markov-chain-monte-carlo/pull/38) [`4575047`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/457504708de375dc23ea86de56505c2cdf67419d)
+
+  - Add OnlineStats and BinningAnalysis for streaming mean, variance, standard error, and blocked autocorrelation-aware estimates
+  - Add StatisticsError variants for invalid samples and non-finite accumulator state
+  - Add TryAccumulator and ObservedStreamError for streaming observations into fallible sinks
+  - Add sampler APIs for streaming by-value, in-place, and delayed observations into accumulators
+  - Export new statistics and streaming types through minimal workflow preludes
+  - Document usage in README and doctests
+  - Ignore local .codex workspace metadata
+- Add sampler thinning support [#40](https://github.com/acgetchell/markov-chain-monte-carlo/pull/40) [`c03d07e`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/c03d07e8bec3e9b5e67c22273689971f60fad85a)
+
+  - add typed ThinningError and thinned result aliases
+  - add state-collecting thinning APIs for by-value, in-place, and delayed samplers
+  - add observing, streaming, and fallible thinning variants across sampler workflows
+  - re-export thinning types through the public API and appropriate preludes
+  - document thinning behavior in README and public doctests
+  - cover zero intervals, interval > steps boundaries, and thinned observation behavior
+- Add serde checkpointing support [#41](https://github.com/acgetchell/markov-chain-monte-carlo/pull/41) [`d976bc6`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/d976bc67f3373cf2ead697508c127b5ae205d2bc)
+
+  - Add optional `serde` feature and derive serialization for `Chain<S>`
+  - Derive `Serialize` for `Sampler` when stored handles support it
+  - Document chain checkpointing as the portable resume path
+  - Add serde-gated tests for checkpoint roundtrip, resumed sampling, sampler serialization, and non-serializable state construction
+  - Mark serde checkpointing as complete in the README
 
 ### Fixed
 
-- keep Metropolis-Hastings acceptance decisions in log space
-- explicitly reject arithmetic-created NaN acceptance ratios
-- document log_prob semantics and numerical behavior at the crate level
-- strengthen ProposalMut::propose_mut(None) contract
-- remove unnecessary S: Clone bound from by-value Proposal APIs
-- make Sampler chain storage private and expose chain_ref/chain_mut accessors
-- update examples, README, and organization docs for by-value proposal wording
-- add tests for extreme log-domain acceptance, no-move rollback, state-dependent log_q_ratio, and -inf edge cases
+- Harden MCMC acceptance and proposal invariants [#35](https://github.com/acgetchell/markov-chain-monte-carlo/pull/35) [`8ad2703`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/8ad27038dd9c79380ac1d77d35834b481bb51a85)
+
+  - keep Metropolis-Hastings acceptance decisions in log space
+  - explicitly reject arithmetic-created NaN acceptance ratios
+  - document log_prob semantics and numerical behavior at the crate level
+  - strengthen ProposalMut::propose_mut(None) contract
+  - remove unnecessary S: Clone bound from by-value Proposal APIs
+  - make Sampler chain storage private and expose chain_ref/chain_mut accessors
+  - update examples, README, and organization docs for by-value proposal wording
+  - add tests for extreme log-domain acceptance, no-move rollback, state-dependent log_q_ratio, and -inf edge cases
+
+### Maintenance
+
+- Add changelog and Python tooling [#39](https://github.com/acgetchell/markov-chain-monte-carlo/pull/39) [`02deb42`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/02deb4291f2bc89311cdb5c254aa284d81ddc4bb)
+
+  - add git-cliff changelog generation with post-processing and release tag helpers
+  - add Ruff, Ty, Pytest, and dprint configuration for repository tooling
+  - wire Python, Markdown, and Semgrep checks into justfile workflows
+  - add Python Semgrep rules and fixtures for script/test hygiene
+  - update release, tooling, code organization, README, references, and agent docs
+  - regenerate CHANGELOG.md from local git history
 
 ## [0.2.1] - 2026-04-30
 
@@ -50,20 +84,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
-- Add docs/code_organization.md with the crate layout, module responsibilities, testing structure, and development conventions
-- Add docs/RELEASING.md with the simplified manual release workflow for this crate
-- Link the new developer docs from README.md
-- Record the documentation additions in CHANGELOG.md
+- Add release and code organization guides [`8f0282a`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/8f0282a0b054660856c8f18e9de4768ea7694e1d)
+
+  - Add docs/code_organization.md with the crate layout, module responsibilities, testing structure, and development conventions
+  - Add docs/RELEASING.md with the simplified manual release workflow for this crate
+  - Link the new developer docs from README.md
+  - Record the documentation additions in CHANGELOG.md
 
 ### Maintenance
 
-- Update Rust toolchain/MSRV to 1.95.0
-- Replace tarpaulin coverage with cargo-llvm-cov for local HTML and CI Cobertura reports
-- Add CodeRabbit, CodeQL, Codecov, Codacy/OpenGrep, Taplo, rustfmt, clippy, typos, and Semgrep configuration
-- Add uv-managed Semgrep tooling with pyproject.toml and uv.lock
-- Expand and sort justfile workflows, including lint groups, setup-tools, Semgrep checks, and coverage recipes
-- Add citation/reference metadata and README sections for contributing, citation, references, and AI tooling disclosure
-- Document Rust/tooling workflow in docs/dev/rust.md and update AGENTS.md guidance
+- Upgrade Rust tooling and validation workflows [#32](https://github.com/acgetchell/markov-chain-monte-carlo/pull/32) [`8194a00`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/8194a006e9c81a953549de5caa4194cd34a38dc2)
+
+  - Update Rust toolchain/MSRV to 1.95.0
+  - Replace tarpaulin coverage with cargo-llvm-cov for local HTML and CI Cobertura reports
+  - Add CodeRabbit, CodeQL, Codecov, Codacy/OpenGrep, Taplo, rustfmt, clippy, typos, and Semgrep configuration
+  - Add uv-managed Semgrep tooling with pyproject.toml and uv.lock
+  - Expand and sort justfile workflows, including lint groups, setup-tools, Semgrep checks, and coverage recipes
+  - Add citation/reference metadata and README sections for contributing, citation, references, and AI tooling disclosure
+  - Document Rust/tooling workflow in docs/dev/rust.md and update AGENTS.md guidance
 
 ## [0.2.0] - 2026-04-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = [ "dep:serde" ]
 [dev-dependencies]
 criterion = "0.8.2"
 proptest = "1.11.0"
-serde_json = "1.0.145"
+serde_json = "1.0.149"
 
 [[bench]]
 name = "stepping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ serde = { version = "1.0.228", features = [ "derive" ], optional = true }
 [features]
 serde = [ "dep:serde" ]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dev-dependencies]
 criterion = "0.8.2"
 proptest = "1.11.0"
@@ -33,6 +36,9 @@ harness = false
 [lints.rust]
 unsafe_code = "forbid"
 missing_docs = "warn"
+
+[lints.rustdoc]
+broken_intra_doc_links = "deny"
 
 [lints.clippy]
 # Transitive dependency version conflicts are outside our control

--- a/README.md
+++ b/README.md
@@ -8,38 +8,77 @@ A composable **Markov Chain Monte Carlo (MCMC)** framework for arbitrary state s
 
 See [CHANGELOG.md](CHANGELOG.md) for release history. Citation metadata and background references are available in [CITATION.cff](CITATION.cff) and [REFERENCES.md](REFERENCES.md).
 
----
+## Introduction
 
-## Overview
+`markov-chain-monte-carlo` provides a small, explicit Metropolis-Hastings toolkit for scientific Rust projects. It is designed for ordinary numeric states, large combinatorial state spaces, and proposal implementations that need rollback-safe mutation or delayed commits.
 
-This crate provides:
+Use this crate when you want:
 
-- A generic Metropolis–Hastings implementation
-- Three proposal models:
-  - **`Proposal<S>`** — by-value proposals for simple/small state spaces
-  - **`ProposalMut<S>`** — in-place mutation with rollback, for large combinatorial state spaces (triangulations, graphs) where cloning is expensive
-  - **`DelayedProposal<S>`** — accept-before-mutation proposals with concrete plans and failure-atomic commits
-- `Chain<S>` with `step` (by-value), `step_mut` (in-place), and `step_delayed` (accept-before-mutation) methods
-- `Sampler<S, T, P, R>` — ergonomic wrapper that bundles a chain with its target, proposal, and RNG; supports `run(n)` / `run_mut(n)` for bulk sampling and implements `Iterator`
-- `Observable<S>` and `SampleBuffer<T>` for computing and collecting derived measurements during sampling
-- `OnlineStats` and `BinningAnalysis` for streaming means, variances, and autocorrelation-corrected error estimates
-- NaN and +∞ detection with automatic state rollback on error
-- Chain statistics: `acceptance_rate()`, `total_steps()`, `reset_counters()`
-- Seeded RNG support for reproducible simulations
+- A generic Metropolis-Hastings chain over user-defined state spaces
+- By-value, in-place, and delayed-commit proposal APIs
+- Log-space acceptance calculations with NaN/+infinity checks
+- Observable measurement APIs for collecting derived quantities
+- Streaming means, variances, and binning error estimates
+- Thinning helpers for long sampler runs
+- Optional `serde` checkpointing for chains and sampler handles
+- Detailed-balance diagnostics for proposal development
 
-The design emphasizes:
+## Features
 
-- Zero-cost abstractions
-- Log-space numerical stability
-- Extensibility for research and experimentation
+- [x] `Target<S>` for unnormalized log probabilities or log densities
+- [x] `Proposal<S>` for simple by-value proposals
+- [x] `ProposalMut<S>` for in-place mutation with rollback tokens
+- [x] `DelayedProposal<S>` for accept-before-mutation workflows with concrete plans
+- [x] `Chain<S>` with by-value, in-place, and delayed step methods
+- [x] `Sampler<S, T, P, R>` for ergonomic bulk runs and iterator-based sampling
+- [x] Observables, fallible observations, and sample buffers
+- [x] Online statistics and binning analysis for correlated samples
+- [x] Thinned run and observation helpers
+- [x] Optional `serde` feature for checkpointing
+- [x] Detailed-balance checks for by-value, in-place, and delayed proposals
 
-For independent parallel chains, give each worker its own `Chain`, proposal state, and RNG stream. The crate keeps parallelism explicit so simulations can control reproducibility and random-stream splitting.
+## Scientific Basis and Scope
 
----
+This crate implements Metropolis-Hastings sampling for user-defined state spaces. The transition rule uses target log-probability differences and proposal probability ratios:
 
-## Quick Start
+```text
+alpha(x, y) = min(1, exp(log pi(y) - log pi(x) + log q(x | y) - log q(y | x)))
+```
 
-### Clone-based (simple states)
+The library is built around the standard MCMC contract:
+
+- `Target<S>` returns an unnormalized natural log probability, log density, or negative action.
+- Proposal implementations must describe the same concrete transition in both the generated move and `log_q_ratio`.
+- Detailed balance, or a valid Metropolis-Hastings correction, is a property of the user-provided target+proposal pair.
+- Irreducibility, aperiodicity, burn-in, autocorrelation, and convergence are domain-specific analysis questions.
+
+What the crate provides:
+
+- Log-space acceptance calculations to avoid underflow in tail probabilities.
+- Explicit rejection of `NaN` and positive-infinite log probabilities or proposal ratios.
+- Rollback-safe in-place proposals for large states where cloning is expensive.
+- Delayed-commit proposals for workflows that need to score a concrete move before mutating state.
+- Empirical detailed-balance checks for representative discrete transitions.
+- Streaming statistics and binning analysis for correlated-sample uncertainty estimates.
+
+What the crate does not prove:
+
+- That a proposal is ergodic on a domain-specific state space.
+- That a chain has mixed enough for a given scientific observable.
+- That a triangulation, graph, or other combinatorial state satisfies external validity constraints.
+- That a chosen model is scientifically appropriate for a downstream study.
+
+For a fuller discussion, see [docs/scientific_basis.md](docs/scientific_basis.md).
+
+## Quickstart
+
+Add the crate:
+
+```bash
+cargo add markov-chain-monte-carlo
+```
+
+Sample a one-dimensional standard normal target with a symmetric random-walk proposal:
 
 ```rust
 use markov_chain_monte_carlo::prelude::by_value::*;
@@ -48,14 +87,16 @@ use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 #[derive(Clone)]
 struct Scalar(f64);
 
-struct Normal;
-impl Target<Scalar> for Normal {
+struct StandardNormal;
+impl Target<Scalar> for StandardNormal {
     fn log_prob(&self, state: &Scalar) -> f64 {
         -0.5 * state.0 * state.0
     }
 }
 
-struct RandomWalk { width: f64 }
+struct RandomWalk {
+    width: f64,
+}
 impl Proposal<Scalar> for RandomWalk {
     fn propose<R: Rng + ?Sized>(&self, current: &Scalar, rng: &mut R) -> Scalar {
         Scalar(current.0 + rng.random_range(-self.width..self.width))
@@ -63,242 +104,95 @@ impl Proposal<Scalar> for RandomWalk {
 }
 
 fn main() -> Result<(), McmcError> {
+    let target = StandardNormal;
+    let proposal = RandomWalk { width: 1.0 };
     let mut rng = StdRng::seed_from_u64(42);
-    let mut chain = Chain::new(Scalar(0.0), &Normal)?;
 
-    for _ in 0..1000 {
-        chain.step(&Normal, &RandomWalk { width: 1.0 }, &mut rng)?;
-    }
+    let chain = Chain::new(Scalar(5.0), &target)?;
+    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
 
-    assert!(chain.acceptance_rate() > 0.2);
-    Ok(())
-}
-```
-
-### Using `Sampler` (ergonomic wrapper)
-
-```rust
-use markov_chain_monte_carlo::prelude::by_value::*;
-use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
-
-# #[derive(Clone)] struct Scalar(f64);
-# struct Normal;
-# impl Target<Scalar> for Normal {
-#     fn log_prob(&self, s: &Scalar) -> f64 { -0.5 * s.0 * s.0 }
-# }
-# struct RandomWalk;
-# impl Proposal<Scalar> for RandomWalk {
-#     fn propose<R: Rng + ?Sized>(&self, c: &Scalar, r: &mut R) -> Scalar {
-#         Scalar(c.0 + r.random_range(-1.0..1.0))
-#     }
-# }
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = StdRng::seed_from_u64(42);
-    let chain = Chain::new(Scalar(0.0), &Normal)?;
-    let mut sampler = Sampler::new(chain, &Normal, &RandomWalk, &mut rng);
-
-    // Burn-in
-    sampler.run(1000)?;
+    sampler.run(1_000)?;
     sampler.chain_mut().reset_counters();
 
-    // Production
-    sampler.run(10_000)?;
+    let samples = sampler.run(10_000)?;
+    assert_eq!(samples.len(), 10_000);
     assert!(sampler.chain_ref().acceptance_rate() > 0.0);
     Ok(())
 }
 ```
 
-### Measuring observables during sampling
+## Examples
 
-```rust
-use markov_chain_monte_carlo::prelude::by_value::*;
-use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+Complete runnable examples live in [`examples/`](examples/):
 
-# #[derive(Clone)] struct Scalar(f64);
-# struct Normal;
-# impl Target<Scalar> for Normal {
-#     fn log_prob(&self, s: &Scalar) -> f64 { -0.5 * s.0 * s.0 }
-# }
-# struct RandomWalk;
-# impl Proposal<Scalar> for RandomWalk {
-#     fn propose<R: Rng + ?Sized>(&self, c: &Scalar, r: &mut R) -> Scalar {
-#         Scalar(c.0 + r.random_range(-1.0..1.0))
-#     }
-# }
-fn main() -> Result<(), McmcError> {
-    let mut rng = StdRng::seed_from_u64(42);
-    let chain = Chain::new(Scalar(0.0), &Normal)?;
-    let mut sampler = Sampler::new(chain, &Normal, &RandomWalk, &mut rng);
-    let mut energy = |state: &Scalar| 0.5 * state.0 * state.0;
+- [`examples/normal_1d.rs`](examples/normal_1d.rs) — by-value random-walk sampler for a normal target
+- [`examples/ising_1d.rs`](examples/ising_1d.rs) — in-place spin-flip proposals for a non-`Clone` Ising state
+- [`examples/iterator_sampling.rs`](examples/iterator_sampling.rs) — `Sampler` as an iterator
+- [`examples/detailed_balance.rs`](examples/detailed_balance.rs) — by-value, in-place, delayed, and batch detailed-balance checks
 
-    let measurements: SampleBuffer<f64> = sampler.run_observing(10_000, &mut energy)?;
-    assert_eq!(measurements.len(), 10_000);
-    Ok(())
-}
+Run them with:
+
+```bash
+just examples
 ```
 
-### Streaming statistics and error bars
+## Validation and Diagnostics
 
-```rust
-use markov_chain_monte_carlo::prelude::*;
+The crate exposes test-facing and analysis-facing tools for scientific workflows:
 
-fn main() {
-    let measurements = [1.0, 2.0, 3.0, 4.0];
+- `McmcError` rejects invalid `NaN` and positive-infinite log probabilities or proposal ratios
+- `ProposalMut` rollback and `DelayedProposal` commit contracts keep rejected or failed moves from corrupting chain state
+- `Observable`, `TryObservable`, and `SampleBuffer` measure derived quantities during sampling
+- `OnlineStats` and `BinningAnalysis` support streaming estimates and correlated-sample error bars
+- `verify_detailed_balance*` helpers empirically test proposal kernels for representative discrete transitions
 
-    let mut stats = OnlineStats::new();
-    stats.extend(measurements);
-    assert_eq!(stats.mean(), Some(2.5));
+These tools are diagnostics, not proofs. Domain-specific state validity, irreducibility, and mixing behavior remain the caller's responsibility.
 
-    let mut bins = BinningAnalysis::new();
-    bins.extend(measurements);
-    assert!(bins.standard_error().is_some());
-}
-```
+For proposal-specific testing patterns, see the [proposal validation guide](docs/proposal_validation.md).
 
-For long sampler runs, stream measurements directly into an accumulator instead of collecting a `SampleBuffer`:
+## Documentation
 
-```rust
-use markov_chain_monte_carlo::prelude::by_value::*;
-use rand::{Rng, SeedableRng, rngs::StdRng};
+- [docs.rs API documentation](https://docs.rs/markov-chain-monte-carlo)
+- [Scientific basis and scope](docs/scientific_basis.md)
+- [Proposal validation guide](docs/proposal_validation.md)
+- [Roadmap](docs/roadmap.md)
+- [Code organization guide](docs/code_organization.md)
+- [Rust development workflow](docs/dev/rust.md)
+- [Release process](docs/RELEASING.md)
 
-# struct T;
-# impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
-# struct P;
-# impl Proposal<f64> for P {
-#     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
-#         current + 1.0
-#     }
-# }
-fn main() -> ObservedIntoRunResult<McmcError, StatisticsError> {
-    let mut rng = StdRng::seed_from_u64(42);
-    let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
-    let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
-    let mut coordinate = |state: &f64| *state;
-    let mut stats = OnlineStats::new();
+## Ecosystem
 
-    sampler.run_observing_into(10_000, &mut coordinate, &mut stats)?;
-    assert_eq!(stats.count(), 10_000);
-    Ok(())
-}
-```
-
-Sampler methods also support thinning. The chain still advances on every step, but cloned states or observable outputs are collected only after every k-th completed step:
-
-```rust
-use markov_chain_monte_carlo::prelude::by_value::*;
-use rand::{Rng, SeedableRng, rngs::StdRng};
-
-# struct T;
-# impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
-# struct P;
-# impl Proposal<f64> for P {
-#     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
-#         current + 1.0
-#     }
-# }
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = StdRng::seed_from_u64(42);
-    let chain = Chain::new(0.0, &T)?;
-    let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
-    let mut coordinate = |state: &f64| *state;
-
-    let samples = sampler.run_observing_with_thinning(10_000, 10, &mut coordinate)?;
-    assert_eq!(samples.len(), 1_000);
-    assert_eq!(sampler.chain_ref().total_steps(), 10_000);
-    Ok(())
-}
-```
-
-### In-place mutation (combinatorial states)
-
-```rust
-use markov_chain_monte_carlo::prelude::in_place::*;
-use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
-
-struct SpinChain { spins: Vec<i8> }  // not Clone
-
-struct Ising;
-impl Target<SpinChain> for Ising {
-    fn log_prob(&self, state: &SpinChain) -> f64 {
-        state.spins.windows(2)
-            .map(|w| f64::from(w[0]) * f64::from(w[1]))
-            .sum()
-    }
-}
-
-struct SpinFlip;
-impl ProposalMut<SpinChain> for SpinFlip {
-    type Undo = usize;  // which site was flipped
-    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
-        if state.spins.is_empty() { return None; }
-        let idx = rng.random_range(0..state.spins.len());
-        state.spins[idx] *= -1;
-        Some(idx)
-    }
-    fn undo(&self, state: &mut SpinChain, idx: usize) {
-        state.spins[idx] *= -1;
-    }
-}
-
-fn main() -> Result<(), McmcError> {
-    let mut rng = StdRng::seed_from_u64(42);
-    let mut chain = Chain::new(SpinChain { spins: vec![1; 20] }, &Ising)?;
-
-    for _ in 0..1000 {
-        chain.step_mut(&Ising, &SpinFlip, &mut rng)?;
-    }
-
-    assert!(chain.acceptance_rate() > 0.0);
-    Ok(())
-}
-```
-
----
-
-## Relationship to Other Crates
-
-This crate is part of a broader ecosystem:
+This crate is part of a broader Rust ecosystem for computational geometry and simulation:
 
 - [`causal-triangulations`](https://crates.io/crates/causal-triangulations) — CDT physics and simulation
-- [`delaunay`](https://crates.io/crates/delaunay) — geometric primitives
-- [`la-stack`](https://crates.io/crates/la-stack) — linear algebra
+- [`delaunay`](https://crates.io/crates/delaunay) — geometric primitives and triangulations
+- [`la-stack`](https://crates.io/crates/la-stack) — fixed-size linear algebra
 
 The long-term architecture separates:
 
-- **Geometry** (triangulations)
-- **Sampling** (this crate)
-- **Physics** (CDT, actions, observables)
-
----
-
-## Planned Features
-
-- [ ] Adaptive Metropolis–Hastings
-- [ ] Simulated annealing / tempering
-- [ ] Parallel chains
-- [ ] Additional diagnostics (ESS, R-hat, autocorrelation reports)
-- [ ] Learned proposals (ML integration)
-- [x] `serde` feature for chain checkpointing
+- **Geometry**: triangulations and geometric predicates
+- **Sampling**: this crate
+- **Physics**: CDT actions, observables, and domain-specific dynamics
 
 ## Contributing
 
 A short local workflow:
 
 ```bash
-just setup        # Install/verify dev tools
-just check        # Run non-mutating validation
-just fix          # Apply formatters/auto-fixes
-just ci           # Run the full local CI simulation
-just changelog    # Regenerate CHANGELOG.md from local git history
+just setup         # Install/verify dev tools
+just check         # Run non-mutating validation
+just fix           # Apply formatters/auto-fixes
+just ci            # Run the full local CI simulation
+just changelog     # Regenerate CHANGELOG.md from local git history
 just bench-compile # Compile Criterion benchmarks without measuring
-just bench        # Run Criterion benchmarks
+just bench         # Run Criterion benchmarks
 ```
 
-For the full command list, run `just --list`. Development tooling details live in [`docs/dev/rust.md`](docs/dev/rust.md), code layout is summarized in [`docs/code_organization.md`](docs/code_organization.md), release steps live in [`docs/RELEASING.md`](docs/RELEASING.md), and AI assistants should follow [`AGENTS.md`](AGENTS.md).
+For the full command list, run `just --list`. AI assistants should follow [`AGENTS.md`](AGENTS.md).
 
 ## Citation
 
-If you use this crate in academic work or downstream research software, please cite it using [`CITATION.cff`](CITATION.cff) or GitHub's "Cite this repository" feature. A Zenodo DOI can be added after an archived tagged release.
+If you use this crate in academic work or downstream research software, please cite it using [`CITATION.cff`](CITATION.cff) or GitHub's "Cite this repository" feature.
 
 ## References
 
@@ -307,8 +201,6 @@ For canonical background references for Metropolis-Hastings, MCMC, and the examp
 ## AI Agents
 
 This repository contains an `AGENTS.md` file, which defines the canonical rules and invariants for AI coding assistants and autonomous agents working on this codebase.
-
-AI tools are expected to read and follow `AGENTS.md` when proposing or applying changes.
 
 Portions of this library were developed with the assistance of AI tools including [ChatGPT], [Claude], [Codex], and [CodeRabbit].
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -29,14 +29,14 @@ body = """
     {% for group, commits in commits | group_by(attribute="group") %}
         ### {{ group | upper_first }}
         {% for commit in commits %}
-            {%- if commit.body and group != "Dependencies" %}
-                {{ commit.body | trim }}
-            {%- else %}
             - {% if commit.breaking %}[**breaking**] {% endif %}\
                 {{ commit.message | split(pat="\n") | first | upper_first | trim }} \
                 [`{{ commit.id | truncate(length=7, end="") }}`]\
                 (https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
                 /commit/{{ commit.id }})
+            {%- if commit.body and group != "Dependencies" %}
+
+            {{ commit.body | indent(prefix="  ", first=true) }}
             {%- endif %}
         {%- endfor %}
     {% endfor %}\n
@@ -82,6 +82,9 @@ topo_order = false
 sort_commits = "oldest"
 
 # Link (#N) references to GitHub PRs before rendering.
+# NOTE: The repo path is hardcoded here because commit_preprocessors run before
+# Tera template rendering, so {{ remote.github.owner }} variables are not
+# available. The body/footer templates above do use the remote.github variables.
 commit_preprocessors = [
     { pattern = '(?m)^Closes #\d+\n\n', replace = "" },
     { pattern = '\(#(\d+)\)', replace = '[#${1}](https://github.com/acgetchell/markov-chain-monte-carlo/pull/${1})' },
@@ -94,9 +97,9 @@ commit_parsers = [
     { message = "(?i)^(chore: |Changed: )?prepare v[0-9]", skip = true },
 
     # Dependency bumps: keep Rust library dependencies, skip CI/action noise.
-    { message = "^chore\\(deps\\): bump (rand|proptest)\\b", group = "Dependencies" },
+    { message = "^chore\\(deps\\): bump (rand|proptest|serde|serde_json)\\b", group = "Dependencies" },
     { message = "^chore\\(deps\\): bump ", skip = true },
-    { message = "(?i)^bump (rand|proptest)\\b", group = "Dependencies" },
+    { message = "(?i)^bump (rand|proptest|serde|serde_json)\\b", group = "Dependencies" },
     { message = "(?i)^bump ", skip = true },
 
     # Conventional commit types
@@ -107,13 +110,18 @@ commit_parsers = [
     { message = "^docs?", group = "Documentation" },
     { message = "^test", group = "Changed" },
     { message = "^style", group = "Changed" },
+    { message = "^build", group = "Maintenance" },
 
     # Non-conventional patterns used in project history
     { message = "(?i)^add", group = "Added" },
     { message = "(?i)^support", group = "Added" },
+    { message = "(?i)^implement", group = "Added" },
+    { message = "(?i)^deprecate", group = "Deprecated" },
     { message = "(?i)^remove", group = "Removed" },
     { message = "(?i)^delete", group = "Removed" },
     { message = "(?i)^change", group = "Changed" },
+    { message = "(?i)^update", group = "Changed" },
+    { message = "(?i)^fix", group = "Fixed" },
 
     # Chore / CI
     { message = "^chore|^ci", group = "Maintenance" },

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -24,8 +24,12 @@ markov-chain-monte-carlo/
 │   ├── dev/
 │   │   └── rust.md
 │   ├── code_organization.md
-│   └── RELEASING.md
+│   ├── proposal_validation.md
+│   ├── RELEASING.md
+│   ├── roadmap.md
+│   └── scientific_basis.md
 ├── examples/
+│   ├── detailed_balance.rs
 │   ├── ising_1d.rs
 │   ├── iterator_sampling.rs
 │   └── normal_1d.rs
@@ -41,6 +45,8 @@ markov-chain-monte-carlo/
 │   ├── lib.rs
 │   ├── observable.rs
 │   ├── sampler.rs
+│   ├── statistics.rs
+│   ├── testing.rs
 │   └── traits.rs
 ├── tests/
 │   ├── proptest_chain.rs
@@ -128,10 +134,27 @@ This module owns:
 
 Use `Sampler` for workflow ergonomics; use `Chain` for the core transition logic.
 
+### `src/statistics.rs`
+
+Defines streaming statistics helpers for post-processing observed samples:
+
+- `OnlineStats` for one-pass means and variances
+- `BinningAnalysis` and `BinningEstimate` for correlated-sample uncertainty estimates
+- `StatisticsError` for invalid inputs and insufficient data
+
+Statistics helpers are ordinary public API, but they should stay independent of chain mutation and proposal mechanics.
+
+### `src/testing.rs`
+
+Contains test-facing validation utilities for proposal development.
+
+Detailed-balance helpers empirically check discrete by-value, in-place, and delayed proposal transitions by sampling forward/reverse moves and comparing estimated Metropolis-Hastings transition flows. Keep these helpers explicit at the crate root because they are test-facing diagnostics rather than everyday sampling imports.
+
 ## Examples
 
 Examples demonstrate complete, runnable sampling workflows:
 
+- `examples/detailed_balance.rs` shows by-value, in-place, delayed, and batch detailed-balance checks.
 - `examples/normal_1d.rs` shows a simple by-value random-walk sampler.
 - `examples/ising_1d.rs` shows in-place mutation with rollback.
 - `examples/iterator_sampling.rs` shows the by-value `Sampler` iterator API.

--- a/docs/proposal_validation.md
+++ b/docs/proposal_validation.md
@@ -1,0 +1,81 @@
+# Proposal Validation Guide
+
+This guide summarizes practical checks for proposal kernels built on `Proposal`, `ProposalMut`, and `DelayedProposal`.
+
+## Why Proposal Validation Matters
+
+Metropolis-Hastings correctness depends on the pair formed by a target distribution and a proposal kernel. The library can apply the acceptance rule, reject invalid floating-point values, and roll back failed moves, but user code still owns the scientific meaning of each proposal.
+
+For every proposal family, validate that:
+
+- Proposed states preserve domain invariants.
+- Invalid moves are reported without corrupting state.
+- Proposal ratios describe the same concrete move that was proposed.
+- Reverse moves are possible wherever the target chain requires them.
+- Representative forward/reverse transitions satisfy detailed balance after the Metropolis-Hastings correction.
+
+## By-Value Proposals
+
+Use `Proposal<S>` when proposed states are cheap to create by value. This is the simplest path for small numeric states or small discrete systems.
+
+Useful checks:
+
+- Unit-test deterministic edge cases.
+- Property-test invariants of proposed states.
+- Use `verify_detailed_balance` for representative discrete transitions.
+- Use `verify_detailed_balance_many` for a small grid or graph of transitions.
+
+For continuous proposals, exact endpoint hits are usually too rare for the current detailed-balance helper. See [Continuous Proposals](#continuous-proposals).
+
+## In-Place Proposals
+
+Use `ProposalMut<S>` when cloning the full state is expensive. The proposal mutates state and returns an undo token that must restore the exact previous state on rejection.
+
+Useful checks:
+
+- Verify `propose_mut(None)` paths leave the state unchanged.
+- Verify `undo` restores the exact previous state for every successful proposal.
+- Test invalid log-probability and invalid log-ratio paths.
+- Use `verify_detailed_balance_mut` on small representative states that implement `Clone + PartialEq`.
+- Use `verify_detailed_balance_mut_many` for batches of local moves.
+
+The detailed-balance helper clones endpoints so it can resample transitions from a clean state. That cloning is intentional test overhead, not a production sampling requirement.
+
+## Delayed Proposals
+
+Use `DelayedProposal<S>` when a concrete move can be planned and scored before mutating state. This is useful for combinatorial systems where rejected moves should avoid mutation entirely.
+
+Useful checks:
+
+- Verify each plan identifies a concrete transition, not only a move class.
+- Test planning failure, proposed-log-probability failure, and log-q-ratio failure paths.
+- Verify `commit` is failure-atomic when it can fail.
+- Use `verify_detailed_balance_delayed` for a specific planned transition.
+- Use `verify_detailed_balance_delayed_many` for batches.
+
+Delayed detailed-balance checks use plan predicates because plans are the transition descriptors. The helper does not assume endpoint equality is enough to identify a move.
+
+## Continuous Proposals
+
+The current detailed-balance helpers are designed for discrete, quantized, or exactly comparable transitions. Continuous proposals almost never resample the exact same endpoint, so exact-hit diagnostics become uninformative.
+
+Reasonable follow-up designs include:
+
+- Bin or coarsen continuous proposals before checking transition flow.
+- Compare forward/reverse proposal densities for explicitly supplied pairs.
+- Add kernel-specific diagnostics that sample paired local neighborhoods.
+- Combine analytic proposal-ratio tests with distributional tests over generated deltas.
+
+Continuous-proposal diagnostics should be developed as a separate API so the existing exact-hit helpers stay honest about their assumptions. That follow-up is tracked in [#42](https://github.com/acgetchell/markov-chain-monte-carlo/issues/42).
+
+## Suggested Test Stack
+
+For a new scientific proposal, combine:
+
+- Ordinary unit tests for hand-picked transitions
+- Property tests for state invariants and rollback behavior
+- Detailed-balance checks over representative discrete transitions
+- Regression tests for known asymmetric move ratios
+- Long-run observable checks with `OnlineStats` or `BinningAnalysis`
+
+No single test proves scientific validity. The goal is to make local proposal mistakes loud before they contaminate long simulations.

--- a/docs/proposal_validation.md
+++ b/docs/proposal_validation.md
@@ -33,7 +33,7 @@ Use `ProposalMut<S>` when cloning the full state is expensive. The proposal muta
 
 Useful checks:
 
-- Verify `propose_mut(None)` paths leave the state unchanged.
+- Verify that `propose_mut` returning `None` instead of `Option<Undo>::Some` leaves the state unchanged.
 - Verify `undo` restores the exact previous state for every successful proposal.
 - Test invalid log-probability and invalid log-ratio paths.
 - Use `verify_detailed_balance_mut` on small representative states that implement `Clone + PartialEq`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,39 @@
+# Roadmap
+
+This roadmap records likely directions for the `markov-chain-monte-carlo` crate. It is not a stability promise; release scope depends on scientific need, API maturity, and validation quality.
+
+## v0.3.0 Scientific Foundations
+
+The v0.3.0 milestone focuses on making the crate useful as the sampling layer for downstream research crates:
+
+- [x] Delayed-commit proposals for accept-before-mutation workflows
+- [x] Observable measurement framework
+- [x] Streaming statistics and binning error estimates
+- [x] Sampler thinning
+- [x] Optional `serde` checkpointing
+- [x] Detailed-balance verification for by-value, in-place, and delayed proposals
+
+## Near-Term Candidates
+
+Likely follow-up work:
+
+- More convergence diagnostics, such as effective sample size, autocorrelation reports, and R-hat helpers
+- Parallel-chain utilities that keep random-stream management explicit
+- Additional examples showing multi-chain analysis and checkpoint/resume workflows
+- More ergonomic detailed-balance fixtures for common discrete proposal patterns
+- Continuous-proposal diagnostics that avoid exact-hit assumptions ([#42](https://github.com/acgetchell/markov-chain-monte-carlo/issues/42))
+- Documentation that connects this crate to `causal-triangulations` proposal validation
+
+## Longer-Term Ideas
+
+Exploratory directions:
+
+- Adaptive Metropolis-Hastings with explicit adaptation windows and post-adaptation freezing
+- Simulated annealing or tempering workflows
+- Learned or data-informed proposal kernels
+- More structured diagnostic reports for publication-quality simulation workflows
+- Optional integrations with downstream geometry and physics crates
+
+## Non-Goals
+
+The crate should remain a focused MCMC library rather than becoming a full simulation framework. Domain-specific actions, triangulation validity, geometry kernels, visualization, and physics observables belong in downstream crates.

--- a/docs/scientific_basis.md
+++ b/docs/scientific_basis.md
@@ -13,8 +13,8 @@ alpha(x, y) = min(1, exp(log pi(y) - log pi(x) + log q(x | y) - log q(y | x)))
 The `Target<S>` implementation supplies `log pi(s)` up to an additive constant. The proposal implementation supplies either symmetric proposals or an explicit log proposal ratio through:
 
 - `Proposal::log_q_ratio(current, proposed)`
-- `ProposalMut::log_q_ratio(proposed_state, undo_token)`
-- `DelayedProposal::log_q_ratio(current_state, plan)`
+- `ProposalMut::log_q_ratio(state, token)`
+- `DelayedProposal::log_q_ratio(state, plan) -> Result<f64, Self::Error>`
 
 These ratios must describe the same concrete transition that was proposed. For combinatorial systems, this usually means accounting for move-kind probabilities, site counts, reverse-site counts, and invalid-move handling.
 

--- a/docs/scientific_basis.md
+++ b/docs/scientific_basis.md
@@ -1,0 +1,60 @@
+# Scientific Basis and Scope
+
+This crate implements Metropolis-Hastings sampling primitives for user-defined state spaces. It provides the transition machinery, numerical checks, rollback contracts, diagnostics, and streaming estimators needed for robust scientific code, but the scientific validity of a chain also depends on the caller's target distribution, proposal kernel, state representation, and analysis choices.
+
+## Metropolis-Hastings Contract
+
+For a current state `x` and proposed state `y`, the crate uses the standard Metropolis-Hastings acceptance probability:
+
+```text
+alpha(x, y) = min(1, exp(log pi(y) - log pi(x) + log q(x | y) - log q(y | x)))
+```
+
+The `Target<S>` implementation supplies `log pi(s)` up to an additive constant. The proposal implementation supplies either symmetric proposals or an explicit log proposal ratio through:
+
+- `Proposal::log_q_ratio(current, proposed)`
+- `ProposalMut::log_q_ratio(proposed_state, undo_token)`
+- `DelayedProposal::log_q_ratio(current_state, plan)`
+
+These ratios must describe the same concrete transition that was proposed. For combinatorial systems, this usually means accounting for move-kind probabilities, site counts, reverse-site counts, and invalid-move handling.
+
+## What the Crate Checks
+
+The library enforces several local invariants:
+
+- Acceptance decisions are computed in log space.
+- `NaN` and positive-infinite target log-probabilities or proposal ratios are rejected.
+- In-place proposals roll back on rejection or invalid proposed values.
+- Delayed proposals separate planning, scoring, acceptance, and commit so mutations happen only after acceptance.
+- Sampling counters and cached log-probabilities stay synchronized through library-owned transitions.
+
+These checks protect the mechanics of a single transition. They do not prove that a user-defined proposal explores the full intended state space.
+
+## Diagnostics
+
+The crate includes diagnostics that help users test assumptions:
+
+- Observables measure derived quantities during sampling.
+- `OnlineStats` provides one-pass summary statistics.
+- `BinningAnalysis` estimates uncertainty for correlated samples.
+- Thinning helpers collect every k-th state or observation while still advancing the chain on every step.
+- Detailed-balance helpers empirically compare forward and reverse transition flows for representative discrete transitions.
+
+Detailed-balance checks are especially useful for new proposal kernels, but they remain empirical tests over selected transitions. Passing them does not establish irreducibility, aperiodicity, or adequate mixing.
+
+## User Responsibilities
+
+Domain code should still validate:
+
+- State invariants before and after domain-specific moves
+- Proposal irreducibility or known connected components for the intended state space
+- Correct proposal ratios for asymmetric moves
+- Burn-in, autocorrelation, effective sample size, and convergence behavior
+- Reproducible random-number seeding and independent streams for parallel chains
+- Scientific interpretation of observables and uncertainty estimates
+
+For constrained triangulations, graphs, or other combinatorial systems, the strongest checks usually combine domain-specific invariant tests with this crate's transition-level diagnostics.
+
+## References
+
+See [`REFERENCES.md`](../REFERENCES.md) for canonical background references on Metropolis-Hastings, MCMC, and the example models used by this repository.

--- a/examples/detailed_balance.rs
+++ b/examples/detailed_balance.rs
@@ -1,0 +1,140 @@
+//! Validate simple proposal distributions with detailed-balance helpers.
+//!
+//! Demonstrates by-value, in-place, delayed, and batch checks.
+//!
+//! Run with: `cargo run --example detailed_balance`
+
+use core::convert::Infallible;
+
+use markov_chain_monte_carlo::prelude::testing::*;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+struct TwoStateTarget;
+impl Target<bool> for TwoStateTarget {
+    fn log_prob(&self, state: &bool) -> f64 {
+        if *state { -2.0 } else { 0.0 }
+    }
+}
+
+struct Flip;
+impl Proposal<bool> for Flip {
+    fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
+        !current
+    }
+}
+
+struct FlipMut;
+impl ProposalMut<bool> for FlipMut {
+    type Undo = bool;
+
+    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+        let previous = *state;
+        *state = !*state;
+        Some(previous)
+    }
+
+    fn undo(&self, state: &mut bool, token: bool) {
+        *state = token;
+    }
+}
+
+struct DelayedFlip;
+impl DelayedProposal<bool> for DelayedFlip {
+    type Plan = bool;
+    type Info = bool;
+    type Error = Infallible;
+
+    fn propose_plan<R: Rng + ?Sized>(
+        &mut self,
+        state: &bool,
+        _: &mut R,
+    ) -> Result<Option<bool>, Infallible> {
+        Ok(Some(!*state))
+    }
+
+    fn proposed_log_prob<T: Target<bool>>(
+        &self,
+        _: &bool,
+        plan: &bool,
+        target: &T,
+    ) -> Result<f64, Infallible> {
+        Ok(target.log_prob(plan))
+    }
+
+    fn info(&self, plan: &bool) -> bool {
+        *plan
+    }
+
+    fn commit<R: Rng + ?Sized>(
+        &mut self,
+        state: &mut bool,
+        plan: bool,
+        _: &mut R,
+    ) -> Result<(), Infallible> {
+        *state = plan;
+        Ok(())
+    }
+}
+
+fn main() -> Result<(), DetailedBalanceError> {
+    let target = TwoStateTarget;
+    let config = DetailedBalanceConfig {
+        samples: 256,
+        tolerance: 1e-10,
+        min_hits: 1,
+    };
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let by_value = verify_detailed_balance(&false, &true, &target, &Flip, &mut rng, config)?;
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let in_place = verify_detailed_balance_mut(&false, &true, &target, &FlipMut, &mut rng, config)?;
+
+    let pairs = [(false, true), (true, false)];
+    let mut rng = StdRng::seed_from_u64(42);
+    let batch = verify_detailed_balance_many(
+        pairs.iter().map(|(current, proposed)| (current, proposed)),
+        &target,
+        &Flip,
+        &mut rng,
+        config,
+    )?;
+
+    let forward = |plan: &bool| *plan;
+    let reverse = |plan: &bool| !*plan;
+    let delayed_transitions = [DetailedBalanceDelayedTransition {
+        current: &false,
+        proposed: &true,
+        forward_plan_matches: &forward,
+        reverse_plan_matches: &reverse,
+    }];
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut delayed_proposal = DelayedFlip;
+    let delayed = verify_detailed_balance_delayed_many(
+        delayed_transitions,
+        &target,
+        &mut delayed_proposal,
+        &mut rng,
+        config,
+    )?;
+
+    assert!(batch.is_success());
+    assert!(delayed.is_success());
+
+    println!(
+        "by-value residual: {:+.3e} (se {:.3e})",
+        by_value.log_balance_residual, by_value.log_balance_standard_error
+    );
+    println!(
+        "in-place residual: {:+.3e} (se {:.3e})",
+        in_place.log_balance_residual, in_place.log_balance_standard_error
+    );
+    println!(
+        "batch checks: {} by-value, {} delayed",
+        batch.reports.len(),
+        delayed.reports.len()
+    );
+    println!("Detailed balance checks passed");
+
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -152,6 +152,7 @@ doc:
 
 # Examples
 examples:
+    cargo run --quiet --example detailed_balance
     cargo run --quiet --example normal_1d
     cargo run --quiet --example ising_1d
     cargo run --quiet --example iterator_sampling
@@ -298,8 +299,37 @@ semgrep-test: _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
     cd tests/semgrep
-    uv run semgrep scan --metrics off --test --strict --config ../../semgrep.yaml src/project_rules/rust_style.rs
+
+    expect_semgrep_count() {
+        local expected="$1"
+        local rule="$2"
+        local target="$3"
+        local json
+        local count
+
+        json="$(uv run semgrep scan --metrics off --json --quiet --strict --config ../../semgrep.yaml "$target")"
+        count="$(printf '%s\n' "$json" | { grep -o "\"check_id\":\"$rule\"" || true; } | wc -l | tr -d '[:space:]')"
+
+        if [[ "$count" != "$expected" ]]; then
+            echo "expected $expected findings for $rule in $target, got $count" >&2
+            exit 1
+        fi
+    }
+
+    expect_semgrep_count 2 mcmc.rust.no-stdio-diagnostics-in-src src/project_rules/rust_style.rs
+    expect_semgrep_count 1 mcmc.rust.no-nonfinite-unwrap-defaults src/project_rules/rust_style.rs
+    expect_semgrep_count 3 mcmc.rust.no-production-unwrap-panic src/project_rules/rust_style.rs
+    expect_semgrep_count 1 mcmc.rust.no-box-dyn-error-in-src src/project_rules/rust_style.rs
+    expect_semgrep_count 1 mcmc.rust.no-clippy-allow-lints src/project_rules/rust_style.rs
+    expect_semgrep_count 1 mcmc.rust.expect-requires-reason src/project_rules/rust_style.rs
+
     uv run semgrep scan --metrics off --test --strict --config ../../semgrep.yaml examples/deep_import.rs
+    expect_semgrep_count 3 mcmc.rust.no-box-dyn-error-in-examples-benches examples/erased_error.rs
+    expect_semgrep_count 0 mcmc.rust.no-box-dyn-error-in-examples-benches examples/typed_error.rs
+    expect_semgrep_count 3 mcmc.rust.no-box-dyn-error-in-examples-benches benches/erased_error.rs
+    expect_semgrep_count 0 mcmc.rust.no-box-dyn-error-in-examples-benches benches/typed_error.rs
+    expect_semgrep_count 3 mcmc.rust.no-box-dyn-error-in-doctests src/doctests/erased_error.rs
+    expect_semgrep_count 0 mcmc.rust.no-box-dyn-error-in-doctests src/doctests/typed_error.rs
     uv run semgrep scan --metrics off --test --strict --config ../../semgrep.yaml scripts/tests/python_exceptions.py
 
 setup: setup-tools
@@ -447,6 +477,11 @@ toml-lint: _ensure-taplo
 validate-examples:
     #!/usr/bin/env bash
     set -euo pipefail
+    output=$(cargo run --quiet --example detailed_balance)
+    echo "$output"
+    echo "$output" | grep -q "Detailed balance checks passed" || { echo "❌ detailed_balance: Missing success marker"; exit 1; }
+    echo "$output" | grep -q "by-value residual" || { echo "❌ detailed_balance: Missing by-value residual"; exit 1; }
+    echo "✅ detailed_balance validated"
     output=$(cargo run --quiet --example normal_1d)
     echo "$output"
     echo "$output" | grep -q "Sample mean" || { echo "❌ normal_1d: Missing sample mean"; exit 1; }

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -119,6 +119,45 @@ rules:
               ...
           }
 
+  - id: mcmc.rust.no-box-dyn-error-in-examples-benches
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use a concrete crate error in examples and benchmarks instead of dynamic error erasure."
+    metadata:
+      category: maintainability
+      rationale: "Examples and benchmarks should model typed error handling that users can copy."
+    paths:
+      include:
+        - "/examples/**/*.rs"
+        - "/benches/**/*.rs"
+    patterns:
+      - pattern-regex: >-
+          ^[ \t]*[^\n]*(\bBox\s*<\s*dyn\s+(std::error::)?Error\b|&\s*dyn\s+(std::error::)?Error\b|\banyhow::Error\b)
+      - pattern-not-regex: '^[ \t]*(//|///|/\*|\*)'
+
+  - id: mcmc.rust.no-box-dyn-error-in-doctests
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use concrete error types in doctests instead of Box<dyn Error> or other dynamic error erasure."
+    metadata:
+      category: maintainability
+      rationale: "Doctests are public examples and should model typed, copyable error handling."
+    paths:
+      include:
+        - "/src/**/*.rs"
+    patterns:
+      - pattern-either:
+          - pattern-regex: >-
+              ^\s*(//!|///).*dyn\s+(std::error::)?Error
+          - pattern-regex: >-
+              ^\s*(//!|///).*anyhow::Error
+          - pattern-regex: >-
+              (?s)/\*\*.*?(Box\s*<\s*dyn\s+(std::error::)?Error|&\s*dyn\s+(std::error::)?Error|anyhow::Error).*?\*/
+          - pattern-regex: >-
+              (?s)/\*!.*?(Box\s*<\s*dyn\s+(std::error::)?Error|&\s*dyn\s+(std::error::)?Error|anyhow::Error).*?\*/
+
   - id: mcmc.rust.no-clippy-allow-lints
     languages:
       - rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,22 @@
 //! `*_with_thinning` variants to collect cloned states or measurements only
 //! every k-th completed step while still advancing the chain on every step.
 //!
+//! # Proposal validation
+//!
+//! The [`verify_detailed_balance`] family of helpers gives proposal authors a
+//! test-facing diagnostic for representative discrete transitions.  Use
+//! [`verify_detailed_balance`] for by-value [`Proposal`] implementations,
+//! [`verify_detailed_balance_mut`] for rollback-based [`ProposalMut`]
+//! implementations, and [`verify_detailed_balance_delayed`] for
+//! [`DelayedProposal`] plans.  The companion batch helpers collect all
+//! per-transition failures in a [`DetailedBalanceBatchReport`], which is useful
+//! when checking a small graph, move table, or list of local states.
+//!
+//! These helpers are empirical diagnostics for exact endpoint hits, not a proof
+//! of ergodicity or convergence.  They are intended for tests, examples, and
+//! proposal-development checks over discrete or otherwise exactly comparable
+//! states.
+//!
 //! Enable the optional `serde` feature to serialize and deserialize
 //! [`Chain<S>`] when `S` implements serde's traits.  [`Sampler`] also derives
 //! serialization when all stored handles support it, but the portable
@@ -479,7 +495,10 @@ pub mod prelude {
     /// Prelude for proposal validation and detailed-balance diagnostics.
     ///
     /// This imports the target and proposal traits plus the public
-    /// detailed-balance helpers, without importing sampler execution types.
+    /// [`crate::verify_detailed_balance`] helpers, without importing sampler
+    /// execution types.  Use this prelude in tests, examples, and benchmarks
+    /// that validate proposal kernels with [`crate::DetailedBalanceConfig`] and
+    /// inspect [`crate::DetailedBalanceReport`] values.
     pub mod testing {
         pub use crate::{
             DelayedProposal, DetailedBalanceBatchReport, DetailedBalanceConfig,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,12 +59,14 @@
 //!     fn log_prob(&self, state: &f64) -> f64 { -0.5 * state * state }
 //! }
 //!
-//! let chain = Chain::new(1.0, &Normal)?;
+//! let Ok(chain) = Chain::new(1.0, &Normal) else {
+//!     unreachable!("normal target returns a finite log probability");
+//! };
 //! let checkpoint = serde_json::to_string(&chain)?;
 //! let restored: Chain<f64> = serde_json::from_str(&checkpoint)?;
 //! assert!((restored.log_prob() - Normal.log_prob(restored.state())).abs() < 1e-12);
 //! # }
-//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! # Ok::<(), serde_json::Error>(())
 //! ```
 //!
 //! # Example
@@ -321,6 +323,7 @@
 //! `Sampler` can also stream observations directly into these accumulators:
 //!
 //! ```
+//! use core::convert::Infallible;
 //! use markov_chain_monte_carlo::prelude::by_value::*;
 //! use rand::{Rng, SeedableRng, rngs::StdRng};
 //!
@@ -333,14 +336,14 @@
 //! #     }
 //! # }
 //! let mut rng = StdRng::seed_from_u64(42);
-//! let chain = Chain::new(0.0, &T)?;
+//! let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
 //! let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
 //! let mut coordinate = |state: &f64| *state;
 //! let mut stats = OnlineStats::new();
 //!
 //! sampler.run_observing_into(4, &mut coordinate, &mut stats)?;
 //! assert_eq!(stats.count(), 4);
-//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! # Ok::<(), ObservedStreamError<McmcError, Infallible, StatisticsError>>(())
 //! ```
 
 mod chain;
@@ -348,6 +351,7 @@ mod error;
 mod observable;
 mod sampler;
 mod statistics;
+mod testing;
 mod traits;
 
 pub use chain::{Chain, DelayedStep, DelayedStepError, Step};
@@ -365,6 +369,13 @@ pub use sampler::{
     TryThinnedObservedRunResult,
 };
 pub use statistics::{BinningAnalysis, BinningEstimate, OnlineStats, StatisticsError};
+pub use testing::{
+    DetailedBalanceBatchReport, DetailedBalanceConfig, DetailedBalanceDelayedTransition,
+    DetailedBalanceDirection, DetailedBalanceError, DetailedBalanceFailure, DetailedBalanceReport,
+    DetailedBalanceState, verify_detailed_balance, verify_detailed_balance_delayed,
+    verify_detailed_balance_delayed_many, verify_detailed_balance_many,
+    verify_detailed_balance_mut, verify_detailed_balance_mut_many,
+};
 pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 
 /// Convenience re-exports for common usage.
@@ -394,6 +405,7 @@ pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 /// use markov_chain_monte_carlo::prelude::by_value::Proposal;
 /// use markov_chain_monte_carlo::prelude::delayed as delayed_prelude;
 /// use markov_chain_monte_carlo::prelude::in_place as in_place_prelude;
+/// use markov_chain_monte_carlo::prelude::testing as testing_prelude;
 ///
 /// fn needs_by_value<T: Target<f64>, P: Proposal<f64>>(_: &T, _: &P) {}
 /// fn accepts_chain(_: &Chain<f64>) {}
@@ -406,6 +418,8 @@ pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 ///     T: delayed_prelude::Target<f64>,
 ///     P: delayed_prelude::DelayedProposal<f64>,
 /// >(_: &T, _: &P) {}
+/// fn needs_testing<T: testing_prelude::Target<f64>>(_: &T) {}
+/// let _: Option<testing_prelude::DetailedBalanceConfig> = None;
 /// ```
 pub mod prelude {
     pub use crate::{
@@ -461,6 +475,21 @@ pub mod prelude {
             TryThinnedObservedRunResult,
         };
     }
+
+    /// Prelude for proposal validation and detailed-balance diagnostics.
+    ///
+    /// This imports the target and proposal traits plus the public
+    /// detailed-balance helpers, without importing sampler execution types.
+    pub mod testing {
+        pub use crate::{
+            DelayedProposal, DetailedBalanceBatchReport, DetailedBalanceConfig,
+            DetailedBalanceDelayedTransition, DetailedBalanceDirection, DetailedBalanceError,
+            DetailedBalanceFailure, DetailedBalanceReport, DetailedBalanceState, Proposal,
+            ProposalMut, Target, verify_detailed_balance, verify_detailed_balance_delayed,
+            verify_detailed_balance_delayed_many, verify_detailed_balance_many,
+            verify_detailed_balance_mut, verify_detailed_balance_mut_many,
+        };
+    }
 }
 
 #[cfg(test)]
@@ -472,10 +501,12 @@ mod public_api_smoke_tests {
     use serde_json::{Error as JsonError, json, to_value};
 
     use super::{
-        BinningAnalysis, BinningEstimate, Chain, DelayedStep, McmcError, Observable,
-        ObservedDelayedStep, OnlineStats, Proposal, ProposalMut, SampleBuffer, Sampler,
-        StatisticsError, Step, Target, ThinningError,
-        prelude::{self, by_value, delayed, in_place},
+        BinningAnalysis, BinningEstimate, Chain, DelayedStep, DetailedBalanceBatchReport,
+        DetailedBalanceConfig, DetailedBalanceDelayedTransition, DetailedBalanceDirection,
+        DetailedBalanceError, DetailedBalanceFailure, DetailedBalanceReport, DetailedBalanceState,
+        McmcError, Observable, ObservedDelayedStep, OnlineStats, Proposal, ProposalMut,
+        SampleBuffer, Sampler, StatisticsError, Step, Target, ThinningError,
+        prelude::{self, by_value, delayed, in_place, testing},
     };
 
     #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -543,12 +574,16 @@ mod public_api_smoke_tests {
         fn needs_by_value<P: by_value::Proposal<f64>>() {}
         fn needs_in_place<P: in_place::ProposalMut<f64>>() {}
         fn needs_delayed<P: delayed::DelayedProposal<f64>>() {}
+        fn needs_testing_target<T: testing::Target<f64>>() {}
+        fn needs_testing_proposal<P: testing::Proposal<f64>>() {}
         fn needs_observable<O: Observable<f64, Output = f64>>(_: &mut O) {}
 
         needs_target::<Smoke>();
         needs_by_value::<Smoke>();
         needs_in_place::<Smoke>();
         needs_delayed::<Smoke>();
+        needs_testing_target::<Smoke>();
+        needs_testing_proposal::<Smoke>();
 
         let mut observable = |state: &f64| *state;
         needs_observable(&mut observable);
@@ -565,6 +600,14 @@ mod public_api_smoke_tests {
         let _: Option<BinningEstimate> = None;
         let _: Option<OnlineStats> = None;
         let _: Option<StatisticsError> = None;
+        let _: Option<DetailedBalanceConfig> = None;
+        let _: Option<DetailedBalanceDirection> = None;
+        let _: Option<DetailedBalanceError> = None;
+        let _: Option<DetailedBalanceFailure> = None;
+        let _: Option<DetailedBalanceDelayedTransition<'_, f64, ()>> = None;
+        let _: Option<DetailedBalanceBatchReport> = None;
+        let _: Option<DetailedBalanceReport> = None;
+        let _: Option<DetailedBalanceState> = None;
         let _: Option<prelude::ThinnedRunResult<(), McmcError>> = None;
         let _: Option<prelude::TryThinnedObservedRunResult<f64, McmcError, Infallible>> = None;
         let _: Option<by_value::ThinnedObservedIntoRunResult<McmcError, Infallible>> = None;
@@ -572,6 +615,9 @@ mod public_api_smoke_tests {
             in_place::TryThinnedObservedIntoRunResult<McmcError, Infallible, Infallible>,
         > = None;
         let _: Option<delayed::ThinnedObservedDelayedIntoRunResult<Infallible, Infallible>> = None;
+        let _: Option<testing::DetailedBalanceConfig> = None;
+        let _: Option<testing::DetailedBalanceError> = None;
+        let _: Option<testing::DetailedBalanceReport> = None;
         let _: Option<
             prelude::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
         > = None;

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -458,7 +458,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     ///
     /// let states = sampler.run_with_thinning(5, 2)?;
@@ -466,7 +466,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     ///
     /// let err = sampler.run_with_thinning(1, 0).unwrap_err();
     /// assert!(matches!(err, ThinningError::InvalidInterval { thin_interval: 0 }));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<McmcError>>(())
     /// ```
     ///
     /// # Errors
@@ -594,7 +594,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &Flat)?;
+    /// let chain = Chain::new(0, &Flat).map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     /// let mut coordinate = |state: &i32| *state;
     ///
@@ -605,7 +605,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     ///     .run_observing_with_thinning(1, 0, &mut coordinate)
     ///     .unwrap_err();
     /// assert!(matches!(err, ThinningError::InvalidInterval { thin_interval: 0 }));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<McmcError>>(())
     /// ```
     ///
     /// # Errors
@@ -694,6 +694,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// [`run_observing_with_thinning`](Self::run_observing_with_thinning).
     ///
     /// ```
+    /// use core::convert::Infallible;
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -709,7 +710,9 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &Flat)?;
+    /// let chain = Chain::new(0, &Flat)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
@@ -717,7 +720,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// sampler.run_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
     /// assert_eq!(stats.count(), 2);
     /// assert_eq!(sampler.chain_ref().total_steps(), 5);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<ObservedStreamError<McmcError, Infallible, StatisticsError>>>(())
     /// ```
     ///
     /// # Errors
@@ -857,13 +860,15 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &Flat)?;
+    /// let chain = Chain::new(0, &Flat)
+    ///     .map_err(ObservedStepError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     /// let mut coordinate = |state: &i32| Ok::<i32, Infallible>(*state);
     ///
     /// let samples = sampler.try_run_observing_with_thinning(5, 2, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<ObservedStepError<McmcError, Infallible>>>(())
     /// ```
     ///
     /// # Errors
@@ -970,14 +975,16 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &Flat)?;
+    /// let chain = Chain::new(0, &Flat)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     /// let mut coordinate = |state: &i32| Ok::<f64, Infallible>(f64::from(*state));
     /// let mut stats = OnlineStats::new();
     ///
     /// sampler.try_run_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<ObservedStreamError<McmcError, Infallible, StatisticsError>>>(())
     /// ```
     ///
     /// # Errors
@@ -1123,7 +1130,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     ///
     /// let states = sampler.run_mut_with_thinning(5, 2)?;
@@ -1131,7 +1138,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ///
     /// let err = sampler.run_mut_with_thinning(1, 0).unwrap_err();
     /// assert!(matches!(err, ThinningError::InvalidInterval { thin_interval: 0 }));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<McmcError>>(())
     /// ```
     ///
     /// # Errors
@@ -1267,13 +1274,13 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     /// let mut coordinate = |state: &S| state.0;
     ///
     /// let samples = sampler.run_mut_observing_with_thinning(5, 2, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<McmcError>>(())
     /// ```
     ///
     /// # Errors
@@ -1361,6 +1368,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// [`run_mut_observing_with_thinning`](Self::run_mut_observing_with_thinning).
     ///
     /// ```
+    /// use core::convert::Infallible;
     /// use markov_chain_monte_carlo::prelude::in_place::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -1381,14 +1389,16 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let chain = Chain::new(S(0), &Flat)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     /// let mut coordinate = |state: &S| f64::from(state.0);
     /// let mut stats = OnlineStats::new();
     ///
     /// sampler.run_mut_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<ObservedStreamError<McmcError, Infallible, StatisticsError>>>(())
     /// ```
     ///
     /// # Errors
@@ -1537,13 +1547,15 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let chain = Chain::new(S(0), &Flat)
+    ///     .map_err(ObservedStepError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     /// let mut coordinate = |state: &S| Ok::<i32, Infallible>(state.0);
     ///
     /// let samples = sampler.try_run_mut_observing_with_thinning(5, 2, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<ObservedStepError<McmcError, Infallible>>>(())
     /// ```
     ///
     /// # Errors
@@ -1658,14 +1670,16 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let chain = Chain::new(S(0), &Flat)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
     /// let mut coordinate = |state: &S| Ok::<f64, Infallible>(f64::from(state.0));
     /// let mut stats = OnlineStats::new();
     ///
     /// sampler.try_run_mut_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<ObservedStreamError<McmcError, Infallible, StatisticsError>>>(())
     /// ```
     ///
     /// # Errors
@@ -1903,7 +1917,9 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let target = Flat;
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &target)?;
+    /// let chain = Chain::new(S(0), &target)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
     ///
     /// let states = sampler.run_delayed_with_thinning(5, 2)?;
@@ -1911,7 +1927,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     ///
     /// let err = sampler.run_delayed_with_thinning(1, 0).unwrap_err();
     /// assert!(matches!(err, ThinningError::InvalidInterval { thin_interval: 0 }));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<DelayedStepError<Infallible>>>(())
     /// ```
     ///
     /// # Errors
@@ -2084,13 +2100,15 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let target = Flat;
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &target)?;
+    /// let chain = Chain::new(0, &target)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
     /// let mut coordinate = |state: &i32| *state;
     ///
     /// let samples = sampler.run_delayed_observing_with_thinning(5, 2, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<DelayedStepError<Infallible>>>(())
     /// ```
     ///
     /// # Errors
@@ -2203,14 +2221,17 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let target = Flat;
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &target)?;
+    /// let chain = Chain::new(0, &target)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
     ///
     /// sampler.run_delayed_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<ObservedStreamError<DelayedStepError<Infallible>, Infallible, StatisticsError>>>(())
     /// ```
     ///
     /// # Errors
@@ -2370,13 +2391,16 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let target = Flat;
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &target)?;
+    /// let chain = Chain::new(0, &target)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStepError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
     /// let mut coordinate = |state: &i32| Ok::<i32, Infallible>(*state);
     ///
     /// let samples = sampler.try_run_delayed_observing_with_thinning(5, 2, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<ObservedStepError<DelayedStepError<Infallible>, Infallible>>>(())
     /// ```
     ///
     /// # Errors
@@ -2496,14 +2520,17 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let target = Flat;
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &target)?;
+    /// let chain = Chain::new(0, &target)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
     /// let mut coordinate = |state: &i32| Ok::<f64, Infallible>(f64::from(*state));
     /// let mut stats = OnlineStats::new();
     ///
     /// sampler.try_run_delayed_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok::<(), ThinningError<ObservedStreamError<DelayedStepError<Infallible>, Infallible, StatisticsError>>>(())
     /// ```
     ///
     /// # Errors

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -361,6 +361,51 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     pub fn into_chain(self) -> Chain<S> {
         self.chain
     }
+
+    /// Run the shared validate/step/modulo-gate loop for thinned methods.
+    fn run_thinning_core<E>(
+        &mut self,
+        steps: usize,
+        thin_interval: usize,
+        step_once: impl FnMut(&mut Self) -> Result<(), E>,
+        emit: impl FnMut(&Self) -> Result<(), E>,
+    ) -> ThinnedRunResult<(), E> {
+        let _ = thinned_capacity::<E>(steps, thin_interval)?;
+        self.run_thinning_loop(steps, thin_interval, step_once, emit)
+    }
+
+    /// Collect samples from the shared thinning loop into a [`SampleBuffer`].
+    fn collect_with_thinning_core<O, E>(
+        &mut self,
+        steps: usize,
+        thin_interval: usize,
+        step_once: impl FnMut(&mut Self) -> Result<(), E>,
+        mut emit: impl FnMut(&Self) -> Result<O, E>,
+    ) -> ThinnedRunResult<SampleBuffer<O>, E> {
+        let mut samples = SampleBuffer::with_capacity(thinned_capacity::<E>(steps, thin_interval)?);
+        self.run_thinning_loop(steps, thin_interval, step_once, |sampler| {
+            samples.push(emit(sampler)?);
+            Ok(())
+        })?;
+        Ok(samples)
+    }
+
+    /// Execute already-validated thinned stepping.
+    fn run_thinning_loop<E>(
+        &mut self,
+        steps: usize,
+        thin_interval: usize,
+        mut step_once: impl FnMut(&mut Self) -> Result<(), E>,
+        mut emit: impl FnMut(&Self) -> Result<(), E>,
+    ) -> ThinnedRunResult<(), E> {
+        for step in 1..=steps {
+            step_once(self).map_err(ThinningError::Run)?;
+            if step % thin_interval == 0 {
+                emit(self).map_err(ThinningError::Run)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 // --- By-value stepping ---
@@ -481,15 +526,9 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     where
         S: Clone,
     {
-        let mut samples =
-            SampleBuffer::with_capacity(thinned_capacity::<McmcError>(steps, thin_interval)?);
-        for step in 1..=steps {
-            self.step().map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
-                samples.push(self.chain.state().clone());
-            }
-        }
-        Ok(samples)
+        self.collect_with_thinning_core(steps, thin_interval, Self::step, |sampler| {
+            Ok(sampler.chain.state().clone())
+        })
     }
 
     /// Perform one by-value step and observe the resulting chain state.
@@ -618,15 +657,9 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
         thin_interval: usize,
         observable: &mut O,
     ) -> ThinnedRunResult<SampleBuffer<O::Output>, McmcError> {
-        let mut samples =
-            SampleBuffer::with_capacity(thinned_capacity::<McmcError>(steps, thin_interval)?);
-        for step in 1..=steps {
-            self.step().map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
-                samples.push(observable.observe(self.chain.state()));
-            }
-        }
-        Ok(samples)
+        self.collect_with_thinning_core(steps, thin_interval, Self::step, |sampler| {
+            Ok(observable.observe(sampler.chain.state()))
+        })
     }
 
     /// Run by-value steps and stream observations into an accumulator.
@@ -738,19 +771,16 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
         O: Observable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        validate_thin_interval(thin_interval)?;
-        for step in 1..=steps {
-            self.step()
-                .map_err(ObservedStreamError::Step)
-                .map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
+        self.run_thinning_core(
+            steps,
+            thin_interval,
+            |sampler| sampler.step().map_err(ObservedStreamError::Step),
+            |sampler| {
                 accumulator
-                    .try_push(observable.observe(self.chain.state()))
+                    .try_push(observable.observe(sampler.chain.state()))
                     .map_err(ObservedStreamError::Accumulation)
-                    .map_err(ThinningError::Run)?;
-            }
-        }
-        Ok(())
+            },
+        )
     }
 
     /// Perform one by-value step and fallibly observe the resulting state.
@@ -882,23 +912,16 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
         thin_interval: usize,
         observable: &mut O,
     ) -> TryThinnedObservedRunResult<O::Output, McmcError, O::Error> {
-        let mut samples = SampleBuffer::with_capacity(thinned_capacity::<
-            ObservedStepError<McmcError, O::Error>,
-        >(steps, thin_interval)?);
-        for step in 1..=steps {
-            self.step()
-                .map_err(ObservedStepError::Step)
-                .map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
-                samples.push(
-                    observable
-                        .try_observe(self.chain.state())
-                        .map_err(ObservedStepError::Observation)
-                        .map_err(ThinningError::Run)?,
-                );
-            }
-        }
-        Ok(samples)
+        self.collect_with_thinning_core(
+            steps,
+            thin_interval,
+            |sampler| sampler.step().map_err(ObservedStepError::Step),
+            |sampler| {
+                observable
+                    .try_observe(sampler.chain.state())
+                    .map_err(ObservedStepError::Observation)
+            },
+        )
     }
 
     /// Run by-value steps and stream fallible observations into an accumulator.
@@ -1002,23 +1025,19 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
         O: TryObservable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        validate_thin_interval(thin_interval)?;
-        for step in 1..=steps {
-            self.step()
-                .map_err(ObservedStreamError::Step)
-                .map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
+        self.run_thinning_core(
+            steps,
+            thin_interval,
+            |sampler| sampler.step().map_err(ObservedStreamError::Step),
+            |sampler| {
                 let sample = observable
-                    .try_observe(self.chain.state())
-                    .map_err(ObservedStreamError::Observation)
-                    .map_err(ThinningError::Run)?;
+                    .try_observe(sampler.chain.state())
+                    .map_err(ObservedStreamError::Observation)?;
                 accumulator
                     .try_push(sample)
                     .map_err(ObservedStreamError::Accumulation)
-                    .map_err(ThinningError::Run)?;
-            }
-        }
-        Ok(())
+            },
+        )
     }
 }
 
@@ -2834,6 +2853,21 @@ mod tests {
     }
 
     #[test]
+    fn run_with_thinning_reports_step_error_without_collecting() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
+
+        let result = sampler.run_with_thinning(5, 2);
+
+        assert!(matches!(
+            result,
+            Err(ThinningError::Run(McmcError::NanLogQRatio))
+        ));
+        assert_eq!(sampler.chain_ref().total_steps(), 0);
+    }
+
+    #[test]
     fn run_observing_collects() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
@@ -2982,6 +3016,31 @@ mod tests {
             result,
             Err(ThinningError::InvalidInterval { thin_interval: 0 })
         ));
+        assert_eq!(stats.count(), 0);
+        assert_eq!(sampler.chain_ref().total_steps(), 0);
+    }
+
+    #[test]
+    fn run_observing_into_with_thinning_reports_step_error_without_accumulating() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
+        let mut observed = false;
+        let mut coordinate = |state: &Scalar| {
+            observed = true;
+            state.0
+        };
+        let mut stats = OnlineStats::new();
+
+        let result = sampler.run_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats);
+
+        assert!(matches!(
+            result,
+            Err(ThinningError::Run(ObservedStreamError::Step(
+                McmcError::NanLogQRatio
+            )))
+        ));
+        assert!(!observed);
         assert_eq!(stats.count(), 0);
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,4 +1,18 @@
-//! Testing and validation helpers.
+//! Test-facing diagnostics for proposal validation.
+//!
+//! This module provides empirical detailed-balance checks for proposal
+//! implementations over discrete or otherwise exactly comparable endpoint
+//! states.  The helpers are designed for tests, examples, and proposal
+//! development: they repeatedly sample a representative transition in both
+//! directions, estimate the Metropolis-Hastings transition flow, and return a
+//! [`DetailedBalanceReport`] or typed [`DetailedBalanceError`].
+//!
+//! Use [`verify_detailed_balance`] for by-value [`Proposal`] implementations,
+//! [`verify_detailed_balance_mut`] for rollback-based [`ProposalMut`]
+//! implementations, and [`verify_detailed_balance_delayed`] for
+//! [`DelayedProposal`] plans.  Batch helpers return
+//! [`DetailedBalanceBatchReport`] so callers can inspect every failed
+//! transition instead of stopping at the first violation.
 
 use core::convert::Infallible;
 use std::error::Error;
@@ -93,6 +107,8 @@ pub struct DetailedBalanceReport {
 impl DetailedBalanceReport {
     /// Return true when the absolute residual is within `tolerance`.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use markov_chain_monte_carlo::DetailedBalanceReport;
     ///
@@ -120,6 +136,8 @@ impl DetailedBalanceReport {
     }
 
     /// Approximate normal z-score for the observed log residual.
+    ///
+    /// # Examples
     ///
     /// ```
     /// use markov_chain_monte_carlo::DetailedBalanceReport;
@@ -340,6 +358,8 @@ pub struct DetailedBalanceBatchReport<E = Infallible> {
 impl<E> DetailedBalanceBatchReport<E> {
     /// Return true when every transition passed.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use markov_chain_monte_carlo::DetailedBalanceBatchReport;
     ///
@@ -379,6 +399,8 @@ pub struct DetailedBalanceDelayedTransition<'a, S, Plan> {
 /// discrete, quantized, or otherwise exactly comparable state spaces.  For
 /// continuous proposals, exact hits are usually too rare; use a coarsened state
 /// representation or a domain-specific diagnostic instead.
+///
+/// # Examples
 ///
 /// ```
 /// use markov_chain_monte_carlo::prelude::testing::*;
@@ -443,6 +465,8 @@ where
 ///
 /// This is useful for checking a small grid, graph edge list, or representative
 /// set of local moves without stopping on the first failed transition.
+///
+/// # Examples
 ///
 /// ```
 /// use markov_chain_monte_carlo::prelude::testing::*;
@@ -522,6 +546,8 @@ where
 /// probability by combining exact endpoint hits with each hit's undo-token-based
 /// log q-ratio.
 ///
+/// # Examples
+///
 /// ```
 /// use markov_chain_monte_carlo::prelude::testing::*;
 /// use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -589,6 +615,8 @@ where
 }
 
 /// Verify many in-place transitions and return every transition violation.
+///
+/// # Examples
 ///
 /// ```
 /// use markov_chain_monte_carlo::prelude::testing::*;
@@ -686,6 +714,8 @@ where
 /// direction, or the estimated detailed-balance residual exceeds the configured
 /// tolerance.
 ///
+/// # Examples
+///
 /// ```
 /// use core::convert::Infallible;
 /// use markov_chain_monte_carlo::prelude::testing::*;
@@ -782,6 +812,8 @@ where
 ///
 /// Each [`DetailedBalanceDelayedTransition`] supplies endpoint states and the
 /// forward/reverse plan predicates for that concrete transition.
+///
+/// # Examples
 ///
 /// ```
 /// use core::convert::Infallible;
@@ -1417,6 +1449,7 @@ const fn usize_to_f64(value: usize) -> f64 {
 #[cfg(test)]
 mod tests {
     use core::convert::Infallible;
+    use std::error::Error as _;
 
     use rand::{Rng, SeedableRng, rngs::StdRng};
 
@@ -1436,6 +1469,20 @@ mod tests {
         }
     }
 
+    struct OneImpossibleEndpoint;
+    impl Target<bool> for OneImpossibleEndpoint {
+        fn log_prob(&self, state: &bool) -> f64 {
+            if *state { f64::NEG_INFINITY } else { 0.0 }
+        }
+    }
+
+    struct NanOnTrue;
+    impl Target<bool> for NanOnTrue {
+        fn log_prob(&self, state: &bool) -> f64 {
+            if *state { f64::NAN } else { 0.0 }
+        }
+    }
+
     struct Flip;
     impl Proposal<bool> for Flip {
         fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
@@ -1451,6 +1498,17 @@ mod tests {
 
         fn log_q_ratio(&self, _: &bool, _: &bool) -> f64 {
             1.0
+        }
+    }
+
+    struct InfiniteLogQ;
+    impl Proposal<bool> for InfiniteLogQ {
+        fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
+            !current
+        }
+
+        fn log_q_ratio(&self, _: &bool, _: &bool) -> f64 {
+            f64::INFINITY
         }
     }
 
@@ -1492,6 +1550,38 @@ mod tests {
 
         fn log_q_ratio(&self, _: &bool, _: &bool) -> f64 {
             1.0
+        }
+    }
+
+    struct InfiniteLogQMut;
+    impl ProposalMut<bool> for InfiniteLogQMut {
+        type Undo = bool;
+
+        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+            let old = *state;
+            *state = !*state;
+            Some(old)
+        }
+
+        fn undo(&self, state: &mut bool, token: bool) {
+            *state = token;
+        }
+
+        fn log_q_ratio(&self, _: &bool, _: &bool) -> f64 {
+            f64::INFINITY
+        }
+    }
+
+    struct NoMoveMut;
+    impl ProposalMut<bool> for NoMoveMut {
+        type Undo = bool;
+
+        fn propose_mut<R: Rng + ?Sized>(&self, _: &mut bool, _: &mut R) -> Option<bool> {
+            None
+        }
+
+        fn undo(&self, state: &mut bool, token: bool) {
+            *state = token;
         }
     }
 
@@ -1609,6 +1699,86 @@ mod tests {
         }
     }
 
+    struct InfiniteLogQDelayed;
+    impl DelayedProposal<bool> for InfiniteLogQDelayed {
+        type Plan = bool;
+        type Info = bool;
+        type Error = Infallible;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            state: &bool,
+            _: &mut R,
+        ) -> Result<Option<bool>, Infallible> {
+            Ok(Some(!*state))
+        }
+
+        fn proposed_log_prob<T: Target<bool>>(
+            &self,
+            _: &bool,
+            plan: &bool,
+            target: &T,
+        ) -> Result<f64, Infallible> {
+            Ok(target.log_prob(plan))
+        }
+
+        fn log_q_ratio(&self, _: &bool, _: &bool) -> Result<f64, Infallible> {
+            Ok(f64::INFINITY)
+        }
+
+        fn info(&self, plan: &bool) -> bool {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut bool,
+            plan: bool,
+            _: &mut R,
+        ) -> Result<(), Infallible> {
+            *state = plan;
+            Ok(())
+        }
+    }
+
+    struct NoPlanDelayed;
+    impl DelayedProposal<bool> for NoPlanDelayed {
+        type Plan = bool;
+        type Info = bool;
+        type Error = Infallible;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            _: &bool,
+            _: &mut R,
+        ) -> Result<Option<bool>, Infallible> {
+            Ok(None)
+        }
+
+        fn proposed_log_prob<T: Target<bool>>(
+            &self,
+            _: &bool,
+            plan: &bool,
+            target: &T,
+        ) -> Result<f64, Infallible> {
+            Ok(target.log_prob(plan))
+        }
+
+        fn info(&self, plan: &bool) -> bool {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut bool,
+            plan: bool,
+            _: &mut R,
+        ) -> Result<(), Infallible> {
+            *state = plan;
+            Ok(())
+        }
+    }
+
     struct ReverseFailingDelayed {
         failure: DelayedFailure,
     }
@@ -1675,6 +1845,152 @@ mod tests {
         }
     }
 
+    /// Build a minimal report with a configurable standard error for helper API tests.
+    fn report_with_standard_error(log_balance_standard_error: f64) -> DetailedBalanceReport {
+        DetailedBalanceReport {
+            samples: 128,
+            forward_hits: 64,
+            reverse_hits: 64,
+            forward_log_proposal: 0.0,
+            reverse_log_proposal: 0.0,
+            forward_log_transition: 0.0,
+            reverse_log_transition: 0.0,
+            log_balance_residual: 0.0,
+            log_balance_standard_error,
+        }
+    }
+
+    #[test]
+    fn default_config_and_report_helpers_cover_public_contract() {
+        let config = DetailedBalanceConfig::default();
+        assert_eq!(config.samples, 10_000);
+        assert_eq!(config.tolerance.to_bits(), 0.1_f64.to_bits());
+        assert_eq!(config.min_hits, 30);
+
+        let report = report_with_standard_error(0.0);
+        assert!(report.is_within_tolerance(0.0));
+        assert_eq!(report.z_score(), None);
+
+        let batch = DetailedBalanceBatchReport::<Infallible> {
+            reports: vec![report],
+            failures: Vec::new(),
+        };
+        assert!(batch.is_success());
+    }
+
+    #[test]
+    fn report_rejects_invalid_tolerances() {
+        let report = report_with_standard_error(1.0);
+
+        assert!(!report.is_within_tolerance(f64::NAN));
+        assert!(!report.is_within_tolerance(-1.0));
+        assert!(!report.is_within_tolerance(f64::INFINITY));
+    }
+
+    #[test]
+    fn display_and_source_explain_detailed_balance_errors() {
+        let report = report_with_standard_error(1.0);
+        assert_eq!(DetailedBalanceDirection::Forward.to_string(), "forward");
+        assert_eq!(DetailedBalanceDirection::Reverse.to_string(), "reverse");
+        assert_eq!(DetailedBalanceState::Current.to_string(), "current");
+        assert_eq!(DetailedBalanceState::Proposed.to_string(), "proposed");
+        assert_eq!(
+            DetailedBalanceError::<DelayedFailure>::InvalidSamples { samples: 0 }.to_string(),
+            "invalid sample count 0: expected at least 1"
+        );
+        assert_eq!(
+            DetailedBalanceError::<DelayedFailure>::InvalidTolerance {
+                tolerance: f64::NAN
+            }
+            .to_string(),
+            "invalid detailed-balance tolerance NaN: expected a finite nonnegative value"
+        );
+        assert_eq!(
+            DetailedBalanceError::<DelayedFailure>::InvalidMinHits {
+                min_hits: 2,
+                samples: 1,
+            }
+            .to_string(),
+            "invalid minimum hit count 2: expected 1..=1"
+        );
+        assert_eq!(
+            DetailedBalanceError::<DelayedFailure>::InvalidTargetLogProb {
+                state: DetailedBalanceState::Current,
+                log_prob: f64::NAN,
+            }
+            .to_string(),
+            "current target log-probability is NaN: expected finite or -infinity"
+        );
+        assert_eq!(
+            DetailedBalanceError::<DelayedFailure>::InvalidLogQRatio {
+                direction: DetailedBalanceDirection::Forward,
+                log_q_ratio: f64::INFINITY,
+            }
+            .to_string(),
+            "forward proposal log q-ratio is inf: expected finite or -infinity"
+        );
+        assert_eq!(
+            DetailedBalanceError::<DelayedFailure>::InvalidLogAcceptanceRatio {
+                direction: DetailedBalanceDirection::Reverse,
+                log_acceptance_ratio: f64::NAN,
+            }
+            .to_string(),
+            "reverse log acceptance ratio is NaN: expected a non-NaN value"
+        );
+        assert_eq!(
+            DetailedBalanceError::InsufficientHits::<DelayedFailure> {
+                direction: DetailedBalanceDirection::Forward,
+                hits: 0,
+                min_hits: 1,
+            }
+            .to_string(),
+            "insufficient forward proposal hits: observed 0, expected at least 1"
+        );
+        assert_eq!(
+            DetailedBalanceError::Violation::<DelayedFailure> {
+                residual: 2.0,
+                tolerance: 1.0,
+                report,
+            }
+            .to_string(),
+            "detailed-balance residual 2 exceeds tolerance 1"
+        );
+
+        let plan_error = DetailedBalanceError::Plan {
+            direction: DetailedBalanceDirection::Forward,
+            source: DelayedFailure::Plan,
+        };
+        assert_eq!(
+            plan_error.to_string(),
+            "forward delayed proposal planning failed: plan failed"
+        );
+        assert_eq!(
+            plan_error.source().map(ToString::to_string),
+            Some(String::from("plan failed"))
+        );
+        assert_eq!(
+            DetailedBalanceError::ProposedLogProb {
+                direction: DetailedBalanceDirection::Forward,
+                source: DelayedFailure::ProposedLogProb,
+            }
+            .to_string(),
+            "forward delayed proposal log-probability evaluation failed: proposed log-probability failed"
+        );
+        assert_eq!(
+            DetailedBalanceError::LogQRatio {
+                direction: DetailedBalanceDirection::Forward,
+                source: DelayedFailure::LogQRatio,
+            }
+            .to_string(),
+            "forward delayed proposal ratio evaluation failed: log q-ratio failed"
+        );
+        assert!(
+            DetailedBalanceError::<DelayedFailure>::InvalidSamples { samples: 0 }
+                .source()
+                .is_none()
+        );
+    }
+
     #[test]
     fn verifies_symmetric_two_state_transition() {
         let mut rng = StdRng::seed_from_u64(42);
@@ -1691,7 +2007,11 @@ mod tests {
         assert_eq!(report.forward_hits, 128);
         assert_eq!(report.reverse_hits, 128);
         assert!(report.is_within_tolerance(1e-12));
-        assert!(report.z_score().is_some_and(|score| score.abs() < 1e-6));
+        if let Some(score) = report.z_score() {
+            assert!(score.abs() < 1e-6);
+        } else {
+            panic!("z_score returned None (standard error == 0.0) for report: {report:?}");
+        }
     }
 
     #[test]
@@ -1857,6 +2177,151 @@ mod tests {
     }
 
     #[test]
+    fn rejects_invalid_target_log_probabilities() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let err =
+            verify_detailed_balance(&true, &false, &NanOnTrue, &Flip, &mut rng, small_config())
+                .unwrap_err();
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidTargetLogProb {
+                state: DetailedBalanceState::Current,
+                log_prob,
+            } if log_prob.is_nan()
+        ));
+
+        let err =
+            verify_detailed_balance(&false, &true, &NanOnTrue, &Flip, &mut rng, small_config())
+                .unwrap_err();
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidTargetLogProb {
+                state: DetailedBalanceState::Proposed,
+                log_prob,
+            } if log_prob.is_nan()
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_proposal_log_ratios() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let err = verify_detailed_balance(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &InfiniteLogQ,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidLogQRatio {
+                direction: DetailedBalanceDirection::Forward,
+                log_q_ratio,
+            } if log_q_ratio.is_infinite() && log_q_ratio.is_sign_positive()
+        ));
+
+        let err = verify_detailed_balance_mut(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &InfiniteLogQMut,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidLogQRatio {
+                direction: DetailedBalanceDirection::Forward,
+                log_q_ratio,
+            } if log_q_ratio.is_infinite() && log_q_ratio.is_sign_positive()
+        ));
+
+        let mut proposal = InfiniteLogQDelayed;
+        let err = verify_detailed_balance_delayed(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+            (|plan| *plan, |plan| !*plan),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidLogQRatio {
+                direction: DetailedBalanceDirection::Forward,
+                log_q_ratio,
+            } if log_q_ratio.is_infinite() && log_q_ratio.is_sign_positive()
+        ));
+    }
+
+    #[test]
+    fn accepts_balanced_zero_flow_with_infinite_uncertainty() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let report = verify_detailed_balance(
+            &false,
+            &true,
+            &OneImpossibleEndpoint,
+            &Flip,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap();
+
+        assert_eq!(report.forward_hits, 128);
+        assert_eq!(report.reverse_hits, 128);
+        assert!(report.log_balance_residual.abs() < f64::EPSILON);
+        assert!(report.log_balance_standard_error.is_infinite());
+        assert_eq!(report.z_score(), None);
+    }
+
+    #[test]
+    fn none_proposals_report_insufficient_hits() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let err = verify_detailed_balance_mut(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &NoMoveMut,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InsufficientHits {
+                direction: DetailedBalanceDirection::Forward,
+                hits: 0,
+                min_hits: 1,
+            }
+        ));
+
+        let mut proposal = NoPlanDelayed;
+        let err = verify_detailed_balance_delayed(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+            (|plan| *plan, |plan| !*plan),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InsufficientHits {
+                direction: DetailedBalanceDirection::Forward,
+                hits: 0,
+                min_hits: 1,
+            }
+        ));
+    }
+
+    #[test]
     fn delayed_reports_reverse_plan_errors() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = ReverseFailingDelayed {
@@ -1999,6 +2464,26 @@ mod tests {
     }
 
     #[test]
+    fn mutable_batch_reports_all_failures() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let pairs = [(false, true), (true, false)];
+        let batch = verify_detailed_balance_mut_many(
+            pairs.iter().map(|(current, proposed)| (current, proposed)),
+            &TwoStateTarget,
+            &BadLogQMut,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap();
+
+        assert!(!batch.is_success());
+        assert_eq!(batch.reports.len(), 0);
+        assert_eq!(batch.failures.len(), 2);
+        assert_eq!(batch.failures[0].index, 0);
+        assert_eq!(batch.failures[1].index, 1);
+    }
+
+    #[test]
     fn delayed_batch_reports_successes() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedFlip;
@@ -2022,6 +2507,42 @@ mod tests {
 
         assert!(batch.is_success());
         assert_eq!(batch.reports.len(), 1);
+    }
+
+    #[test]
+    fn delayed_batch_reports_failures() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = FailingDelayed {
+            failure: DelayedFailure::Plan,
+        };
+        let forward = |plan: &bool| *plan;
+        let reverse = |plan: &bool| !*plan;
+        let transitions = [DetailedBalanceDelayedTransition {
+            current: &false,
+            proposed: &true,
+            forward_plan_matches: &forward,
+            reverse_plan_matches: &reverse,
+        }];
+        let batch = verify_detailed_balance_delayed_many(
+            transitions,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap();
+
+        assert!(!batch.is_success());
+        assert_eq!(batch.reports.len(), 0);
+        assert_eq!(batch.failures.len(), 1);
+        assert_eq!(batch.failures[0].index, 0);
+        assert!(matches!(
+            batch.failures[0].error,
+            DetailedBalanceError::Plan {
+                direction: DetailedBalanceDirection::Forward,
+                source: DelayedFailure::Plan,
+            }
+        ));
     }
 
     #[test]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,2131 @@
+//! Testing and validation helpers.
+
+use core::convert::Infallible;
+use std::error::Error;
+use std::fmt;
+
+use rand::Rng;
+
+use crate::{DelayedProposal, Proposal, ProposalMut, Target};
+
+/// Configuration for empirical detailed-balance verification.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[must_use]
+pub struct DetailedBalanceConfig {
+    /// Number of proposal samples drawn in each direction.
+    pub samples: usize,
+    /// Absolute tolerance for the log detailed-balance residual.
+    pub tolerance: f64,
+    /// Minimum hit count required in each direction.
+    pub min_hits: usize,
+}
+
+impl Default for DetailedBalanceConfig {
+    fn default() -> Self {
+        Self {
+            samples: 10_000,
+            tolerance: 0.1,
+            min_hits: 30,
+        }
+    }
+}
+
+/// Direction of an empirical detailed-balance check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetailedBalanceDirection {
+    /// The transition from the current state to the proposed state.
+    Forward,
+    /// The transition from the proposed state back to the current state.
+    Reverse,
+}
+
+impl fmt::Display for DetailedBalanceDirection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Forward => write!(f, "forward"),
+            Self::Reverse => write!(f, "reverse"),
+        }
+    }
+}
+
+/// State role in an empirical detailed-balance check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetailedBalanceState {
+    /// The current state supplied to the check.
+    Current,
+    /// The proposed state supplied to the check.
+    Proposed,
+}
+
+impl fmt::Display for DetailedBalanceState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Current => write!(f, "current"),
+            Self::Proposed => write!(f, "proposed"),
+        }
+    }
+}
+
+/// Empirical detailed-balance verification report.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[must_use]
+pub struct DetailedBalanceReport {
+    /// Number of proposal samples drawn in each direction.
+    pub samples: usize,
+    /// Number of times the forward transition was proposed.
+    pub forward_hits: usize,
+    /// Number of times the reverse transition was proposed.
+    pub reverse_hits: usize,
+    /// Estimated `log(q(proposed | current))`.
+    pub forward_log_proposal: f64,
+    /// Estimated `log(q(current | proposed))`.
+    pub reverse_log_proposal: f64,
+    /// Estimated log transition probability after MH acceptance, forward.
+    pub forward_log_transition: f64,
+    /// Estimated log transition probability after MH acceptance, reverse.
+    pub reverse_log_transition: f64,
+    /// Estimated `log(forward flow) - log(reverse flow)`.
+    pub log_balance_residual: f64,
+    /// Approximate standard error of `log_balance_residual`.
+    pub log_balance_standard_error: f64,
+}
+
+impl DetailedBalanceReport {
+    /// Return true when the absolute residual is within `tolerance`.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DetailedBalanceReport;
+    ///
+    /// let report = DetailedBalanceReport {
+    ///     samples: 128,
+    ///     forward_hits: 128,
+    ///     reverse_hits: 128,
+    ///     forward_log_proposal: 0.0,
+    ///     reverse_log_proposal: 0.0,
+    ///     forward_log_transition: 0.0,
+    ///     reverse_log_transition: 0.0,
+    ///     log_balance_residual: 1e-3,
+    ///     log_balance_standard_error: 0.01,
+    /// };
+    ///
+    /// assert!(report.is_within_tolerance(0.01));
+    /// assert!(!report.is_within_tolerance(1e-4));
+    /// ```
+    #[must_use]
+    pub fn is_within_tolerance(&self, tolerance: f64) -> bool {
+        self.log_balance_residual.is_finite()
+            && tolerance.is_finite()
+            && tolerance >= 0.0
+            && self.log_balance_residual.abs() <= tolerance
+    }
+
+    /// Approximate normal z-score for the observed log residual.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DetailedBalanceReport;
+    ///
+    /// let report = DetailedBalanceReport {
+    ///     samples: 128,
+    ///     forward_hits: 128,
+    ///     reverse_hits: 128,
+    ///     forward_log_proposal: 0.0,
+    ///     reverse_log_proposal: 0.0,
+    ///     forward_log_transition: 0.0,
+    ///     reverse_log_transition: 0.0,
+    ///     log_balance_residual: 0.02,
+    ///     log_balance_standard_error: 0.01,
+    /// };
+    ///
+    /// assert_eq!(report.z_score(), Some(2.0));
+    /// ```
+    #[must_use]
+    pub fn z_score(&self) -> Option<f64> {
+        if self.log_balance_standard_error.is_finite() && self.log_balance_standard_error > 0.0 {
+            Some(self.log_balance_residual / self.log_balance_standard_error)
+        } else {
+            None
+        }
+    }
+}
+
+/// Error returned by empirical detailed-balance verification.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub enum DetailedBalanceError<E = Infallible> {
+    /// `samples` must be greater than zero.
+    InvalidSamples {
+        /// Invalid sample count.
+        samples: usize,
+    },
+    /// `tolerance` must be finite and nonnegative.
+    InvalidTolerance {
+        /// Invalid tolerance.
+        tolerance: f64,
+    },
+    /// `min_hits` must be greater than zero and no larger than `samples`.
+    InvalidMinHits {
+        /// Invalid minimum hit count.
+        min_hits: usize,
+        /// Number of proposal samples drawn in each direction.
+        samples: usize,
+    },
+    /// Target log-probability was `NaN` or positive infinity for one endpoint.
+    InvalidTargetLogProb {
+        /// Endpoint whose log-probability was invalid.
+        state: DetailedBalanceState,
+        /// Observed target log-probability.
+        log_prob: f64,
+    },
+    /// Proposal log q-ratio was `NaN` or positive infinity for one direction.
+    InvalidLogQRatio {
+        /// Direction whose log q-ratio was invalid.
+        direction: DetailedBalanceDirection,
+        /// Observed log q-ratio.
+        log_q_ratio: f64,
+    },
+    /// Metropolis-Hastings log acceptance ratio was `NaN`.
+    InvalidLogAcceptanceRatio {
+        /// Direction whose log acceptance ratio was invalid.
+        direction: DetailedBalanceDirection,
+        /// Observed log acceptance ratio.
+        log_acceptance_ratio: f64,
+    },
+    /// Delayed proposal planning failed.
+    Plan {
+        /// Direction whose planning failed.
+        direction: DetailedBalanceDirection,
+        /// Underlying proposal error.
+        source: E,
+    },
+    /// Delayed proposal log-probability evaluation failed.
+    ProposedLogProb {
+        /// Direction whose proposed log-probability evaluation failed.
+        direction: DetailedBalanceDirection,
+        /// Underlying proposal error.
+        source: E,
+    },
+    /// Delayed proposal log q-ratio evaluation failed.
+    LogQRatio {
+        /// Direction whose proposal ratio evaluation failed.
+        direction: DetailedBalanceDirection,
+        /// Underlying proposal error.
+        source: E,
+    },
+    /// Too few exact proposal hits were observed in one direction.
+    InsufficientHits {
+        /// Direction with too few hits.
+        direction: DetailedBalanceDirection,
+        /// Observed hit count.
+        hits: usize,
+        /// Required hit count.
+        min_hits: usize,
+    },
+    /// Estimated detailed-balance residual exceeded the configured tolerance.
+    Violation {
+        /// Estimated `log(forward flow) - log(reverse flow)`.
+        residual: f64,
+        /// Configured absolute tolerance.
+        tolerance: f64,
+        /// Detailed empirical report.
+        report: DetailedBalanceReport,
+    },
+}
+
+impl<E: fmt::Display> fmt::Display for DetailedBalanceError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSamples { samples } => {
+                write!(f, "invalid sample count {samples}: expected at least 1")
+            }
+            Self::InvalidTolerance { tolerance } => write!(
+                f,
+                "invalid detailed-balance tolerance {tolerance}: expected a finite nonnegative value"
+            ),
+            Self::InvalidMinHits { min_hits, samples } => write!(
+                f,
+                "invalid minimum hit count {min_hits}: expected 1..={samples}"
+            ),
+            Self::InvalidTargetLogProb { state, log_prob } => write!(
+                f,
+                "{state} target log-probability is {log_prob}: expected finite or -infinity"
+            ),
+            Self::InvalidLogQRatio {
+                direction,
+                log_q_ratio,
+            } => write!(
+                f,
+                "{direction} proposal log q-ratio is {log_q_ratio}: expected finite or -infinity"
+            ),
+            Self::InvalidLogAcceptanceRatio {
+                direction,
+                log_acceptance_ratio,
+            } => write!(
+                f,
+                "{direction} log acceptance ratio is {log_acceptance_ratio}: expected a non-NaN value"
+            ),
+            Self::Plan { direction, source } => {
+                write!(f, "{direction} delayed proposal planning failed: {source}")
+            }
+            Self::ProposedLogProb { direction, source } => write!(
+                f,
+                "{direction} delayed proposal log-probability evaluation failed: {source}"
+            ),
+            Self::LogQRatio { direction, source } => {
+                write!(
+                    f,
+                    "{direction} delayed proposal ratio evaluation failed: {source}"
+                )
+            }
+            Self::InsufficientHits {
+                direction,
+                hits,
+                min_hits,
+            } => write!(
+                f,
+                "insufficient {direction} proposal hits: observed {hits}, expected at least {min_hits}"
+            ),
+            Self::Violation {
+                residual,
+                tolerance,
+                ..
+            } => write!(
+                f,
+                "detailed-balance residual {residual} exceeds tolerance {tolerance}"
+            ),
+        }
+    }
+}
+
+impl<E> Error for DetailedBalanceError<E>
+where
+    E: Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Plan { source, .. }
+            | Self::ProposedLogProb { source, .. }
+            | Self::LogQRatio { source, .. } => Some(source),
+            Self::InvalidSamples { .. }
+            | Self::InvalidTolerance { .. }
+            | Self::InvalidMinHits { .. }
+            | Self::InvalidTargetLogProb { .. }
+            | Self::InvalidLogQRatio { .. }
+            | Self::InvalidLogAcceptanceRatio { .. }
+            | Self::InsufficientHits { .. }
+            | Self::Violation { .. } => None,
+        }
+    }
+}
+
+/// One failed detailed-balance check in a batch.
+#[derive(Debug, Clone, PartialEq)]
+#[must_use]
+pub struct DetailedBalanceFailure<E = Infallible> {
+    /// Zero-based index of the checked transition.
+    pub index: usize,
+    /// Error reported for this transition.
+    pub error: DetailedBalanceError<E>,
+}
+
+/// Batch detailed-balance report that preserves every failure.
+#[derive(Debug, Clone, PartialEq)]
+#[must_use]
+pub struct DetailedBalanceBatchReport<E = Infallible> {
+    /// Successful transition reports.
+    pub reports: Vec<DetailedBalanceReport>,
+    /// Failed transition checks, including all violations.
+    pub failures: Vec<DetailedBalanceFailure<E>>,
+}
+
+impl<E> DetailedBalanceBatchReport<E> {
+    /// Return true when every transition passed.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DetailedBalanceBatchReport;
+    ///
+    /// let batch: DetailedBalanceBatchReport = DetailedBalanceBatchReport {
+    ///     reports: Vec::new(),
+    ///     failures: Vec::new(),
+    /// };
+    ///
+    /// assert!(batch.is_success());
+    /// ```
+    #[must_use]
+    pub const fn is_success(&self) -> bool {
+        self.failures.is_empty()
+    }
+}
+
+/// One delayed-commit transition to check in a batch.
+#[must_use]
+pub struct DetailedBalanceDelayedTransition<'a, S, Plan> {
+    /// Current endpoint for the transition.
+    pub current: &'a S,
+    /// Proposed endpoint for the transition.
+    pub proposed: &'a S,
+    /// Predicate identifying sampled forward plans from `current` to `proposed`.
+    pub forward_plan_matches: &'a dyn Fn(&Plan) -> bool,
+    /// Predicate identifying sampled reverse plans from `proposed` to `current`.
+    pub reverse_plan_matches: &'a dyn Fn(&Plan) -> bool,
+}
+
+/// Empirically verify detailed balance for one discrete by-value transition.
+///
+/// This helper samples `proposal` from `current` and `proposed`, estimates the
+/// off-diagonal Metropolis-Hastings transition probabilities in both directions,
+/// and checks that the log transition flows agree within `config.tolerance`.
+///
+/// Because it compares states with [`PartialEq`], this is intended for
+/// discrete, quantized, or otherwise exactly comparable state spaces.  For
+/// continuous proposals, exact hits are usually too rare; use a coarsened state
+/// representation or a domain-specific diagnostic instead.
+///
+/// ```
+/// use markov_chain_monte_carlo::prelude::testing::*;
+/// use rand::{Rng, SeedableRng, rngs::StdRng};
+///
+/// struct Flat;
+/// impl Target<bool> for Flat {
+///     fn log_prob(&self, _: &bool) -> f64 { 0.0 }
+/// }
+///
+/// struct Flip;
+/// impl Proposal<bool> for Flip {
+///     fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
+///         !current
+///     }
+/// }
+///
+/// let mut rng = StdRng::seed_from_u64(42);
+/// let report = verify_detailed_balance(
+///     &false,
+///     &true,
+///     &Flat,
+///     &Flip,
+///     &mut rng,
+///     DetailedBalanceConfig {
+///         samples: 128,
+///         tolerance: 1e-12,
+///         min_hits: 1,
+///     },
+/// )?;
+///
+/// assert_eq!(report.forward_hits, 128);
+/// assert!(report.is_within_tolerance(1e-12));
+/// # Ok::<(), DetailedBalanceError>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns [`DetailedBalanceError`] if the configuration is invalid, target
+/// log-probabilities or proposal ratios are `NaN`/`+infinity`, too few exact
+/// hits are observed in either direction, or the estimated detailed-balance
+/// residual exceeds the configured tolerance.
+pub fn verify_detailed_balance<S, T, P, R>(
+    current: &S,
+    proposed: &S,
+    target: &T,
+    proposal: &P,
+    rng: &mut R,
+    config: DetailedBalanceConfig,
+) -> Result<DetailedBalanceReport, DetailedBalanceError>
+where
+    S: PartialEq,
+    T: Target<S>,
+    P: Proposal<S> + ?Sized,
+    R: Rng + ?Sized,
+{
+    validate_config(config)?;
+    verify_detailed_balance_unchecked(current, proposed, target, proposal, rng, config)
+}
+
+/// Verify many by-value transitions and return every transition violation.
+///
+/// This is useful for checking a small grid, graph edge list, or representative
+/// set of local moves without stopping on the first failed transition.
+///
+/// ```
+/// use markov_chain_monte_carlo::prelude::testing::*;
+/// use rand::{Rng, SeedableRng, rngs::StdRng};
+///
+/// struct Flat;
+/// impl Target<bool> for Flat {
+///     fn log_prob(&self, _: &bool) -> f64 { 0.0 }
+/// }
+///
+/// struct Flip;
+/// impl Proposal<bool> for Flip {
+///     fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
+///         !current
+///     }
+/// }
+///
+/// let pairs = [(false, true), (true, false)];
+/// let mut rng = StdRng::seed_from_u64(42);
+/// let batch = verify_detailed_balance_many(
+///     pairs.iter().map(|(current, proposed)| (current, proposed)),
+///     &Flat,
+///     &Flip,
+///     &mut rng,
+///     DetailedBalanceConfig {
+///         samples: 128,
+///         tolerance: 1e-12,
+///         min_hits: 1,
+///     },
+/// )?;
+///
+/// assert!(batch.is_success());
+/// assert_eq!(batch.reports.len(), 2);
+/// # Ok::<(), DetailedBalanceError>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns [`DetailedBalanceError`] if the configuration is invalid.  Per-transition
+/// failures are collected in [`DetailedBalanceBatchReport::failures`].
+pub fn verify_detailed_balance_many<'a, S, T, P, R, I>(
+    pairs: I,
+    target: &T,
+    proposal: &P,
+    rng: &mut R,
+    config: DetailedBalanceConfig,
+) -> Result<DetailedBalanceBatchReport, DetailedBalanceError>
+where
+    S: PartialEq + 'a,
+    T: Target<S>,
+    P: Proposal<S> + ?Sized,
+    R: Rng + ?Sized,
+    I: IntoIterator<Item = (&'a S, &'a S)>,
+{
+    let mut batch = DetailedBalanceBatchReport {
+        reports: Vec::new(),
+        failures: Vec::new(),
+    };
+
+    validate_config(config)?;
+
+    for (index, (current, proposed)) in pairs.into_iter().enumerate() {
+        match verify_detailed_balance_unchecked(current, proposed, target, proposal, rng, config) {
+            Ok(report) => batch.reports.push(report),
+            Err(error) => batch.failures.push(DetailedBalanceFailure { index, error }),
+        }
+    }
+
+    Ok(batch)
+}
+
+/// Empirically verify detailed balance for one in-place transition.
+///
+/// This helper clones each endpoint before calling [`ProposalMut::propose_mut`],
+/// so it is intended for test code and representative transitions rather than
+/// production sampling.  It estimates the full Metropolis-Hastings transition
+/// probability by combining exact endpoint hits with each hit's undo-token-based
+/// log q-ratio.
+///
+/// ```
+/// use markov_chain_monte_carlo::prelude::testing::*;
+/// use rand::{Rng, SeedableRng, rngs::StdRng};
+///
+/// struct Flat;
+/// impl Target<bool> for Flat {
+///     fn log_prob(&self, _: &bool) -> f64 { 0.0 }
+/// }
+///
+/// struct Flip;
+/// impl ProposalMut<bool> for Flip {
+///     type Undo = bool;
+///
+///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+///         let old = *state;
+///         *state = !*state;
+///         Some(old)
+///     }
+///
+///     fn undo(&self, state: &mut bool, token: bool) {
+///         *state = token;
+///     }
+/// }
+///
+/// let mut rng = StdRng::seed_from_u64(42);
+/// let report = verify_detailed_balance_mut(
+///     &false,
+///     &true,
+///     &Flat,
+///     &Flip,
+///     &mut rng,
+///     DetailedBalanceConfig {
+///         samples: 128,
+///         tolerance: 1e-12,
+///         min_hits: 1,
+///     },
+/// )?;
+///
+/// assert!(report.is_within_tolerance(1e-12));
+/// # Ok::<(), DetailedBalanceError>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns [`DetailedBalanceError`] if the configuration is invalid, target
+/// log-probabilities or proposal ratios are `NaN`/`+infinity`, too few exact
+/// hits are observed in either direction, or the estimated detailed-balance
+/// residual exceeds the configured tolerance.
+pub fn verify_detailed_balance_mut<S, T, P, R>(
+    current: &S,
+    proposed: &S,
+    target: &T,
+    proposal: &P,
+    rng: &mut R,
+    config: DetailedBalanceConfig,
+) -> Result<DetailedBalanceReport, DetailedBalanceError>
+where
+    S: Clone + PartialEq,
+    T: Target<S>,
+    P: ProposalMut<S> + ?Sized,
+    R: Rng + ?Sized,
+{
+    validate_config(config)?;
+    verify_detailed_balance_mut_unchecked(current, proposed, target, proposal, rng, config)
+}
+
+/// Verify many in-place transitions and return every transition violation.
+///
+/// ```
+/// use markov_chain_monte_carlo::prelude::testing::*;
+/// use rand::{Rng, SeedableRng, rngs::StdRng};
+///
+/// struct Flat;
+/// impl Target<bool> for Flat {
+///     fn log_prob(&self, _: &bool) -> f64 { 0.0 }
+/// }
+///
+/// struct Flip;
+/// impl ProposalMut<bool> for Flip {
+///     type Undo = bool;
+///
+///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+///         let old = *state;
+///         *state = !*state;
+///         Some(old)
+///     }
+///
+///     fn undo(&self, state: &mut bool, token: bool) {
+///         *state = token;
+///     }
+/// }
+///
+/// let pairs = [(false, true), (true, false)];
+/// let mut rng = StdRng::seed_from_u64(42);
+/// let batch = verify_detailed_balance_mut_many(
+///     pairs.iter().map(|(current, proposed)| (current, proposed)),
+///     &Flat,
+///     &Flip,
+///     &mut rng,
+///     DetailedBalanceConfig {
+///         samples: 128,
+///         tolerance: 1e-12,
+///         min_hits: 1,
+///     },
+/// )?;
+///
+/// assert!(batch.is_success());
+/// assert_eq!(batch.reports.len(), 2);
+/// # Ok::<(), DetailedBalanceError>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns [`DetailedBalanceError`] if the configuration is invalid.  Per-transition
+/// failures are collected in [`DetailedBalanceBatchReport::failures`].
+pub fn verify_detailed_balance_mut_many<'a, S, T, P, R, I>(
+    pairs: I,
+    target: &T,
+    proposal: &P,
+    rng: &mut R,
+    config: DetailedBalanceConfig,
+) -> Result<DetailedBalanceBatchReport, DetailedBalanceError>
+where
+    S: Clone + PartialEq + 'a,
+    T: Target<S>,
+    P: ProposalMut<S> + ?Sized,
+    R: Rng + ?Sized,
+    I: IntoIterator<Item = (&'a S, &'a S)>,
+{
+    let mut batch = DetailedBalanceBatchReport {
+        reports: Vec::new(),
+        failures: Vec::new(),
+    };
+
+    validate_config(config)?;
+
+    for (index, (current, proposed)) in pairs.into_iter().enumerate() {
+        match verify_detailed_balance_mut_unchecked(
+            current, proposed, target, proposal, rng, config,
+        ) {
+            Ok(report) => batch.reports.push(report),
+            Err(error) => batch.failures.push(DetailedBalanceFailure { index, error }),
+        }
+    }
+
+    Ok(batch)
+}
+
+/// Empirically verify detailed balance for one delayed-commit transition.
+///
+/// `plan_matches.0` identifies sampled forward plans from `current` to
+/// `proposed`; `plan_matches.1` identifies sampled reverse plans from
+/// `proposed` to `current`.  This keeps the delayed helper plan-based, matching
+/// the [`DelayedProposal`] contract where plans are the concrete transition
+/// descriptors used for scoring and proposal ratios.
+///
+/// # Errors
+///
+/// Returns [`DetailedBalanceError`] if the configuration is invalid, delayed
+/// proposal planning/scoring fails, target log-probabilities or proposal ratios
+/// are `NaN`/`+infinity`, too few matching plans are observed in either
+/// direction, or the estimated detailed-balance residual exceeds the configured
+/// tolerance.
+///
+/// ```
+/// use core::convert::Infallible;
+/// use markov_chain_monte_carlo::prelude::testing::*;
+/// use rand::{Rng, SeedableRng, rngs::StdRng};
+///
+/// struct Flat;
+/// impl Target<bool> for Flat {
+///     fn log_prob(&self, _: &bool) -> f64 { 0.0 }
+/// }
+///
+/// struct FlipPlan;
+/// impl DelayedProposal<bool> for FlipPlan {
+///     type Plan = bool;
+///     type Info = bool;
+///     type Error = Infallible;
+///
+///     fn propose_plan<R: Rng + ?Sized>(
+///         &mut self,
+///         state: &bool,
+///         _: &mut R,
+///     ) -> Result<Option<bool>, Infallible> {
+///         Ok(Some(!*state))
+///     }
+///
+///     fn proposed_log_prob<T: Target<bool>>(
+///         &self,
+///         _: &bool,
+///         plan: &bool,
+///         target: &T,
+///     ) -> Result<f64, Infallible> {
+///         Ok(target.log_prob(plan))
+///     }
+///
+///     fn info(&self, plan: &bool) -> bool { *plan }
+///
+///     fn commit<R: Rng + ?Sized>(
+///         &mut self,
+///         state: &mut bool,
+///         plan: bool,
+///         _: &mut R,
+///     ) -> Result<(), Infallible> {
+///         *state = plan;
+///         Ok(())
+///     }
+/// }
+///
+/// let mut rng = StdRng::seed_from_u64(42);
+/// let mut proposal = FlipPlan;
+/// let report = verify_detailed_balance_delayed(
+///     &false,
+///     &true,
+///     &Flat,
+///     &mut proposal,
+///     &mut rng,
+///     DetailedBalanceConfig {
+///         samples: 128,
+///         tolerance: 1e-12,
+///         min_hits: 1,
+///     },
+///     (|plan| *plan, |plan| !*plan),
+/// )?;
+///
+/// assert!(report.is_within_tolerance(1e-12));
+/// # Ok::<(), DetailedBalanceError<Infallible>>(())
+/// ```
+pub fn verify_detailed_balance_delayed<S, T, P, R>(
+    current: &S,
+    proposed: &S,
+    target: &T,
+    proposal: &mut P,
+    rng: &mut R,
+    config: DetailedBalanceConfig,
+    plan_matches: (impl Fn(&P::Plan) -> bool, impl Fn(&P::Plan) -> bool),
+) -> Result<DetailedBalanceReport, DetailedBalanceError<P::Error>>
+where
+    T: Target<S>,
+    P: DelayedProposal<S> + ?Sized,
+    R: Rng + ?Sized,
+{
+    validate_config(config)?;
+    let (forward_matches, reverse_matches) = plan_matches;
+    verify_detailed_balance_delayed_unchecked(
+        current,
+        proposed,
+        target,
+        proposal,
+        rng,
+        config,
+        (&forward_matches, &reverse_matches),
+    )
+}
+
+/// Verify many delayed-commit transitions and return every transition violation.
+///
+/// Each [`DetailedBalanceDelayedTransition`] supplies endpoint states and the
+/// forward/reverse plan predicates for that concrete transition.
+///
+/// ```
+/// use core::convert::Infallible;
+/// use markov_chain_monte_carlo::prelude::testing::*;
+/// use rand::{Rng, SeedableRng, rngs::StdRng};
+///
+/// struct Flat;
+/// impl Target<bool> for Flat {
+///     fn log_prob(&self, _: &bool) -> f64 { 0.0 }
+/// }
+///
+/// struct FlipPlan;
+/// impl DelayedProposal<bool> for FlipPlan {
+///     type Plan = bool;
+///     type Info = bool;
+///     type Error = Infallible;
+///
+///     fn propose_plan<R: Rng + ?Sized>(
+///         &mut self,
+///         state: &bool,
+///         _: &mut R,
+///     ) -> Result<Option<bool>, Infallible> {
+///         Ok(Some(!*state))
+///     }
+///
+///     fn proposed_log_prob<T: Target<bool>>(
+///         &self,
+///         _: &bool,
+///         plan: &bool,
+///         target: &T,
+///     ) -> Result<f64, Infallible> {
+///         Ok(target.log_prob(plan))
+///     }
+///
+///     fn info(&self, plan: &bool) -> bool { *plan }
+///
+///     fn commit<R: Rng + ?Sized>(
+///         &mut self,
+///         state: &mut bool,
+///         plan: bool,
+///         _: &mut R,
+///     ) -> Result<(), Infallible> {
+///         *state = plan;
+///         Ok(())
+///     }
+/// }
+///
+/// let forward = |plan: &bool| *plan;
+/// let reverse = |plan: &bool| !*plan;
+/// let transitions = [DetailedBalanceDelayedTransition {
+///     current: &false,
+///     proposed: &true,
+///     forward_plan_matches: &forward,
+///     reverse_plan_matches: &reverse,
+/// }];
+/// let mut proposal = FlipPlan;
+/// let mut rng = StdRng::seed_from_u64(42);
+/// let batch = verify_detailed_balance_delayed_many(
+///     transitions,
+///     &Flat,
+///     &mut proposal,
+///     &mut rng,
+///     DetailedBalanceConfig {
+///         samples: 128,
+///         tolerance: 1e-12,
+///         min_hits: 1,
+///     },
+/// )?;
+///
+/// assert!(batch.is_success());
+/// assert_eq!(batch.reports.len(), 1);
+/// # Ok::<(), DetailedBalanceError<Infallible>>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns [`DetailedBalanceError`] if the configuration is invalid.  Per-transition
+/// failures are collected in [`DetailedBalanceBatchReport::failures`].
+pub fn verify_detailed_balance_delayed_many<'a, S, T, P, R, I>(
+    transitions: I,
+    target: &T,
+    proposal: &mut P,
+    rng: &mut R,
+    config: DetailedBalanceConfig,
+) -> Result<DetailedBalanceBatchReport<P::Error>, DetailedBalanceError<P::Error>>
+where
+    S: 'a,
+    T: Target<S>,
+    P: DelayedProposal<S> + ?Sized,
+    P::Plan: 'a,
+    R: Rng + ?Sized,
+    I: IntoIterator<Item = DetailedBalanceDelayedTransition<'a, S, P::Plan>>,
+{
+    let mut batch = DetailedBalanceBatchReport {
+        reports: Vec::new(),
+        failures: Vec::new(),
+    };
+
+    validate_config(config)?;
+
+    for (index, transition) in transitions.into_iter().enumerate() {
+        match verify_detailed_balance_delayed_unchecked(
+            transition.current,
+            transition.proposed,
+            target,
+            proposal,
+            rng,
+            config,
+            (
+                transition.forward_plan_matches,
+                transition.reverse_plan_matches,
+            ),
+        ) {
+            Ok(report) => batch.reports.push(report),
+            Err(error) => batch.failures.push(DetailedBalanceFailure { index, error }),
+        }
+    }
+
+    Ok(batch)
+}
+
+/// Run a by-value detailed-balance check after the public caller has already
+/// validated the sampling configuration.
+fn verify_detailed_balance_unchecked<S, T, P, R>(
+    current: &S,
+    proposed: &S,
+    target: &T,
+    proposal: &P,
+    rng: &mut R,
+    config: DetailedBalanceConfig,
+) -> Result<DetailedBalanceReport, DetailedBalanceError>
+where
+    S: PartialEq,
+    T: Target<S>,
+    P: Proposal<S> + ?Sized,
+    R: Rng + ?Sized,
+{
+    let endpoint_log_probs = endpoint_log_probs(current, proposed, target)?;
+    let forward_log_q_ratio = proposal.log_q_ratio(current, proposed);
+    check_log_q_ratio(DetailedBalanceDirection::Forward, forward_log_q_ratio)?;
+    let reverse_log_q_ratio = proposal.log_q_ratio(proposed, current);
+    check_log_q_ratio(DetailedBalanceDirection::Reverse, reverse_log_q_ratio)?;
+
+    let forward_acceptance = acceptance_probability(
+        DetailedBalanceDirection::Forward,
+        endpoint_log_probs.proposed - endpoint_log_probs.current + forward_log_q_ratio,
+    )?;
+    let reverse_acceptance = acceptance_probability(
+        DetailedBalanceDirection::Reverse,
+        endpoint_log_probs.current - endpoint_log_probs.proposed + reverse_log_q_ratio,
+    )?;
+
+    let forward = estimate_by_value_transition(
+        current,
+        proposed,
+        proposal,
+        rng,
+        config.samples,
+        forward_acceptance,
+    );
+    let reverse = estimate_by_value_transition(
+        proposed,
+        current,
+        proposal,
+        rng,
+        config.samples,
+        reverse_acceptance,
+    );
+
+    finish_report(endpoint_log_probs, forward, reverse, config)
+}
+
+/// Run an in-place detailed-balance check after configuration validation,
+/// estimating each direction from cloned endpoint states.
+fn verify_detailed_balance_mut_unchecked<S, T, P, R>(
+    current: &S,
+    proposed: &S,
+    target: &T,
+    proposal: &P,
+    rng: &mut R,
+    config: DetailedBalanceConfig,
+) -> Result<DetailedBalanceReport, DetailedBalanceError>
+where
+    S: Clone + PartialEq,
+    T: Target<S>,
+    P: ProposalMut<S> + ?Sized,
+    R: Rng + ?Sized,
+{
+    let endpoint_log_probs = endpoint_log_probs(current, proposed, target)?;
+    let forward = estimate_mut_transition(
+        current,
+        proposed,
+        target,
+        proposal,
+        rng,
+        TransitionRequest {
+            samples: config.samples,
+            from_log_prob: endpoint_log_probs.current,
+            direction: DetailedBalanceDirection::Forward,
+        },
+    )?;
+    let reverse = estimate_mut_transition(
+        proposed,
+        current,
+        target,
+        proposal,
+        rng,
+        TransitionRequest {
+            samples: config.samples,
+            from_log_prob: endpoint_log_probs.proposed,
+            direction: DetailedBalanceDirection::Reverse,
+        },
+    )?;
+
+    finish_report(endpoint_log_probs, forward, reverse, config)
+}
+
+/// Run a delayed-proposal detailed-balance check after configuration validation,
+/// using caller-supplied predicates to identify matching concrete plans.
+fn verify_detailed_balance_delayed_unchecked<S, T, P, R, F, G>(
+    current: &S,
+    proposed: &S,
+    target: &T,
+    proposal: &mut P,
+    rng: &mut R,
+    config: DetailedBalanceConfig,
+    plan_matches: (&F, &G),
+) -> Result<DetailedBalanceReport, DetailedBalanceError<P::Error>>
+where
+    T: Target<S>,
+    P: DelayedProposal<S> + ?Sized,
+    R: Rng + ?Sized,
+    F: Fn(&P::Plan) -> bool + ?Sized,
+    G: Fn(&P::Plan) -> bool + ?Sized,
+{
+    let endpoint_log_probs = endpoint_log_probs(current, proposed, target)?;
+    let forward = estimate_delayed_transition(
+        current,
+        target,
+        proposal,
+        rng,
+        TransitionRequest {
+            samples: config.samples,
+            from_log_prob: endpoint_log_probs.current,
+            direction: DetailedBalanceDirection::Forward,
+        },
+        plan_matches.0,
+    )?;
+    let reverse = estimate_delayed_transition(
+        proposed,
+        target,
+        proposal,
+        rng,
+        TransitionRequest {
+            samples: config.samples,
+            from_log_prob: endpoint_log_probs.proposed,
+            direction: DetailedBalanceDirection::Reverse,
+        },
+        plan_matches.1,
+    )?;
+
+    finish_report(endpoint_log_probs, forward, reverse, config)
+}
+
+/// Validate detailed-balance configuration before sampling.
+fn validate_config<E>(config: DetailedBalanceConfig) -> Result<(), DetailedBalanceError<E>> {
+    if config.samples == 0 {
+        return Err(DetailedBalanceError::InvalidSamples {
+            samples: config.samples,
+        });
+    }
+    if !config.tolerance.is_finite() || config.tolerance < 0.0 {
+        return Err(DetailedBalanceError::InvalidTolerance {
+            tolerance: config.tolerance,
+        });
+    }
+    if config.min_hits == 0 || config.min_hits > config.samples {
+        return Err(DetailedBalanceError::InvalidMinHits {
+            min_hits: config.min_hits,
+            samples: config.samples,
+        });
+    }
+    Ok(())
+}
+
+/// Cached endpoint target log-probabilities for the two states in a check.
+#[derive(Debug, Clone, Copy)]
+struct EndpointLogProbs {
+    current: f64,
+    proposed: f64,
+}
+
+/// Evaluate and validate both endpoint target log-probabilities before sampling
+/// proposal transitions.
+fn endpoint_log_probs<S, T, E>(
+    current: &S,
+    proposed: &S,
+    target: &T,
+) -> Result<EndpointLogProbs, DetailedBalanceError<E>>
+where
+    T: Target<S>,
+{
+    let current_log_prob = target.log_prob(current);
+    check_log_prob(DetailedBalanceState::Current, current_log_prob)?;
+    let proposed_log_prob = target.log_prob(proposed);
+    check_log_prob(DetailedBalanceState::Proposed, proposed_log_prob)?;
+
+    Ok(EndpointLogProbs {
+        current: current_log_prob,
+        proposed: proposed_log_prob,
+    })
+}
+
+/// Check that an endpoint has a valid target log-probability.
+const fn check_log_prob<E>(
+    state: DetailedBalanceState,
+    log_prob: f64,
+) -> Result<(), DetailedBalanceError<E>> {
+    if log_prob.is_nan() || log_prob == f64::INFINITY {
+        Err(DetailedBalanceError::InvalidTargetLogProb { state, log_prob })
+    } else {
+        Ok(())
+    }
+}
+
+/// Check that a proposal log q-ratio is valid.
+const fn check_log_q_ratio<E>(
+    direction: DetailedBalanceDirection,
+    log_q_ratio: f64,
+) -> Result<(), DetailedBalanceError<E>> {
+    if log_q_ratio.is_nan() || log_q_ratio == f64::INFINITY {
+        Err(DetailedBalanceError::InvalidLogQRatio {
+            direction,
+            log_q_ratio,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+/// Check that empirical sampling produced enough exact hits.
+const fn check_hits<E>(
+    direction: DetailedBalanceDirection,
+    hits: usize,
+    min_hits: usize,
+) -> Result<(), DetailedBalanceError<E>> {
+    if hits >= min_hits {
+        Ok(())
+    } else {
+        Err(DetailedBalanceError::InsufficientHits {
+            direction,
+            hits,
+            min_hits,
+        })
+    }
+}
+
+/// Empirical hit and acceptance-weight totals for one transition direction.
+#[derive(Debug, Clone, Copy)]
+struct TransitionEstimate {
+    hits: usize,
+    weight_sum: f64,
+    weight_square_sum: f64,
+}
+
+/// Shared sampling metadata for one transition-estimation pass.
+#[derive(Debug, Clone, Copy)]
+struct TransitionRequest {
+    samples: usize,
+    from_log_prob: f64,
+    direction: DetailedBalanceDirection,
+}
+
+impl TransitionEstimate {
+    /// Start an empty empirical transition estimate.
+    const fn empty() -> Self {
+        Self {
+            hits: 0,
+            weight_sum: 0.0,
+            weight_square_sum: 0.0,
+        }
+    }
+
+    /// Add one matching proposal hit with its Metropolis-Hastings acceptance
+    /// probability.
+    fn push(&mut self, acceptance_probability: f64) {
+        self.hits += 1;
+        self.weight_sum += acceptance_probability;
+        self.weight_square_sum += acceptance_probability * acceptance_probability;
+    }
+
+    /// Estimate the log proposal probability from exact endpoint hits.
+    fn log_proposal_probability(self, samples: usize) -> f64 {
+        log_empirical_probability(self.hits, samples)
+    }
+
+    /// Estimate the log accepted transition probability from accumulated
+    /// acceptance weights.
+    fn log_transition_probability(self, samples: usize) -> f64 {
+        log_empirical_weight(self.weight_sum, samples)
+    }
+
+    /// Approximate the standard error of the accepted log transition estimate
+    /// using the observed acceptance-weight variance.
+    fn log_standard_error(self, samples: usize) -> f64 {
+        let mean = empirical_mean(self.weight_sum, samples);
+        if mean <= 0.0 {
+            return f64::INFINITY;
+        }
+
+        let second_moment = empirical_mean(self.weight_square_sum, samples);
+        let variance = mean.mul_add(-mean, second_moment).max(0.0);
+        let mean_standard_error = (variance / usize_to_f64(samples)).sqrt();
+        mean_standard_error / mean
+    }
+}
+
+/// Sample a by-value proposal repeatedly and accumulate hits that exactly match
+/// the requested endpoint.
+fn estimate_by_value_transition<S, P, R>(
+    from: &S,
+    to: &S,
+    proposal: &P,
+    rng: &mut R,
+    samples: usize,
+    acceptance_probability: f64,
+) -> TransitionEstimate
+where
+    S: PartialEq,
+    P: Proposal<S> + ?Sized,
+    R: Rng + ?Sized,
+{
+    let mut estimate = TransitionEstimate::empty();
+    for _ in 0..samples {
+        if proposal.propose(from, rng).eq(to) {
+            estimate.push(acceptance_probability);
+        }
+    }
+    estimate
+}
+
+/// Sample an in-place proposal from cloned endpoints and score each exact hit
+/// with the proposal's undo-token log ratio.
+fn estimate_mut_transition<S, T, P, R>(
+    from: &S,
+    to: &S,
+    target: &T,
+    proposal: &P,
+    rng: &mut R,
+    request: TransitionRequest,
+) -> Result<TransitionEstimate, DetailedBalanceError>
+where
+    S: Clone + PartialEq,
+    T: Target<S>,
+    P: ProposalMut<S> + ?Sized,
+    R: Rng + ?Sized,
+{
+    let mut estimate = TransitionEstimate::empty();
+    for _ in 0..request.samples {
+        let mut candidate = from.clone();
+        let Some(token) = proposal.propose_mut(&mut candidate, rng) else {
+            continue;
+        };
+        if candidate.eq(to) {
+            let proposed_log_prob = target.log_prob(&candidate);
+            check_log_prob(DetailedBalanceState::Proposed, proposed_log_prob)?;
+            let log_q_ratio = proposal.log_q_ratio(&candidate, &token);
+            check_log_q_ratio(request.direction, log_q_ratio)?;
+            estimate.push(acceptance_probability(
+                request.direction,
+                proposed_log_prob - request.from_log_prob + log_q_ratio,
+            )?);
+        }
+    }
+    Ok(estimate)
+}
+
+/// Sample delayed proposal plans and score the plans accepted by the caller's
+/// transition predicate.
+fn estimate_delayed_transition<S, T, P, R, F>(
+    from: &S,
+    target: &T,
+    proposal: &mut P,
+    rng: &mut R,
+    request: TransitionRequest,
+    plan_matches: &F,
+) -> Result<TransitionEstimate, DetailedBalanceError<P::Error>>
+where
+    T: Target<S>,
+    P: DelayedProposal<S> + ?Sized,
+    R: Rng + ?Sized,
+    F: Fn(&P::Plan) -> bool + ?Sized,
+{
+    let mut estimate = TransitionEstimate::empty();
+    for _ in 0..request.samples {
+        let Some(plan) =
+            proposal
+                .propose_plan(from, rng)
+                .map_err(|source| DetailedBalanceError::Plan {
+                    direction: request.direction,
+                    source,
+                })?
+        else {
+            continue;
+        };
+        if plan_matches(&plan) {
+            let proposed_log_prob =
+                proposal
+                    .proposed_log_prob(from, &plan, target)
+                    .map_err(|source| DetailedBalanceError::ProposedLogProb {
+                        direction: request.direction,
+                        source,
+                    })?;
+            check_log_prob(DetailedBalanceState::Proposed, proposed_log_prob)?;
+            let log_q_ratio = proposal.log_q_ratio(from, &plan).map_err(|source| {
+                DetailedBalanceError::LogQRatio {
+                    direction: request.direction,
+                    source,
+                }
+            })?;
+            check_log_q_ratio(request.direction, log_q_ratio)?;
+            estimate.push(acceptance_probability(
+                request.direction,
+                proposed_log_prob - request.from_log_prob + log_q_ratio,
+            )?);
+        }
+    }
+    Ok(estimate)
+}
+
+/// Combine forward and reverse empirical estimates into the public report and
+/// turn insufficient hits or excessive residuals into typed errors.
+fn finish_report<E>(
+    endpoint_log_probs: EndpointLogProbs,
+    forward: TransitionEstimate,
+    reverse: TransitionEstimate,
+    config: DetailedBalanceConfig,
+) -> Result<DetailedBalanceReport, DetailedBalanceError<E>> {
+    check_hits(
+        DetailedBalanceDirection::Forward,
+        forward.hits,
+        config.min_hits,
+    )?;
+    check_hits(
+        DetailedBalanceDirection::Reverse,
+        reverse.hits,
+        config.min_hits,
+    )?;
+
+    let forward_log_transition = forward.log_transition_probability(config.samples);
+    let reverse_log_transition = reverse.log_transition_probability(config.samples);
+    let forward_log_flow = endpoint_log_probs.current + forward_log_transition;
+    let reverse_log_flow = endpoint_log_probs.proposed + reverse_log_transition;
+    let log_balance_residual = log_residual(forward_log_flow, reverse_log_flow);
+    let log_balance_standard_error = forward
+        .log_standard_error(config.samples)
+        .hypot(reverse.log_standard_error(config.samples));
+
+    let report = DetailedBalanceReport {
+        samples: config.samples,
+        forward_hits: forward.hits,
+        reverse_hits: reverse.hits,
+        forward_log_proposal: forward.log_proposal_probability(config.samples),
+        reverse_log_proposal: reverse.log_proposal_probability(config.samples),
+        forward_log_transition,
+        reverse_log_transition,
+        log_balance_residual,
+        log_balance_standard_error,
+    };
+
+    if !report.is_within_tolerance(config.tolerance) {
+        return Err(DetailedBalanceError::Violation {
+            residual: log_balance_residual,
+            tolerance: config.tolerance,
+            report,
+        });
+    }
+
+    Ok(report)
+}
+
+/// Compute the log-flow difference while treating two impossible flows as
+/// exactly balanced.
+fn log_residual(forward_log_flow: f64, reverse_log_flow: f64) -> f64 {
+    if forward_log_flow == f64::NEG_INFINITY && reverse_log_flow == f64::NEG_INFINITY {
+        0.0
+    } else {
+        forward_log_flow - reverse_log_flow
+    }
+}
+
+/// Convert a log Metropolis-Hastings ratio into an acceptance probability,
+/// rejecting undefined ratios before they contaminate empirical estimates.
+fn acceptance_probability<E>(
+    direction: DetailedBalanceDirection,
+    log_acceptance_ratio: f64,
+) -> Result<f64, DetailedBalanceError<E>> {
+    if log_acceptance_ratio.is_nan() {
+        Err(DetailedBalanceError::InvalidLogAcceptanceRatio {
+            direction,
+            log_acceptance_ratio,
+        })
+    } else {
+        Ok(log_acceptance_ratio.min(0.0).exp())
+    }
+}
+
+/// Convert an exact hit count into an empirical log-proposal probability.
+fn log_empirical_probability(hits: usize, samples: usize) -> f64 {
+    log_empirical_weight(usize_to_f64(hits), samples)
+}
+
+/// Convert an accumulated transition weight into an empirical log probability.
+fn log_empirical_weight(weight_sum: f64, samples: usize) -> f64 {
+    empirical_mean(weight_sum, samples).ln()
+}
+
+/// Divide an accumulated empirical weight by the number of proposal samples.
+fn empirical_mean(weight_sum: f64, samples: usize) -> f64 {
+    weight_sum / usize_to_f64(samples)
+}
+
+/// Convert bounded sample counts into floating-point values for empirical
+/// probability estimates.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "empirical probabilities intentionally convert bounded sample counts to f64"
+)]
+const fn usize_to_f64(value: usize) -> f64 {
+    value as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use core::convert::Infallible;
+
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use super::*;
+
+    struct TwoStateTarget;
+    impl Target<bool> for TwoStateTarget {
+        fn log_prob(&self, state: &bool) -> f64 {
+            if *state { -2.0 } else { 0.0 }
+        }
+    }
+
+    struct ImpossibleTarget;
+    impl Target<bool> for ImpossibleTarget {
+        fn log_prob(&self, _: &bool) -> f64 {
+            f64::NEG_INFINITY
+        }
+    }
+
+    struct Flip;
+    impl Proposal<bool> for Flip {
+        fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
+            !current
+        }
+    }
+
+    struct BadLogQ;
+    impl Proposal<bool> for BadLogQ {
+        fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
+            !current
+        }
+
+        fn log_q_ratio(&self, _: &bool, _: &bool) -> f64 {
+            1.0
+        }
+    }
+
+    struct Stuck;
+    impl Proposal<bool> for Stuck {
+        fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
+            *current
+        }
+    }
+
+    struct FlipMut;
+    impl ProposalMut<bool> for FlipMut {
+        type Undo = bool;
+
+        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+            let old = *state;
+            *state = !*state;
+            Some(old)
+        }
+
+        fn undo(&self, state: &mut bool, token: bool) {
+            *state = token;
+        }
+    }
+
+    struct BadLogQMut;
+    impl ProposalMut<bool> for BadLogQMut {
+        type Undo = bool;
+
+        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+            let old = *state;
+            *state = !*state;
+            Some(old)
+        }
+
+        fn undo(&self, state: &mut bool, token: bool) {
+            *state = token;
+        }
+
+        fn log_q_ratio(&self, _: &bool, _: &bool) -> f64 {
+            1.0
+        }
+    }
+
+    struct DelayedFlip;
+    impl DelayedProposal<bool> for DelayedFlip {
+        type Plan = bool;
+        type Info = bool;
+        type Error = Infallible;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            state: &bool,
+            _: &mut R,
+        ) -> Result<Option<bool>, Infallible> {
+            Ok(Some(!*state))
+        }
+
+        fn proposed_log_prob<T: Target<bool>>(
+            &self,
+            _: &bool,
+            plan: &bool,
+            target: &T,
+        ) -> Result<f64, Infallible> {
+            Ok(target.log_prob(plan))
+        }
+
+        fn info(&self, plan: &bool) -> bool {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut bool,
+            plan: bool,
+            _: &mut R,
+        ) -> Result<(), Infallible> {
+            *state = plan;
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum DelayedFailure {
+        Plan,
+        ProposedLogProb,
+        LogQRatio,
+    }
+
+    impl fmt::Display for DelayedFailure {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::Plan => write!(f, "plan failed"),
+                Self::ProposedLogProb => write!(f, "proposed log-probability failed"),
+                Self::LogQRatio => write!(f, "log q-ratio failed"),
+            }
+        }
+    }
+
+    impl Error for DelayedFailure {}
+
+    struct FailingDelayed {
+        failure: DelayedFailure,
+    }
+
+    impl DelayedProposal<bool> for FailingDelayed {
+        type Plan = bool;
+        type Info = bool;
+        type Error = DelayedFailure;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            state: &bool,
+            _: &mut R,
+        ) -> Result<Option<bool>, DelayedFailure> {
+            if self.failure == DelayedFailure::Plan {
+                Err(DelayedFailure::Plan)
+            } else {
+                Ok(Some(!*state))
+            }
+        }
+
+        fn proposed_log_prob<T: Target<bool>>(
+            &self,
+            _: &bool,
+            plan: &bool,
+            target: &T,
+        ) -> Result<f64, DelayedFailure> {
+            if self.failure == DelayedFailure::ProposedLogProb {
+                Err(DelayedFailure::ProposedLogProb)
+            } else {
+                Ok(target.log_prob(plan))
+            }
+        }
+
+        fn log_q_ratio(&self, _: &bool, _: &bool) -> Result<f64, DelayedFailure> {
+            if self.failure == DelayedFailure::LogQRatio {
+                Err(DelayedFailure::LogQRatio)
+            } else {
+                Ok(0.0)
+            }
+        }
+
+        fn info(&self, plan: &bool) -> bool {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut bool,
+            plan: bool,
+            _: &mut R,
+        ) -> Result<(), DelayedFailure> {
+            *state = plan;
+            Ok(())
+        }
+    }
+
+    struct ReverseFailingDelayed {
+        failure: DelayedFailure,
+    }
+
+    impl DelayedProposal<bool> for ReverseFailingDelayed {
+        type Plan = bool;
+        type Info = bool;
+        type Error = DelayedFailure;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            state: &bool,
+            _: &mut R,
+        ) -> Result<Option<bool>, DelayedFailure> {
+            if *state && self.failure == DelayedFailure::Plan {
+                Err(DelayedFailure::Plan)
+            } else {
+                Ok(Some(!*state))
+            }
+        }
+
+        fn proposed_log_prob<T: Target<bool>>(
+            &self,
+            state: &bool,
+            plan: &bool,
+            target: &T,
+        ) -> Result<f64, DelayedFailure> {
+            if *state && self.failure == DelayedFailure::ProposedLogProb {
+                Err(DelayedFailure::ProposedLogProb)
+            } else {
+                Ok(target.log_prob(plan))
+            }
+        }
+
+        fn log_q_ratio(&self, state: &bool, _: &bool) -> Result<f64, DelayedFailure> {
+            if *state && self.failure == DelayedFailure::LogQRatio {
+                Err(DelayedFailure::LogQRatio)
+            } else {
+                Ok(0.0)
+            }
+        }
+
+        fn info(&self, plan: &bool) -> bool {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut bool,
+            plan: bool,
+            _: &mut R,
+        ) -> Result<(), DelayedFailure> {
+            *state = plan;
+            Ok(())
+        }
+    }
+
+    /// Return a fast deterministic configuration for exact two-state tests.
+    fn small_config() -> DetailedBalanceConfig {
+        DetailedBalanceConfig {
+            samples: 128,
+            tolerance: 1e-12,
+            min_hits: 1,
+        }
+    }
+
+    #[test]
+    fn verifies_symmetric_two_state_transition() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let report = verify_detailed_balance(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &Flip,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap();
+
+        assert_eq!(report.forward_hits, 128);
+        assert_eq!(report.reverse_hits, 128);
+        assert!(report.is_within_tolerance(1e-12));
+        assert!(report.z_score().is_some_and(|score| score.abs() < 1e-6));
+    }
+
+    #[test]
+    fn verifies_mutable_two_state_transition() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let report = verify_detailed_balance_mut(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &FlipMut,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap();
+
+        assert_eq!(report.forward_hits, 128);
+        assert_eq!(report.reverse_hits, 128);
+        assert!(report.is_within_tolerance(1e-12));
+    }
+
+    #[test]
+    fn verifies_delayed_two_state_transition() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = DelayedFlip;
+        let report = verify_detailed_balance_delayed(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+            (|plan| *plan, |plan| !*plan),
+        )
+        .unwrap();
+
+        assert_eq!(report.forward_hits, 128);
+        assert_eq!(report.reverse_hits, 128);
+        assert!(report.is_within_tolerance(1e-12));
+    }
+
+    #[test]
+    fn rejects_bad_log_q_ratio() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let err = verify_detailed_balance(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &BadLogQ,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::Violation {
+                residual,
+                tolerance: 1e-12,
+                ..
+            } if (residual - 1.0).abs() < 1e-12
+        ));
+    }
+
+    #[test]
+    fn mutable_rejects_bad_log_q_ratio() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let err = verify_detailed_balance_mut(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &BadLogQMut,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::Violation {
+                residual,
+                tolerance: 1e-12,
+                ..
+            } if (residual - 1.0).abs() < 1e-12
+        ));
+    }
+
+    #[test]
+    fn delayed_reports_plan_errors() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = FailingDelayed {
+            failure: DelayedFailure::Plan,
+        };
+        let err = verify_detailed_balance_delayed(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+            (|plan| *plan, |plan| !*plan),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::Plan {
+                direction: DetailedBalanceDirection::Forward,
+                source: DelayedFailure::Plan,
+            }
+        ));
+    }
+
+    #[test]
+    fn delayed_reports_proposed_log_prob_errors() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = FailingDelayed {
+            failure: DelayedFailure::ProposedLogProb,
+        };
+        let err = verify_detailed_balance_delayed(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+            (|plan| *plan, |plan| !*plan),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::ProposedLogProb {
+                direction: DetailedBalanceDirection::Forward,
+                source: DelayedFailure::ProposedLogProb,
+            }
+        ));
+    }
+
+    #[test]
+    fn delayed_reports_log_q_ratio_errors() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = FailingDelayed {
+            failure: DelayedFailure::LogQRatio,
+        };
+        let err = verify_detailed_balance_delayed(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+            (|plan| *plan, |plan| !*plan),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::LogQRatio {
+                direction: DetailedBalanceDirection::Forward,
+                source: DelayedFailure::LogQRatio,
+            }
+        ));
+    }
+
+    #[test]
+    fn delayed_reports_reverse_plan_errors() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = ReverseFailingDelayed {
+            failure: DelayedFailure::Plan,
+        };
+        let err = verify_detailed_balance_delayed(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+            (|plan| *plan, |plan| !*plan),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::Plan {
+                direction: DetailedBalanceDirection::Reverse,
+                source: DelayedFailure::Plan,
+            }
+        ));
+    }
+
+    #[test]
+    fn delayed_reports_reverse_proposed_log_prob_errors() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = ReverseFailingDelayed {
+            failure: DelayedFailure::ProposedLogProb,
+        };
+        let err = verify_detailed_balance_delayed(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+            (|plan| *plan, |plan| !*plan),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::ProposedLogProb {
+                direction: DetailedBalanceDirection::Reverse,
+                source: DelayedFailure::ProposedLogProb,
+            }
+        ));
+    }
+
+    #[test]
+    fn delayed_reports_reverse_log_q_ratio_errors() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = ReverseFailingDelayed {
+            failure: DelayedFailure::LogQRatio,
+        };
+        let err = verify_detailed_balance_delayed(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+            (|plan| *plan, |plan| !*plan),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::LogQRatio {
+                direction: DetailedBalanceDirection::Reverse,
+                source: DelayedFailure::LogQRatio,
+            }
+        ));
+    }
+
+    #[test]
+    fn reports_insufficient_hits() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let err = verify_detailed_balance(
+            &false,
+            &true,
+            &TwoStateTarget,
+            &Stuck,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InsufficientHits {
+                direction: DetailedBalanceDirection::Forward,
+                hits: 0,
+                min_hits: 1,
+            }
+        ));
+    }
+
+    #[test]
+    fn reports_invalid_log_acceptance_ratio() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let err = verify_detailed_balance(
+            &false,
+            &true,
+            &ImpossibleTarget,
+            &Flip,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidLogAcceptanceRatio {
+                direction: DetailedBalanceDirection::Forward,
+                log_acceptance_ratio,
+            } if log_acceptance_ratio.is_nan()
+        ));
+    }
+
+    #[test]
+    fn batch_reports_all_failures() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let pairs = [(false, true), (true, false)];
+        let batch = verify_detailed_balance_many(
+            pairs.iter().map(|(current, proposed)| (current, proposed)),
+            &TwoStateTarget,
+            &BadLogQ,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap();
+
+        assert!(!batch.is_success());
+        assert_eq!(batch.failures.len(), 2);
+        assert_eq!(batch.failures[0].index, 0);
+        assert_eq!(batch.failures[1].index, 1);
+    }
+
+    #[test]
+    fn delayed_batch_reports_successes() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = DelayedFlip;
+        let forward = |plan: &bool| *plan;
+        let reverse = |plan: &bool| !*plan;
+        let transitions = [DetailedBalanceDelayedTransition {
+            current: &false,
+            proposed: &true,
+            forward_plan_matches: &forward,
+            reverse_plan_matches: &reverse,
+        }];
+
+        let batch = verify_detailed_balance_delayed_many(
+            transitions,
+            &TwoStateTarget,
+            &mut proposal,
+            &mut rng,
+            small_config(),
+        )
+        .unwrap();
+
+        assert!(batch.is_success());
+        assert_eq!(batch.reports.len(), 1);
+    }
+
+    #[test]
+    fn batch_rejects_invalid_config_without_fake_transition_index() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let err = verify_detailed_balance_many(
+            core::iter::empty::<(&bool, &bool)>(),
+            &TwoStateTarget,
+            &Flip,
+            &mut rng,
+            DetailedBalanceConfig {
+                samples: 0,
+                tolerance: 1e-12,
+                min_hits: 1,
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidSamples { samples: 0 }
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_config() {
+        let err: DetailedBalanceError = validate_config(DetailedBalanceConfig {
+            samples: 0,
+            tolerance: 0.0,
+            min_hits: 1,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidSamples { samples: 0 }
+        ));
+
+        let err = validate_config::<Infallible>(DetailedBalanceConfig {
+            samples: 1,
+            tolerance: -1.0,
+            min_hits: 1,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidTolerance { tolerance }
+                if tolerance.to_bits() == (-1.0_f64).to_bits()
+        ));
+
+        let err = validate_config::<Infallible>(DetailedBalanceConfig {
+            samples: 1,
+            tolerance: f64::NAN,
+            min_hits: 1,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidTolerance { tolerance } if tolerance.is_nan()
+        ));
+
+        let err = validate_config::<Infallible>(DetailedBalanceConfig {
+            samples: 1,
+            tolerance: f64::INFINITY,
+            min_hits: 1,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidTolerance { tolerance }
+                if tolerance.is_infinite() && tolerance.is_sign_positive()
+        ));
+
+        let err = validate_config::<Infallible>(DetailedBalanceConfig {
+            samples: 1,
+            tolerance: 0.0,
+            min_hits: 0,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidMinHits {
+                min_hits: 0,
+                samples: 1,
+            }
+        ));
+
+        let err = validate_config::<Infallible>(DetailedBalanceConfig {
+            samples: 1,
+            tolerance: 0.0,
+            min_hits: 2,
+        })
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            DetailedBalanceError::InvalidMinHits {
+                min_hits: 2,
+                samples: 1,
+            }
+        ));
+    }
+}

--- a/tests/semgrep/benches/erased_error.rs
+++ b/tests/semgrep/benches/erased_error.rs
@@ -1,0 +1,11 @@
+fn erased_benchmark_error() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+fn borrowed_benchmark_error(error: &dyn std::error::Error) {
+    let _ = error.to_string();
+}
+
+fn anyhow_benchmark_error(error: anyhow::Error) {
+    let _ = error.to_string();
+}

--- a/tests/semgrep/benches/typed_error.rs
+++ b/tests/semgrep/benches/typed_error.rs
@@ -1,0 +1,9 @@
+use markov_chain_monte_carlo::McmcError;
+
+fn typed_benchmark_error() -> Result<(), McmcError> {
+    Ok(())
+}
+
+fn borrowed_typed_benchmark_error(error: &McmcError) {
+    let _ = error.to_string();
+}

--- a/tests/semgrep/examples/erased_error.rs
+++ b/tests/semgrep/examples/erased_error.rs
@@ -1,0 +1,11 @@
+fn erased_example_error() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+fn borrowed_example_error(error: &dyn std::error::Error) {
+    let _ = error.to_string();
+}
+
+fn anyhow_example_error(error: anyhow::Error) {
+    let _ = error.to_string();
+}

--- a/tests/semgrep/examples/typed_error.rs
+++ b/tests/semgrep/examples/typed_error.rs
@@ -1,0 +1,9 @@
+use markov_chain_monte_carlo::McmcError;
+
+fn typed_example_error() -> Result<(), McmcError> {
+    Ok(())
+}
+
+fn borrowed_typed_example_error(error: &McmcError) {
+    let _ = error.to_string();
+}

--- a/tests/semgrep/src/doctests/erased_error.rs
+++ b/tests/semgrep/src/doctests/erased_error.rs
@@ -1,0 +1,18 @@
+/// ```
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn doctest_with_boxed_error() {}
+
+/**
+ * ```
+ * # fn borrowed(error: &dyn std::error::Error) { let _ = error.to_string(); }
+ * ```
+ */
+pub fn block_doctest_with_borrowed_error() {}
+
+/*!
+ * ```
+ * # Ok::<(), anyhow::Error>(())
+ * ```
+ */
+pub fn inner_block_doctest_with_anyhow_error() {}

--- a/tests/semgrep/src/doctests/typed_error.rs
+++ b/tests/semgrep/src/doctests/typed_error.rs
@@ -1,0 +1,15 @@
+/// ```
+/// # use markov_chain_monte_carlo::McmcError;
+/// # Ok::<(), McmcError>(())
+/// ```
+pub fn doctest_with_typed_error() {}
+
+/**
+ * ```
+ * # use markov_chain_monte_carlo::McmcError;
+ * # fn borrowed(error: &McmcError) {
+ * #     let _ = error.to_string();
+ * # }
+ * ```
+ */
+pub fn block_doctest_with_typed_error() {}


### PR DESCRIPTION
- Add detailed-balance verification APIs for by-value, in-place, delayed, and batch proposal checks.
- Add typed reports and errors, scoped testing prelude exports, public doctests, and a runnable detailed_balance example.
- Document proposal validation, scientific basis, roadmap, and refreshed README usage guidance.
- Add Semgrep guardrails and fixtures to keep examples, benches, and doctests on typed errors.
- Improve git-cliff and agent commit guidance, then regenerate CHANGELOG.md.
- Bump serde_json dev-dependency to 1.0.149.

Closes #19 