### PR TITLE
feat!: validate sampler construction and checkpoint restores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +441,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "markov-chain-monte-carlo"
 version = "0.2.1"
 dependencies = [
+ "approx",
  "criterion",
  "proptest",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = [ "dep:serde" ]
 all-features = true
 
 [dev-dependencies]
+approx = "0.5.1"
 criterion = "0.8.2"
 proptest = "1.11.0"
 serde_json = "1.0.149"

--- a/README.md
+++ b/README.md
@@ -138,6 +138,24 @@ fn main() -> Result<(), McmcError> {
 
 Markov Chain Monte Carlo (MCMC) framework.
 
+`markov-chain-monte-carlo` provides small, explicit Metropolis-Hastings
+tools for Rust projects with user-defined state spaces, proposal mechanisms,
+and measurement workflows.
+
+Use this crate when you need ordinary by-value proposals, rollback-safe
+mutation for large states, delayed commits, validated checkpoint restores, or
+streaming observables for long sampler runs.
+
+### Features
+
+- Generic `Chain<S>` and `Sampler` APIs over user-defined state spaces.
+- By-value, in-place, and delayed-commit proposal workflows.
+- Log-space acceptance with typed errors for invalid target or proposal
+  values.
+- Optional `serde` checkpoint serialization with validated restore flows.
+- Observables, thinning helpers, streaming statistics, and proposal
+  diagnostics.
+
 This API guide documents the crate's Metropolis-Hastings contracts,
 numerical semantics, proposal workflows, sampler helpers, observables, and
 streaming statistics. For installation, feature selection, and a concise
@@ -263,7 +281,8 @@ impl Target<f64> for Normal {
 
 let chain = Chain::new(1.0, &Normal)
     .expect("normal target returns a finite log probability");
-let checkpoint = serde_json::to_string(&chain)?;
+let checkpoint = chain.checkpoint();
+let checkpoint = serde_json::to_string(&checkpoint)?;
 let checkpoint: ChainCheckpoint<f64> = serde_json::from_str(&checkpoint)?;
 let restored = Chain::from_checkpoint(checkpoint, &Normal)
     .expect("normal target returns a finite checkpoint log probability");

--- a/README.md
+++ b/README.md
@@ -4,23 +4,43 @@
 
 Small, explicit Metropolis-Hastings tools in Rust for ordinary numeric states, large combinatorial state spaces, and proposal implementations that need rollback-safe mutation or delayed commits.
 
+## 📐 Introduction
+
+This library implements composable Metropolis-Hastings sampling in Rust for workflows where the state space, proposal mechanism, and measurement strategy are application-specific. The goal is to keep the transition mechanics explicit while supporting cheap cloned states, large rollback-mutable states, delayed-commit proposals, long streaming runs, and proposal diagnostics.
+
+🚧 **Pre-release (0.x)** — This crate is under active development and not yet ready for production use. APIs may change without notice.
+
 Use this crate when you want:
 
 - a generic Metropolis-Hastings chain over user-defined state spaces
 - by-value, in-place, and delayed-commit proposal APIs
 - log-space acceptance calculations with NaN/+infinity checks
 - observable measurement APIs, streaming statistics, and binning error estimates
+- thinning helpers for long sampler runs
+- optional `serde` checkpointing with validated resume flows
 - detailed-balance diagnostics for proposal development
 
 This crate provides the sampler mechanics; proposal correctness, ergodicity, convergence assessment, and scientific model choice remain domain-specific responsibilities.
 
+## ✨ Features
+
+- Generic `Chain<S>` over user-defined state spaces with explicit accepted/rejected counters.
+- Log-space Metropolis-Hastings acceptance with typed errors for NaN and positive-infinite target or proposal values.
+- Three proposal workflows: by-value `Proposal`, rollback-safe in-place `ProposalMut`, and delayed-commit `DelayedProposal`.
+- `Sampler` helpers for repeated runs, iterator-style sampling, thinning, observations, and counter resets after burn-in.
+- Streaming `OnlineStats` and `BinningAnalysis` for long correlated runs without retaining every sample.
+- `ChainCheckpoint` restore APIs that recompute cached log-probabilities against the resumed target.
+- Optional `serde` support for serializing chains, samplers, and portable checkpoints.
+- Detailed-balance diagnostics for proposal tests on representative discrete transitions.
+
 ## Contents
 
+- [📐 Introduction](#-introduction)
+- [✨ Features](#-features)
 - [🚀 Quick start](#-quick-start)
 - [🧭 Choosing an API](#-choosing-an-api)
 - [📦 Cargo features](#-cargo-features)
 - [📚 API guide](#-api-guide)
-  - [Features](#features)
   - [Scientific basis and scope](#scientific-basis-and-scope)
   - [Numerical semantics](#numerical-semantics)
   - [Long runs and parallelism](#long-runs-and-parallelism)
@@ -107,7 +127,7 @@ fn main() -> Result<(), McmcError> {
 
 ## 📦 Cargo features
 
-- `serde` — enable `serde::Serialize` / `Deserialize` for `Chain` and `Sampler` checkpointing.
+- `serde` — enable `serde::Serialize` for `Chain` and `Sampler`, plus `ChainCheckpoint` serialization/deserialization for validated resume flows.
 
 ## 📚 API guide
 
@@ -118,46 +138,16 @@ fn main() -> Result<(), McmcError> {
 
 Markov Chain Monte Carlo (MCMC) framework.
 
-🚧 **Pre-release (0.x)** — This crate is under active development and
-not yet ready for production use. APIs may change without notice.
-
-`markov-chain-monte-carlo` provides a small, explicit Metropolis-Hastings
-toolkit for scientific Rust projects. It is designed for ordinary numeric
-states, large combinatorial state spaces, and proposal implementations that
-need rollback-safe mutation or delayed commits.  The crate aims to provide
-a composable, zero-cost abstraction for MCMC methods over arbitrary state
-spaces, including discrete and combinatorial systems (e.g., triangulations).
-
-Use this crate when you want:
-
-- A generic Metropolis-Hastings chain over user-defined state spaces
-- By-value, in-place, and delayed-commit proposal APIs
-- Log-space acceptance calculations with NaN/+infinity checks
-- Observable measurement APIs for collecting derived quantities
-- Streaming means, variances, and binning error estimates
-- Thinning helpers for long sampler runs
-- Optional `serde` checkpointing for chains and sampler handles
-- Detailed-balance diagnostics for proposal development
+This API guide documents the crate's Metropolis-Hastings contracts,
+numerical semantics, proposal workflows, sampler helpers, observables, and
+streaming statistics. For installation, feature selection, and a concise
+orientation to the crate, see the hand-written sections at the top of the
+repository README.
 
 [`Target::log_prob`] should return an unnormalized natural log-probability
 or log-density.  Additive constants are fine because Metropolis-Hastings
 only uses differences, but arbitrary scores or logits will sample a
 different distribution.
-
-### Features
-
-- `Target<S>` for unnormalized log probabilities or log densities
-- `Proposal<S>` for simple by-value proposals
-- `ProposalMut<S>` for in-place mutation with rollback tokens
-- `DelayedProposal<S>` for accept-before-mutation workflows with concrete
-  plans
-- `Chain<S>` with by-value, in-place, and delayed step methods
-- `Sampler<S, T, P, R>` for ergonomic bulk runs and iterator-based sampling
-- Observables, fallible observations, and sample buffers
-- Online statistics and binning analysis for correlated samples
-- Thinned run and observation helpers
-- Optional `serde` feature for checkpointing
-- Detailed-balance checks for by-value, in-place, and delayed proposals
 
 ### Scientific basis and scope
 
@@ -255,13 +245,15 @@ of ergodicity or convergence.  They are intended for tests, examples, and
 proposal-development checks over discrete or otherwise exactly comparable
 states.
 
-Enable the optional `serde` feature to serialize and deserialize
-[`Chain<S>`] when `S` implements serde's traits.  [`Sampler`] also derives
-serialization when all stored handles support it, but the portable
-checkpoint for resuming a run is the owned [`Chain<S>`]; targets, proposals,
-and RNG streams are reconstructed by the caller.
+Enable the optional `serde` feature to serialize [`Chain<S>`] checkpoints
+when `S` implements serde's traits.  Restore checkpoint data with
+[`Chain::from_checkpoint`] so the cached log-probability is recomputed from
+the target used for resumed sampling.  [`Sampler`] also derives
+serialization when all stored handles support it, but targets, proposals,
+and RNG streams are reconstructed by the caller for portable resumes.
 
 ```rust
+use approx::assert_relative_eq;
 use markov_chain_monte_carlo::prelude::*;
 
 struct Normal;
@@ -269,12 +261,17 @@ impl Target<f64> for Normal {
     fn log_prob(&self, state: &f64) -> f64 { -0.5 * state * state }
 }
 
-let Ok(chain) = Chain::new(1.0, &Normal) else {
-    unreachable!("normal target returns a finite log probability");
-};
+let chain = Chain::new(1.0, &Normal)
+    .expect("normal target returns a finite log probability");
 let checkpoint = serde_json::to_string(&chain)?;
-let restored: Chain<f64> = serde_json::from_str(&checkpoint)?;
-assert!((restored.log_prob() - Normal.log_prob(restored.state())).abs() < 1e-12);
+let checkpoint: ChainCheckpoint<f64> = serde_json::from_str(&checkpoint)?;
+let restored = Chain::from_checkpoint(checkpoint, &Normal)
+    .expect("normal target returns a finite checkpoint log probability");
+assert_relative_eq!(
+    restored.log_prob(),
+    Normal.log_prob(restored.state()),
+    epsilon = 1e-12
+);
 ```
 
 ### Example
@@ -457,11 +454,11 @@ use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 
 let mut rng = StdRng::seed_from_u64(42);
 let chain = Chain::new(Scalar(0.0), &Normal)?;
-let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng);
+let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng)?;
 
 // Burn-in
 sampler.run(1000)?;
-sampler.chain_mut().reset_counters();
+sampler.reset_counters();
 
 // Production
 sampler.run(10_000)?;
@@ -479,7 +476,7 @@ use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 
 let mut rng = StdRng::seed_from_u64(42);
 let chain = Chain::new(Scalar(0.0), &Normal)?;
-let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng);
+let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng)?;
 let mut energy = |state: &Scalar| 0.5 * state.0 * state.0;
 
 let samples: SampleBuffer<f64> = sampler.run_observing(256, &mut energy)?;
@@ -513,7 +510,7 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 
 let mut rng = StdRng::seed_from_u64(42);
 let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
-let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
 let mut coordinate = |state: &f64| *state;
 let mut stats = OnlineStats::new();
 

--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -268,50 +268,41 @@ fn bench_sampler_runs(c: &mut Criterion) {
     let spin_proposal = SpinFlip;
 
     c.bench_function("sampler/run_by_value_100", |b| {
-        b.iter_batched(
-            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
-            |(chain, mut rng)| {
-                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng).unwrap();
-                sampler.run(black_box(BULK_STEPS)).unwrap();
-                black_box(sampler.chain_ref().state().0);
-            },
-            BatchSize::SmallInput,
-        );
+        let mut rng = StdRng::seed_from_u64(SEED);
+        let mut sampler =
+            Sampler::new(scalar_chain(&target), &target, &proposal, &mut rng).unwrap();
+
+        b.iter(|| {
+            sampler.run(black_box(BULK_STEPS)).unwrap();
+            black_box(sampler.chain_ref().state().0);
+        });
     });
 
     c.bench_function("sampler/run_mut_100", |b| {
-        b.iter_batched(
-            || {
-                (
-                    spin_chain(&Alignment { beta: 0.0 }),
-                    StdRng::seed_from_u64(SEED),
-                )
-            },
-            |(chain, mut rng)| {
-                let mut sampler = Sampler::new(chain, &flat, &spin_proposal, &mut rng).unwrap();
-                sampler.run_mut(black_box(BULK_STEPS)).unwrap();
-                black_box(sampler.chain_ref().state().spins[0]);
-            },
-            BatchSize::SmallInput,
-        );
+        let mut rng = StdRng::seed_from_u64(SEED);
+        let mut sampler = Sampler::new(
+            spin_chain(&Alignment { beta: 0.0 }),
+            &flat,
+            &spin_proposal,
+            &mut rng,
+        )
+        .unwrap();
+
+        b.iter(|| {
+            sampler.run_mut(black_box(BULK_STEPS)).unwrap();
+            black_box(sampler.chain_ref().state().spins[0]);
+        });
     });
 
     c.bench_function("sampler/run_delayed_100", |b| {
-        b.iter_batched(
-            || {
-                (
-                    scalar_chain(&flat),
-                    DelayedWalk { delta: 1.0 },
-                    StdRng::seed_from_u64(SEED),
-                )
-            },
-            |(chain, mut delayed, mut rng)| {
-                let mut sampler = Sampler::new(chain, &flat, &mut delayed, &mut rng).unwrap();
-                sampler.run_delayed(black_box(BULK_STEPS)).unwrap();
-                black_box(sampler.chain_ref().state().0);
-            },
-            BatchSize::SmallInput,
-        );
+        let mut delayed = DelayedWalk { delta: 1.0 };
+        let mut rng = StdRng::seed_from_u64(SEED);
+        let mut sampler = Sampler::new(scalar_chain(&flat), &flat, &mut delayed, &mut rng).unwrap();
+
+        b.iter(|| {
+            sampler.run_delayed(black_box(BULK_STEPS)).unwrap();
+            black_box(sampler.chain_ref().state().0);
+        });
     });
 }
 
@@ -321,18 +312,17 @@ fn bench_observing(c: &mut Criterion) {
     let proposal = RandomWalk { width: 1.0 };
 
     c.bench_function("observing/run_observing_buffer_100", |b| {
-        b.iter_batched(
-            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
-            |(chain, mut rng)| {
-                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng).unwrap();
-                let mut square = |state: &Scalar| state.0 * state.0;
-                let observations = sampler
-                    .run_observing(black_box(BULK_STEPS), &mut square)
-                    .unwrap();
-                black_box(observations.as_slice());
-            },
-            BatchSize::SmallInput,
-        );
+        let mut rng = StdRng::seed_from_u64(SEED);
+        let mut sampler =
+            Sampler::new(scalar_chain(&target), &target, &proposal, &mut rng).unwrap();
+        let mut square = |state: &Scalar| state.0 * state.0;
+
+        b.iter(|| {
+            let observations = sampler
+                .run_observing(black_box(BULK_STEPS), &mut square)
+                .unwrap();
+            black_box(observations.as_slice());
+        });
     });
 
     c.bench_function("observing/manual_online_sum_100", |b| {

--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -271,7 +271,7 @@ fn bench_sampler_runs(c: &mut Criterion) {
         b.iter_batched(
             || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
             |(chain, mut rng)| {
-                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
+                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng).unwrap();
                 sampler.run(black_box(BULK_STEPS)).unwrap();
                 black_box(sampler.chain_ref().state().0);
             },
@@ -288,7 +288,7 @@ fn bench_sampler_runs(c: &mut Criterion) {
                 )
             },
             |(chain, mut rng)| {
-                let mut sampler = Sampler::new(chain, &flat, &spin_proposal, &mut rng);
+                let mut sampler = Sampler::new(chain, &flat, &spin_proposal, &mut rng).unwrap();
                 sampler.run_mut(black_box(BULK_STEPS)).unwrap();
                 black_box(sampler.chain_ref().state().spins[0]);
             },
@@ -306,7 +306,7 @@ fn bench_sampler_runs(c: &mut Criterion) {
                 )
             },
             |(chain, mut delayed, mut rng)| {
-                let mut sampler = Sampler::new(chain, &flat, &mut delayed, &mut rng);
+                let mut sampler = Sampler::new(chain, &flat, &mut delayed, &mut rng).unwrap();
                 sampler.run_delayed(black_box(BULK_STEPS)).unwrap();
                 black_box(sampler.chain_ref().state().0);
             },
@@ -324,7 +324,7 @@ fn bench_observing(c: &mut Criterion) {
         b.iter_batched(
             || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
             |(chain, mut rng)| {
-                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
+                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng).unwrap();
                 let mut square = |state: &Scalar| state.0 * state.0;
                 let observations = sampler
                     .run_observing(black_box(BULK_STEPS), &mut square)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -93,7 +93,7 @@ just ci
 just publish-check
 ```
 
-`just fix` reruns formatters and README generation. `just ci` covers formatting, Clippy, Python tooling checks, benchmark harness compilation, docs, tests, all-features coverage, examples, example output validation, YAML, TOML, Markdown, spelling, GitHub Actions, Semgrep checks, and `cargo rdme --check`. `just publish-check` validates crates.io metadata and runs `cargo publish --locked --allow-dirty --dry-run`.
+`just fix` reruns formatters and README generation. `just ci` covers formatting, Clippy, Python tooling checks, benchmark harness compilation, docs, tests, examples, example output validation, YAML, TOML, Markdown, spelling, GitHub Actions, Semgrep checks, and `cargo rdme --check`. `just publish-check` validates crates.io metadata and runs `cargo publish --locked --allow-dirty --dry-run`.
 
 ### 6. Commit, push, and open the PR
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -93,7 +93,7 @@ just ci
 just publish-check
 ```
 
-`just fix` reruns formatters and README generation. `just ci` covers formatting, Clippy, Python tooling checks, benchmark harness compilation, docs, tests, examples, example output validation, YAML, TOML, Markdown, spelling, GitHub Actions, Semgrep checks, and `cargo rdme --check`. `just publish-check` validates crates.io metadata and runs `cargo publish --locked --allow-dirty --dry-run`.
+`just fix` reruns formatters and README generation. `just ci` covers formatting, Clippy, Python tooling checks, benchmark harness compilation, docs, tests, all-features coverage, examples, example output validation, YAML, TOML, Markdown, spelling, GitHub Actions, Semgrep checks, and `cargo rdme --check`. `just publish-check` validates crates.io metadata and runs `cargo publish --locked --allow-dirty --dry-run`.
 
 ### 6. Commit, push, and open the PR
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -43,7 +43,7 @@ For cross-repo muscle memory, the same checks are also available through grouped
 - `just lint-config` - JSON, TOML, YAML, and GitHub Actions validation
 - `just lint-docs` - Markdown formatting and spellcheck
 
-`just ci` runs `just check`, benchmark harness compilation, documentation, tests, examples, and deterministic example-output validation.
+`just ci` runs `just check`, benchmark harness compilation, documentation, tests, all-features Cobertura coverage, examples, and deterministic example-output validation.
 
 ## Setup
 
@@ -91,7 +91,7 @@ The initial `benches/stepping.rs` suite protects core transition costs:
 
 ## Coverage
 
-Coverage uses `cargo llvm-cov`.
+Coverage uses `cargo llvm-cov` with all crate features enabled.
 
 - Local HTML report: `just coverage`
 - CI Cobertura XML: `just coverage-ci`

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -43,7 +43,7 @@ For cross-repo muscle memory, the same checks are also available through grouped
 - `just lint-config` - JSON, TOML, YAML, and GitHub Actions validation
 - `just lint-docs` - Markdown formatting and spellcheck
 
-`just ci` runs `just check`, benchmark harness compilation, documentation, tests, all-features Cobertura coverage, examples, and deterministic example-output validation.
+`just ci` runs `just check`, benchmark harness compilation, documentation, tests, examples, and deterministic example-output validation.
 
 ## Setup
 

--- a/examples/ising_1d.rs
+++ b/examples/ising_1d.rs
@@ -90,7 +90,7 @@ fn main() -> Result<(), McmcError> {
     let target = Ising { coupling, beta };
     let proposal = SpinFlip;
     let chain = Chain::new(SpinChain::all_up(n_spins), &target)?;
-    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
+    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng)?;
 
     println!("1-D Ising model ({n_spins} spins, β={beta}, J={coupling}, seed={seed})");
     println!(
@@ -107,7 +107,7 @@ fn main() -> Result<(), McmcError> {
     );
 
     // Reset counters so acceptance rate reflects production only
-    sampler.chain_mut().reset_counters();
+    sampler.reset_counters();
 
     // Collect samples
     let n_samples: u32 = 20_000;

--- a/examples/iterator_sampling.rs
+++ b/examples/iterator_sampling.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), McmcError> {
     let target = StandardNormal;
     let proposal = RandomWalk { width: 1.0 };
     let chain = Chain::new(Scalar(5.0), &target)?;
-    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
+    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng)?;
 
     println!("Iterator-based sampling of N(0,1) (seed={seed})");
 
@@ -56,7 +56,7 @@ fn main() -> Result<(), McmcError> {
     println!("Burn-in complete ({burn_in} steps via iterator)");
 
     // Reset counters so acceptance rate reflects production only
-    sampler.chain_mut().reset_counters();
+    sampler.reset_counters();
 
     // Collect samples: use step() when you need to read state between steps.
     // The iterator yields Result<(), McmcError> (not the state), so collecting

--- a/examples/normal_1d.rs
+++ b/examples/normal_1d.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), McmcError> {
     let target = StandardNormal;
     let proposal = RandomWalk { width: 1.0 };
     let chain = Chain::new(Scalar(5.0), &target)?;
-    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng);
+    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng)?;
 
     println!("Sampling N(0,1) with Metropolis–Hastings (seed={seed})");
     println!("Initial state: x = {:.3}", sampler.chain_ref().state().0);
@@ -56,7 +56,7 @@ fn main() -> Result<(), McmcError> {
     );
 
     // Reset counters so acceptance rate reflects production only
-    sampler.chain_mut().reset_counters();
+    sampler.reset_counters();
 
     // Collect samples
     let n_samples = 10_000;

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ cargo_llvm_cov_version := "0.8.5"
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes examples from reports while allowing tests to exercise library code.
 _coverage_base_args := '''--ignore-filename-regex '(^|/)examples/' \
-  --workspace --lib --tests \
+  --workspace --all-features --lib --tests \
   --verbose'''
 
 # Internal helpers: ensure external tooling is installed
@@ -121,7 +121,7 @@ check-fast:
     cargo check
 
 # CI simulation: comprehensive validation
-ci: check bench-compile doc test-all examples validate-examples
+ci: check bench-compile doc test-all coverage-ci examples validate-examples
     @echo "🎯 CI checks complete!"
 
 # Clean build artifacts

--- a/justfile
+++ b/justfile
@@ -121,7 +121,7 @@ check-fast:
     cargo check
 
 # CI simulation: comprehensive validation
-ci: check bench-compile doc test-all coverage-ci examples validate-examples
+ci: check bench-compile doc test-all examples validate-examples
     @echo "🎯 CI checks complete!"
 
 # Clean build artifacts

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -171,7 +171,10 @@ impl<S> ChainCheckpoint<S> {
         self.rejected
     }
 
-    /// Total number of counted steps in the checkpoint.
+    /// Total number of counted steps in the checkpoint (`accepted + rejected`).
+    ///
+    /// The sum saturates at [`usize::MAX`] on overflow rather than wrapping or
+    /// panicking.
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::*;
@@ -383,6 +386,11 @@ impl<S> Chain<S> {
         }
         self.log_prob = log_prob;
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn set_cached_log_prob_for_testing(&mut self, log_prob: f64) {
+        self.log_prob = log_prob;
     }
 
     /// Perform a single Metropolis–Hastings step with a by-value proposal.
@@ -841,6 +849,9 @@ impl<S> Chain<S> {
 
     /// Total number of steps taken (`accepted + rejected`).
     ///
+    /// The sum saturates at [`usize::MAX`] on overflow rather than wrapping or
+    /// panicking.
+    ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
@@ -870,6 +881,11 @@ impl<S> Chain<S> {
 
     /// Acceptance rate of the chain.
     ///
+    /// Returns `accepted / (accepted + rejected)`, or `0.0` when no steps have
+    /// been counted.  The ratio is computed in floating point so very large
+    /// counters preserve the acceptance fraction instead of saturating the
+    /// denominator first.
+    ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
@@ -896,15 +912,12 @@ impl<S> Chain<S> {
     #[must_use]
     #[expect(
         clippy::cast_precision_loss,
-        reason = "acceptance counts won't exceed 2^52"
+        reason = "large acceptance counts are intentionally converted for ratio calculation"
     )]
     pub fn acceptance_rate(&self) -> f64 {
-        let total = self.accepted.saturating_add(self.rejected);
-        if total == 0 {
-            0.0
-        } else {
-            self.accepted as f64 / total as f64
-        }
+        let accepted = self.accepted as f64;
+        let total = accepted + self.rejected as f64;
+        if total == 0.0 { 0.0 } else { accepted / total }
     }
 
     /// Reset acceptance and rejection counters to zero.

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,10 +1,14 @@
 //! MCMC chain implementation.
 
+use core::hint::cold_path;
+
 use std::error::Error;
 use std::fmt;
 
 use rand::distr::Open01;
 use rand::{Rng, RngExt};
+#[cfg(feature = "serde")]
+use serde::{Serialize, Serializer};
 
 use crate::{DelayedProposal, McmcError, Proposal, ProposalMut, Target};
 
@@ -17,6 +21,7 @@ fn accept_from_log_uniform(log_alpha: f64, log_u: f64) -> bool {
     // NaN can arise from valid inputs such as -inf - (-inf); treat that as a
     // zero acceptance probability instead of relying on float comparison quirks.
     if log_alpha.is_nan() {
+        cold_path();
         false
     } else if log_alpha >= 0.0 {
         true
@@ -41,9 +46,11 @@ fn accept_log_alpha<R: Rng + ?Sized>(log_alpha: f64, rng: &mut R) -> bool {
 /// with the proposal-specific `McmcError` variants.
 fn check_proposed_log_prob(log_prob: f64) -> Result<(), McmcError> {
     if log_prob.is_nan() {
+        cold_path();
         return Err(McmcError::NanProposedLogProb);
     }
     if log_prob == f64::INFINITY {
+        cold_path();
         return Err(McmcError::InfiniteProposedLogProb);
     }
     Ok(())
@@ -55,9 +62,11 @@ fn check_proposed_log_prob(log_prob: f64) -> Result<(), McmcError> {
 /// implementation while preserving identical NaN and `+inf` error semantics.
 fn check_log_q_ratio(log_q: f64) -> Result<(), McmcError> {
     if log_q.is_nan() {
+        cold_path();
         return Err(McmcError::NanLogQRatio);
     }
     if log_q == f64::INFINITY {
+        cold_path();
         return Err(McmcError::InfiniteLogQRatio);
     }
     Ok(())
@@ -83,6 +92,111 @@ pub struct Step<I> {
 
 /// Telemetry for a delayed-commit Metropolis-Hastings step.
 pub type DelayedStep<I> = Step<I>;
+
+/// Portable checkpoint data for a [`Chain`].
+///
+/// A checkpoint stores the chain state and counters, but deliberately does not
+/// store the cached log-probability. Restore checkpoints with
+/// [`Chain::from_checkpoint`] so the cache is recomputed from the target that
+/// will be used for resumed sampling.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub struct ChainCheckpoint<S> {
+    /// Current state.
+    state: S,
+    /// Number of accepted moves.
+    accepted: usize,
+    /// Number of rejected moves.
+    rejected: usize,
+}
+
+impl<S> ChainCheckpoint<S> {
+    /// Create a checkpoint from owned state and counters.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// let checkpoint = ChainCheckpoint::new(1.0_f64, 2, 3);
+    ///
+    /// assert_eq!(*checkpoint.state(), 1.0);
+    /// assert_eq!(checkpoint.accepted(), 2);
+    /// assert_eq!(checkpoint.rejected(), 3);
+    /// assert_eq!(checkpoint.total_steps(), 5);
+    /// ```
+    pub const fn new(state: S, accepted: usize, rejected: usize) -> Self {
+        Self {
+            state,
+            accepted,
+            rejected,
+        }
+    }
+
+    /// Shared reference to the checkpointed state.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// let checkpoint = ChainCheckpoint::new("state", 0, 0);
+    /// assert_eq!(checkpoint.state(), &"state");
+    /// ```
+    #[must_use]
+    pub const fn state(&self) -> &S {
+        &self.state
+    }
+
+    /// Number of accepted moves in the checkpoint.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// let checkpoint = ChainCheckpoint::new((), 7, 11);
+    /// assert_eq!(checkpoint.accepted(), 7);
+    /// ```
+    #[must_use]
+    pub const fn accepted(&self) -> usize {
+        self.accepted
+    }
+
+    /// Number of rejected moves in the checkpoint.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// let checkpoint = ChainCheckpoint::new((), 7, 11);
+    /// assert_eq!(checkpoint.rejected(), 11);
+    /// ```
+    #[must_use]
+    pub const fn rejected(&self) -> usize {
+        self.rejected
+    }
+
+    /// Total number of counted steps in the checkpoint.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// let checkpoint = ChainCheckpoint::new((), 7, 11);
+    /// assert_eq!(checkpoint.total_steps(), 18);
+    /// ```
+    #[must_use]
+    pub const fn total_steps(&self) -> usize {
+        self.accepted.saturating_add(self.rejected)
+    }
+
+    /// Consume the checkpoint into its raw parts.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// let checkpoint = ChainCheckpoint::new("state", 7, 11);
+    /// assert_eq!(checkpoint.into_parts(), ("state", 7, 11));
+    /// ```
+    #[must_use]
+    pub fn into_parts(self) -> (S, usize, usize) {
+        (self.state, self.accepted, self.rejected)
+    }
+}
 
 /// Errors from a delayed-commit Metropolis-Hastings step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -138,7 +252,6 @@ impl<E: Error + 'static> Error for DelayedStepError<E> {
 }
 
 /// A single MCMC chain.
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug)]
 #[must_use]
 pub struct Chain<S> {
@@ -152,17 +265,28 @@ pub struct Chain<S> {
     rejected: usize,
 }
 
+#[cfg(feature = "serde")]
+impl<S: Serialize> Serialize for Chain<S> {
+    fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+    where
+        Ser: Serializer,
+    {
+        self.checkpoint().serialize(serializer)
+    }
+}
+
 impl<S> Chain<S> {
     /// Create a new chain from an initial state.
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::*;
     ///
     /// # struct T;
     /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
     /// let chain = Chain::new(1.0_f64, &T)?;
     /// assert_eq!(chain.accepted(), 0);
-    /// assert!((chain.log_prob() - (-0.5)).abs() < 1e-12);
+    /// assert_relative_eq!(chain.log_prob(), -0.5, epsilon = 1e-12);
     /// # Ok::<(), McmcError>(())
     /// ```
     ///
@@ -174,9 +298,11 @@ impl<S> Chain<S> {
     pub fn new<T: Target<S>>(initial: S, target: &T) -> Result<Self, McmcError> {
         let log_prob = target.log_prob(&initial);
         if log_prob.is_nan() {
+            cold_path();
             return Err(McmcError::NanInitialLogProb);
         }
         if log_prob == f64::INFINITY {
+            cold_path();
             return Err(McmcError::InfiniteInitialLogProb);
         }
         Ok(Self {
@@ -185,6 +311,78 @@ impl<S> Chain<S> {
             accepted: 0,
             rejected: 0,
         })
+    }
+
+    /// Restore a chain from checkpoint data and a target distribution.
+    ///
+    /// The checkpoint does not contain a cached log-probability. This method
+    /// recomputes the cache from `target` and preserves the checkpointed
+    /// counters.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`McmcError::NanCheckpointLogProb`] or
+    /// [`McmcError::InfiniteCheckpointLogProb`] if the target's
+    /// log-probability for the checkpoint state is NaN or +∞.
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// struct Normal;
+    /// impl Target<f64> for Normal {
+    ///     fn log_prob(&self, state: &f64) -> f64 { -0.5 * state * state }
+    /// }
+    ///
+    /// let checkpoint = ChainCheckpoint::new(2.0, 7, 11);
+    /// let chain = Chain::from_checkpoint(checkpoint, &Normal)?;
+    ///
+    /// assert_eq!(*chain.state(), 2.0);
+    /// assert_relative_eq!(chain.log_prob(), -2.0, epsilon = 1e-12);
+    /// assert_eq!(chain.total_steps(), 18);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub fn from_checkpoint<T: Target<S>>(
+        checkpoint: ChainCheckpoint<S>,
+        target: &T,
+    ) -> Result<Self, McmcError> {
+        let (state, accepted, rejected) = checkpoint.into_parts();
+        let log_prob = target.log_prob(&state);
+        if log_prob.is_nan() {
+            cold_path();
+            return Err(McmcError::NanCheckpointLogProb);
+        }
+        if log_prob == f64::INFINITY {
+            cold_path();
+            return Err(McmcError::InfiniteCheckpointLogProb);
+        }
+        Ok(Self {
+            state,
+            log_prob,
+            accepted,
+            rejected,
+        })
+    }
+
+    /// Refresh the cached log-probability for the current state.
+    ///
+    /// This is used when a chain is paired with a sampler target, so resumed or
+    /// transferred chains do not continue sampling from a stale cache.
+    pub(crate) fn refresh_current_log_prob<T: Target<S>>(
+        &mut self,
+        target: &T,
+    ) -> Result<(), McmcError> {
+        let log_prob = target.log_prob(&self.state);
+        if log_prob.is_nan() {
+            cold_path();
+            return Err(McmcError::NanCurrentLogProb);
+        }
+        if log_prob == f64::INFINITY {
+            cold_path();
+            return Err(McmcError::InfiniteCurrentLogProb);
+        }
+        self.log_prob = log_prob;
+        Ok(())
     }
 
     /// Perform a single Metropolis–Hastings step with a by-value proposal.
@@ -240,9 +438,9 @@ impl<S> Chain<S> {
         if accept {
             self.state = proposed;
             self.log_prob = log_prob_new;
-            self.accepted += 1;
+            self.accepted = self.accepted.saturating_add(1);
         } else {
-            self.rejected += 1;
+            self.rejected = self.rejected.saturating_add(1);
         }
         Ok(())
     }
@@ -291,7 +489,7 @@ impl<S> Chain<S> {
         rng: &mut R,
     ) -> Result<bool, McmcError> {
         let Some(token) = proposal.propose_mut(&mut self.state, rng) else {
-            self.rejected += 1;
+            self.rejected = self.rejected.saturating_add(1);
             return Ok(false);
         };
 
@@ -313,10 +511,10 @@ impl<S> Chain<S> {
 
         if accept {
             self.log_prob = log_prob_new;
-            self.accepted += 1;
+            self.accepted = self.accepted.saturating_add(1);
         } else {
             proposal.undo(&mut self.state, token);
-            self.rejected += 1;
+            self.rejected = self.rejected.saturating_add(1);
         }
         Ok(accept)
     }
@@ -418,7 +616,7 @@ impl<S> Chain<S> {
             .propose_plan(&self.state, rng)
             .map_err(DelayedStepError::Plan)?
         else {
-            self.rejected += 1;
+            self.rejected = self.rejected.saturating_add(1);
             return Ok(Step {
                 accepted: false,
                 proposed: false,
@@ -448,7 +646,7 @@ impl<S> Chain<S> {
                 .commit(&mut self.state, plan, rng)
                 .map_err(DelayedStepError::Commit)?;
             self.log_prob = log_prob_new;
-            self.accepted += 1;
+            self.accepted = self.accepted.saturating_add(1);
             Ok(Step {
                 accepted: true,
                 proposed: true,
@@ -458,7 +656,7 @@ impl<S> Chain<S> {
                 log_alpha: Some(log_alpha),
             })
         } else {
-            self.rejected += 1;
+            self.rejected = self.rejected.saturating_add(1);
             Ok(Step {
                 accepted: false,
                 proposed: true,
@@ -473,12 +671,13 @@ impl<S> Chain<S> {
     /// Shared reference to the current state.
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::*;
     ///
     /// # struct T;
     /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
     /// let chain = Chain::new(1.0_f64, &T)?;
-    /// assert!((*chain.state() - 1.0).abs() < f64::EPSILON);
+    /// assert_relative_eq!(*chain.state(), 1.0);
     /// # Ok::<(), McmcError>(())
     /// ```
     #[must_use]
@@ -499,14 +698,15 @@ impl<S> Chain<S> {
     /// error).
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::*;
     ///
     /// # struct T;
     /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
     /// let mut chain = Chain::new(0.0_f64, &T)?;
     /// chain.replace_state(2.0, &T)?;
-    /// assert!((*chain.state() - 2.0).abs() < f64::EPSILON);
-    /// assert!((chain.log_prob() - (-2.0)).abs() < 1e-12);
+    /// assert_relative_eq!(*chain.state(), 2.0);
+    /// assert_relative_eq!(chain.log_prob(), -2.0, epsilon = 1e-12);
     /// # Ok::<(), McmcError>(())
     /// ```
     pub fn replace_state<T: Target<S>>(
@@ -516,9 +716,11 @@ impl<S> Chain<S> {
     ) -> Result<(), McmcError> {
         let lp = target.log_prob(&new_state);
         if lp.is_nan() {
+            cold_path();
             return Err(McmcError::NanReplacementLogProb);
         }
         if lp == f64::INFINITY {
+            cold_path();
             return Err(McmcError::InfiniteReplacementLogProb);
         }
         self.state = new_state;
@@ -529,13 +731,14 @@ impl<S> Chain<S> {
     /// Consume the chain and return the state.
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::*;
     ///
     /// # struct T;
     /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
     /// let chain = Chain::new(3.0_f64, &T)?;
     /// let state = chain.into_state();
-    /// assert!((state - 3.0).abs() < f64::EPSILON);
+    /// assert_relative_eq!(state, 3.0);
     /// # Ok::<(), McmcError>(())
     /// ```
     #[must_use]
@@ -543,9 +746,52 @@ impl<S> Chain<S> {
         self.state
     }
 
+    /// Borrow checkpoint data for serialization without cloning the state.
+    ///
+    /// Use [`into_checkpoint`](Self::into_checkpoint) when an owned checkpoint
+    /// is needed.
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// # struct T;
+    /// # impl Target<String> for T { fn log_prob(&self, _: &String) -> f64 { 0.0 } }
+    /// let chain = Chain::new(String::from("state"), &T)?;
+    /// let checkpoint = chain.checkpoint();
+    ///
+    /// assert_eq!(checkpoint.state().as_str(), "state");
+    /// assert_eq!(checkpoint.total_steps(), 0);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub const fn checkpoint(&self) -> ChainCheckpoint<&S> {
+        ChainCheckpoint::new(&self.state, self.accepted, self.rejected)
+    }
+
+    /// Consume the chain into an owned checkpoint.
+    ///
+    /// Restore the returned checkpoint with [`from_checkpoint`](Self::from_checkpoint)
+    /// and the target that will be used for resumed sampling.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::*;
+    ///
+    /// # struct T;
+    /// # impl Target<String> for T { fn log_prob(&self, _: &String) -> f64 { 0.0 } }
+    /// let chain = Chain::new(String::from("state"), &T)?;
+    /// let checkpoint = chain.into_checkpoint();
+    ///
+    /// assert_eq!(checkpoint.into_parts(), (String::from("state"), 0, 0));
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub fn into_checkpoint(self) -> ChainCheckpoint<S> {
+        ChainCheckpoint::new(self.state, self.accepted, self.rejected)
+    }
+
     /// Current log-probability of the chain state.
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::*;
     ///
     /// # struct T;
@@ -553,7 +799,7 @@ impl<S> Chain<S> {
     /// #     fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x }
     /// # }
     /// let chain = Chain::new(1.0_f64, &T)?;
-    /// assert!((chain.log_prob() - (-0.5)).abs() < 1e-12);
+    /// assert_relative_eq!(chain.log_prob(), -0.5, epsilon = 1e-12);
     /// # Ok::<(), McmcError>(())
     /// ```
     #[must_use]
@@ -619,7 +865,7 @@ impl<S> Chain<S> {
     /// ```
     #[must_use]
     pub const fn total_steps(&self) -> usize {
-        self.accepted + self.rejected
+        self.accepted.saturating_add(self.rejected)
     }
 
     /// Acceptance rate of the chain.
@@ -653,7 +899,7 @@ impl<S> Chain<S> {
         reason = "acceptance counts won't exceed 2^52"
     )]
     pub fn acceptance_rate(&self) -> f64 {
-        let total = self.accepted + self.rejected;
+        let total = self.accepted.saturating_add(self.rejected);
         if total == 0 {
             0.0
         } else {
@@ -705,8 +951,10 @@ impl<S> Chain<S> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use approx::assert_relative_eq;
     use rand::{SeedableRng, rngs::StdRng};
+
+    use super::*;
 
     // --- Test fixtures ---
 
@@ -754,16 +1002,10 @@ mod tests {
     #[test]
     fn new_initial_log_prob() {
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        assert!(
-            (chain.log_prob()).abs() < 1e-12,
-            "log_prob at 0 should be 0.0"
-        );
+        assert_relative_eq!(chain.log_prob(), 0.0, epsilon = 1e-12);
 
         let chain2 = Chain::new(Scalar(1.0), &Normal).unwrap();
-        assert!(
-            (chain2.log_prob() - (-0.5)).abs() < 1e-12,
-            "log_prob at 1 should be -0.5"
-        );
+        assert_relative_eq!(chain2.log_prob(), -0.5, epsilon = 1e-12);
     }
 
     #[cfg(feature = "serde")]
@@ -774,10 +1016,15 @@ mod tests {
         chain.step(&Normal, &FixedProposal(0.0), &mut rng).unwrap();
 
         let checkpoint = serde_json::to_string(&chain).unwrap();
-        let mut restored: Chain<Scalar> = serde_json::from_str(&checkpoint).unwrap();
+        let checkpoint: ChainCheckpoint<Scalar> = serde_json::from_str(&checkpoint).unwrap();
+        let mut restored = Chain::from_checkpoint(checkpoint, &Normal).unwrap();
 
         assert_eq!(restored.state(), &Scalar(0.0));
-        assert!((restored.log_prob() - Normal.log_prob(restored.state())).abs() < 1e-12);
+        assert_relative_eq!(
+            restored.log_prob(),
+            Normal.log_prob(restored.state()),
+            epsilon = 1e-12
+        );
         assert_eq!(restored.accepted(), 1);
         assert_eq!(restored.rejected(), 0);
         assert_eq!(restored.total_steps(), 1);
@@ -787,7 +1034,54 @@ mod tests {
             .unwrap();
 
         assert_eq!(restored.total_steps(), 2);
-        assert!((restored.log_prob() - Normal.log_prob(restored.state())).abs() < 1e-12);
+        assert_relative_eq!(
+            restored.log_prob(),
+            Normal.log_prob(restored.state()),
+            epsilon = 1e-12
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_checkpoint_does_not_trust_cached_log_prob() {
+        let checkpoint = r#"{"state":2.0,"log_prob":1000.0,"accepted":3,"rejected":4}"#;
+        let checkpoint: ChainCheckpoint<Scalar> = serde_json::from_str(checkpoint).unwrap();
+        let restored = Chain::from_checkpoint(checkpoint, &Normal).unwrap();
+
+        assert_eq!(restored.state(), &Scalar(2.0));
+        assert_relative_eq!(restored.log_prob(), -2.0, epsilon = 1e-12);
+        assert_eq!(restored.accepted(), 3);
+        assert_eq!(restored.rejected(), 4);
+    }
+
+    #[test]
+    fn from_checkpoint_rejects_invalid_target_log_prob() {
+        struct NanTarget;
+        impl Target<Scalar> for NanTarget {
+            fn log_prob(&self, _: &Scalar) -> f64 {
+                f64::NAN
+            }
+        }
+
+        let checkpoint = ChainCheckpoint::new(Scalar(0.0), 1, 2);
+        let result = Chain::from_checkpoint(checkpoint, &NanTarget);
+
+        assert!(matches!(result, Err(McmcError::NanCheckpointLogProb)));
+    }
+
+    #[test]
+    fn from_checkpoint_rejects_infinite_target_log_prob() {
+        struct InfTarget;
+        impl Target<Scalar> for InfTarget {
+            fn log_prob(&self, _: &Scalar) -> f64 {
+                f64::INFINITY
+            }
+        }
+
+        let checkpoint = ChainCheckpoint::new(Scalar(0.0), 1, 2);
+        let result = Chain::from_checkpoint(checkpoint, &InfTarget);
+
+        assert!(matches!(result, Err(McmcError::InfiniteCheckpointLogProb)));
     }
 
     #[cfg(feature = "serde")]
@@ -804,7 +1098,7 @@ mod tests {
 
         let chain = Chain::new(NonSerializableState(1.0), &NonSerializableTarget).unwrap();
 
-        assert!((chain.log_prob() - (-0.5)).abs() < 1e-12);
+        assert_relative_eq!(chain.log_prob(), -0.5, epsilon = 1e-12);
         assert_eq!(chain.total_steps(), 0);
     }
 
@@ -813,7 +1107,7 @@ mod tests {
     #[test]
     fn acceptance_rate_zero_steps() {
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        assert!((chain.acceptance_rate()).abs() < f64::EPSILON);
+        assert_relative_eq!(chain.acceptance_rate(), 0.0);
     }
 
     #[test]
@@ -1087,10 +1381,7 @@ mod tests {
         }
         let mean = sum / f64::from(n);
 
-        assert!(
-            mean.abs() < 0.1,
-            "Sample mean {mean} should be near 0 for standard normal"
-        );
+        assert_relative_eq!(mean, 0.0, epsilon = 0.1);
 
         let rate = chain.acceptance_rate();
         assert!(
@@ -1105,10 +1396,7 @@ mod tests {
     fn symmetric_proposal_zero_log_q() {
         let proposal = RandomWalk { width: 1.0 };
         let ratio = proposal.log_q_ratio(&Scalar(0.0), &Scalar(1.0));
-        assert!(
-            ratio.abs() < f64::EPSILON,
-            "Symmetric proposal should have log_q_ratio = 0"
-        );
+        assert_relative_eq!(ratio, 0.0);
     }
 
     // =====================================================================
@@ -1212,10 +1500,7 @@ mod tests {
 
         assert!(!accepted, "Should return false when proposal returns None");
         assert_eq!(chain.state, MutScalar(1.0), "State should be unchanged");
-        assert!(
-            (chain.log_prob() - log_prob).abs() < f64::EPSILON,
-            "Cached log_prob should remain synchronized after no-move proposal"
-        );
+        assert_relative_eq!(chain.log_prob(), log_prob);
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 1);
     }
@@ -1236,10 +1521,7 @@ mod tests {
             MutScalar(1.0),
             "ProposalMut::propose_mut(None) must leave state unchanged"
         );
-        assert!(
-            (chain.log_prob() - log_prob).abs() < f64::EPSILON,
-            "Cached log_prob should remain synchronized after internally rolled-back no-move"
-        );
+        assert_relative_eq!(chain.log_prob(), log_prob);
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 1);
     }
@@ -1393,10 +1675,7 @@ mod tests {
         }
         let mean = sum / f64::from(n);
 
-        assert!(
-            mean.abs() < 0.1,
-            "Sample mean {mean} should be near 0 for standard normal"
-        );
+        assert_relative_eq!(mean, 0.0, epsilon = 0.1);
 
         let rate = chain.acceptance_rate();
         assert!(
@@ -1427,10 +1706,7 @@ mod tests {
     fn symmetric_proposal_mut_zero_log_q() {
         let proposal = FixedMutProposal(0.0);
         let ratio = proposal.log_q_ratio(&MutScalar(1.0), &2.0);
-        assert!(
-            ratio.abs() < f64::EPSILON,
-            "Default ProposalMut log_q_ratio should be 0"
-        );
+        assert_relative_eq!(ratio, 0.0);
     }
 
     // =====================================================================
@@ -1574,7 +1850,7 @@ mod tests {
         assert!(step.accepted);
         assert!(step.proposed);
         assert_eq!(step.info, Some(0.0));
-        assert!((step.log_prob_before - (-2.0)).abs() < 1e-12);
+        assert_relative_eq!(step.log_prob_before, -2.0, epsilon = 1e-12);
         assert_eq!(step.log_prob_after, Some(0.0));
         assert_eq!(step.log_alpha, Some(2.0));
         assert_eq!(chain.state, MutScalar(0.0));
@@ -1595,7 +1871,7 @@ mod tests {
         assert!(!step.accepted);
         assert!(step.proposed);
         assert_eq!(step.info, Some(100.0));
-        assert!(step.log_prob_before.abs() < f64::EPSILON);
+        assert_relative_eq!(step.log_prob_before, 0.0);
         assert_eq!(step.log_prob_after, None);
         assert_eq!(step.log_alpha, Some(-5000.0));
         assert_eq!(chain.state, MutScalar(0.0));
@@ -1617,7 +1893,7 @@ mod tests {
         assert!(!step.accepted);
         assert!(!step.proposed);
         assert_eq!(step.info, None);
-        assert!((step.log_prob_before - log_prob).abs() < f64::EPSILON);
+        assert_relative_eq!(step.log_prob_before, log_prob);
         assert_eq!(step.log_prob_after, None);
         assert_eq!(step.log_alpha, None);
         assert_eq!(chain.state, MutScalar(1.0));
@@ -1816,7 +2092,7 @@ mod tests {
             Err(DelayedStepError::Commit(DelayedFixtureError::Commit))
         ));
         assert_eq!(chain.state, MutScalar(2.0));
-        assert!((chain.log_prob() - log_prob).abs() < f64::EPSILON);
+        assert_relative_eq!(chain.log_prob(), log_prob);
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 0);
     }
@@ -1876,7 +2152,7 @@ mod tests {
             Err(DelayedStepError::Commit(DelayedFixtureError::Commit))
         ));
         assert_eq!(chain.state, MutScalar(2.0));
-        assert!((chain.log_prob() - log_prob).abs() < f64::EPSILON);
+        assert_relative_eq!(chain.log_prob(), log_prob);
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 0);
     }
@@ -1888,10 +2164,7 @@ mod tests {
         let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
         chain.replace_state(Scalar(2.0), &Normal).unwrap();
         assert_eq!(chain.state, Scalar(2.0));
-        assert!(
-            (chain.log_prob() - (-2.0)).abs() < 1e-12,
-            "log_prob should be recomputed after replace_state"
-        );
+        assert_relative_eq!(chain.log_prob(), -2.0, epsilon = 1e-12);
     }
 
     #[test]
@@ -1947,7 +2220,7 @@ mod tests {
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 0);
         assert_eq!(chain.total_steps(), 0);
-        assert!((chain.acceptance_rate()).abs() < f64::EPSILON);
+        assert_relative_eq!(chain.acceptance_rate(), 0.0);
     }
 
     #[test]
@@ -1962,6 +2235,22 @@ mod tests {
         }
         assert_eq!(chain.total_steps(), steps);
         assert_eq!(chain.total_steps(), chain.accepted() + chain.rejected());
+    }
+
+    #[test]
+    fn checkpoint_total_steps_saturates_at_usize_max() {
+        let checkpoint = ChainCheckpoint::new((), usize::MAX, 1);
+
+        assert_eq!(checkpoint.total_steps(), usize::MAX);
+    }
+
+    #[test]
+    fn chain_total_steps_saturates_after_checkpoint_restore() {
+        let checkpoint = ChainCheckpoint::new(Scalar(0.0), usize::MAX, 1);
+        let chain = Chain::from_checkpoint(checkpoint, &Normal).unwrap();
+
+        assert_eq!(chain.total_steps(), usize::MAX);
+        assert_relative_eq!(chain.acceptance_rate(), 1.0);
     }
 
     // --- Asymmetric proposal tests ---

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,10 @@ pub enum McmcError {
     NanLogQRatio,
     /// Target returned NaN log-probability for a replacement state.
     NanReplacementLogProb,
+    /// Target returned NaN log-probability for a checkpoint state.
+    NanCheckpointLogProb,
+    /// Target returned NaN log-probability for the current chain state.
+    NanCurrentLogProb,
     /// Target returned +∞ log-probability for the initial state.
     ///
     /// This indicates infinite probability, which is invalid for any
@@ -37,6 +41,16 @@ pub enum McmcError {
     /// This indicates infinite probability, which is invalid for any
     /// proper (normalizable) distribution.
     InfiniteReplacementLogProb,
+    /// Target returned +∞ log-probability for a checkpoint state.
+    ///
+    /// This indicates infinite probability, which is invalid for any
+    /// proper (normalizable) distribution.
+    InfiniteCheckpointLogProb,
+    /// Target returned +∞ log-probability for the current chain state.
+    ///
+    /// This indicates infinite probability, which is invalid for any
+    /// proper (normalizable) distribution.
+    InfiniteCurrentLogProb,
 }
 
 impl fmt::Display for McmcError {
@@ -61,6 +75,18 @@ impl fmt::Display for McmcError {
                     "target returned NaN log-probability for a replacement state"
                 )
             }
+            Self::NanCheckpointLogProb => {
+                write!(
+                    f,
+                    "target returned NaN log-probability for a checkpoint state"
+                )
+            }
+            Self::NanCurrentLogProb => {
+                write!(
+                    f,
+                    "target returned NaN log-probability for the current chain state"
+                )
+            }
             Self::InfiniteInitialLogProb => {
                 write!(
                     f,
@@ -78,6 +104,18 @@ impl fmt::Display for McmcError {
                 write!(
                     f,
                     "target returned +inf log-probability for a replacement state"
+                )
+            }
+            Self::InfiniteCheckpointLogProb => {
+                write!(
+                    f,
+                    "target returned +inf log-probability for a checkpoint state"
+                )
+            }
+            Self::InfiniteCurrentLogProb => {
+                write!(
+                    f,
+                    "target returned +inf log-probability for the current chain state"
                 )
             }
         }
@@ -124,6 +162,24 @@ mod tests {
     }
 
     #[test]
+    fn display_nan_checkpoint_log_prob() {
+        let msg = McmcError::NanCheckpointLogProb.to_string();
+        assert_eq!(
+            msg,
+            "target returned NaN log-probability for a checkpoint state"
+        );
+    }
+
+    #[test]
+    fn display_nan_current_log_prob() {
+        let msg = McmcError::NanCurrentLogProb.to_string();
+        assert_eq!(
+            msg,
+            "target returned NaN log-probability for the current chain state"
+        );
+    }
+
+    #[test]
     fn display_infinite_initial_log_prob() {
         let msg = McmcError::InfiniteInitialLogProb.to_string();
         assert_eq!(
@@ -153,6 +209,24 @@ mod tests {
         assert_eq!(
             msg,
             "target returned +inf log-probability for a replacement state"
+        );
+    }
+
+    #[test]
+    fn display_infinite_checkpoint_log_prob() {
+        let msg = McmcError::InfiniteCheckpointLogProb.to_string();
+        assert_eq!(
+            msg,
+            "target returned +inf log-probability for a checkpoint state"
+        );
+    }
+
+    #[test]
+    fn display_infinite_current_log_prob() {
+        let msg = McmcError::InfiniteCurrentLogProb.to_string();
+        assert_eq!(
+            msg,
+            "target returned +inf log-probability for the current chain state"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,23 @@
 //! Markov Chain Monte Carlo (MCMC) framework.
 //!
+//! `markov-chain-monte-carlo` provides small, explicit Metropolis-Hastings
+//! tools for Rust projects with user-defined state spaces, proposal mechanisms,
+//! and measurement workflows.
+//!
+//! Use this crate when you need ordinary by-value proposals, rollback-safe
+//! mutation for large states, delayed commits, validated checkpoint restores, or
+//! streaming observables for long sampler runs.
+//!
+//! # Features
+//!
+//! - Generic `Chain<S>` and `Sampler` APIs over user-defined state spaces.
+//! - By-value, in-place, and delayed-commit proposal workflows.
+//! - Log-space acceptance with typed errors for invalid target or proposal
+//!   values.
+//! - Optional `serde` checkpoint serialization with validated restore flows.
+//! - Observables, thinning helpers, streaming statistics, and proposal
+//!   diagnostics.
+//!
 //! This API guide documents the crate's Metropolis-Hastings contracts,
 //! numerical semantics, proposal workflows, sampler helpers, observables, and
 //! streaming statistics. For installation, feature selection, and a concise
@@ -126,7 +144,8 @@
 //!
 //! let chain = Chain::new(1.0, &Normal)
 //!     .expect("normal target returns a finite log probability");
-//! let checkpoint = serde_json::to_string(&chain)?;
+//! let checkpoint = chain.checkpoint();
+//! let checkpoint = serde_json::to_string(&checkpoint)?;
 //! let checkpoint: ChainCheckpoint<f64> = serde_json::from_str(&checkpoint)?;
 //! let restored = Chain::from_checkpoint(checkpoint, &Normal)
 //!     .expect("normal target returns a finite checkpoint log probability");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,45 +1,15 @@
 //! Markov Chain Monte Carlo (MCMC) framework.
 //!
-//! 🚧 **Pre-release (0.x)** — This crate is under active development and
-//! not yet ready for production use. APIs may change without notice.
-//!
-//! `markov-chain-monte-carlo` provides a small, explicit Metropolis-Hastings
-//! toolkit for scientific Rust projects. It is designed for ordinary numeric
-//! states, large combinatorial state spaces, and proposal implementations that
-//! need rollback-safe mutation or delayed commits.  The crate aims to provide
-//! a composable, zero-cost abstraction for MCMC methods over arbitrary state
-//! spaces, including discrete and combinatorial systems (e.g., triangulations).
-//!
-//! Use this crate when you want:
-//!
-//! - A generic Metropolis-Hastings chain over user-defined state spaces
-//! - By-value, in-place, and delayed-commit proposal APIs
-//! - Log-space acceptance calculations with NaN/+infinity checks
-//! - Observable measurement APIs for collecting derived quantities
-//! - Streaming means, variances, and binning error estimates
-//! - Thinning helpers for long sampler runs
-//! - Optional `serde` checkpointing for chains and sampler handles
-//! - Detailed-balance diagnostics for proposal development
+//! This API guide documents the crate's Metropolis-Hastings contracts,
+//! numerical semantics, proposal workflows, sampler helpers, observables, and
+//! streaming statistics. For installation, feature selection, and a concise
+//! orientation to the crate, see the hand-written sections at the top of the
+//! repository README.
 //!
 //! [`Target::log_prob`] should return an unnormalized natural log-probability
 //! or log-density.  Additive constants are fine because Metropolis-Hastings
 //! only uses differences, but arbitrary scores or logits will sample a
 //! different distribution.
-//!
-//! # Features
-//!
-//! - `Target<S>` for unnormalized log probabilities or log densities
-//! - `Proposal<S>` for simple by-value proposals
-//! - `ProposalMut<S>` for in-place mutation with rollback tokens
-//! - `DelayedProposal<S>` for accept-before-mutation workflows with concrete
-//!   plans
-//! - `Chain<S>` with by-value, in-place, and delayed step methods
-//! - `Sampler<S, T, P, R>` for ergonomic bulk runs and iterator-based sampling
-//! - Observables, fallible observations, and sample buffers
-//! - Online statistics and binning analysis for correlated samples
-//! - Thinned run and observation helpers
-//! - Optional `serde` feature for checkpointing
-//! - Detailed-balance checks for by-value, in-place, and delayed proposals
 //!
 //! # Scientific basis and scope
 //!
@@ -137,14 +107,16 @@
 //! proposal-development checks over discrete or otherwise exactly comparable
 //! states.
 //!
-//! Enable the optional `serde` feature to serialize and deserialize
-//! [`Chain<S>`] when `S` implements serde's traits.  [`Sampler`] also derives
-//! serialization when all stored handles support it, but the portable
-//! checkpoint for resuming a run is the owned [`Chain<S>`]; targets, proposals,
-//! and RNG streams are reconstructed by the caller.
+//! Enable the optional `serde` feature to serialize [`Chain<S>`] checkpoints
+//! when `S` implements serde's traits.  Restore checkpoint data with
+//! [`Chain::from_checkpoint`] so the cached log-probability is recomputed from
+//! the target used for resumed sampling.  [`Sampler`] also derives
+//! serialization when all stored handles support it, but targets, proposals,
+//! and RNG streams are reconstructed by the caller for portable resumes.
 //!
 //! ```
 //! # #[cfg(feature = "serde")] {
+//! use approx::assert_relative_eq;
 //! use markov_chain_monte_carlo::prelude::*;
 //!
 //! struct Normal;
@@ -152,12 +124,17 @@
 //!     fn log_prob(&self, state: &f64) -> f64 { -0.5 * state * state }
 //! }
 //!
-//! let Ok(chain) = Chain::new(1.0, &Normal) else {
-//!     unreachable!("normal target returns a finite log probability");
-//! };
+//! let chain = Chain::new(1.0, &Normal)
+//!     .expect("normal target returns a finite log probability");
 //! let checkpoint = serde_json::to_string(&chain)?;
-//! let restored: Chain<f64> = serde_json::from_str(&checkpoint)?;
-//! assert!((restored.log_prob() - Normal.log_prob(restored.state())).abs() < 1e-12);
+//! let checkpoint: ChainCheckpoint<f64> = serde_json::from_str(&checkpoint)?;
+//! let restored = Chain::from_checkpoint(checkpoint, &Normal)
+//!     .expect("normal target returns a finite checkpoint log probability");
+//! assert_relative_eq!(
+//!     restored.log_prob(),
+//!     Normal.log_prob(restored.state()),
+//!     epsilon = 1e-12
+//! );
 //! # }
 //! # Ok::<(), serde_json::Error>(())
 //! ```
@@ -353,11 +330,11 @@
 //! # }
 //! let mut rng = StdRng::seed_from_u64(42);
 //! let chain = Chain::new(Scalar(0.0), &Normal)?;
-//! let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng);
+//! let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng)?;
 //!
 //! // Burn-in
 //! sampler.run(1000)?;
-//! sampler.chain_mut().reset_counters();
+//! sampler.reset_counters();
 //!
 //! // Production
 //! sampler.run(10_000)?;
@@ -387,7 +364,7 @@
 //! # }
 //! let mut rng = StdRng::seed_from_u64(42);
 //! let chain = Chain::new(Scalar(0.0), &Normal)?;
-//! let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng);
+//! let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng)?;
 //! let mut energy = |state: &Scalar| 0.5 * state.0 * state.0;
 //!
 //! let samples: SampleBuffer<f64> = sampler.run_observing(256, &mut energy)?;
@@ -430,7 +407,7 @@
 //! # }
 //! let mut rng = StdRng::seed_from_u64(42);
 //! let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
-//! let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+//! let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
 //! let mut coordinate = |state: &f64| *state;
 //! let mut stats = OnlineStats::new();
 //!
@@ -447,7 +424,7 @@ mod statistics;
 mod testing;
 mod traits;
 
-pub use chain::{Chain, DelayedStep, DelayedStepError, Step};
+pub use chain::{Chain, ChainCheckpoint, DelayedStep, DelayedStepError, Step};
 pub use error::McmcError;
 pub use observable::{
     Observable, ObservedStepError, ObservedStreamError, SampleBuffer, TryAccumulator, TryObservable,
@@ -476,16 +453,11 @@ pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 /// The top-level prelude contains only the shared sampling foundation:
 ///
 /// ```
-/// use std::convert::Infallible;
-///
 /// use markov_chain_monte_carlo::prelude::*;
 ///
 /// fn accepts_target<T: Target<f64>>(_: &T) {}
 /// fn accepts_stats(_: OnlineStats, _: BinningAnalysis) {}
 /// fn accepts_stream_result(_: ObservedIntoRunResult<McmcError, StatisticsError>) {}
-/// fn accepts_delayed_stream_result(
-///     _: TryObservedDelayedIntoRunResult<Infallible, StatisticsError, StatisticsError>,
-/// ) {}
 /// ```
 ///
 /// Workflow-specific preludes are available when tests, examples, or
@@ -516,13 +488,11 @@ pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
 /// ```
 pub mod prelude {
     pub use crate::{
-        BinningAnalysis, BinningEstimate, Chain, McmcError, Observable, ObservedIntoRunResult,
-        ObservedStepError, ObservedStreamError, OnlineStats, SampleBuffer, Sampler,
-        StatisticsError, Target, ThinnedObservedDelayedIntoRunResult, ThinnedObservedIntoRunResult,
-        ThinnedRunResult, ThinningError, TryAccumulator, TryObservable,
-        TryObservedDelayedIntoRunResult, TryObservedIntoRunResult,
-        TryThinnedObservedDelayedIntoRunResult, TryThinnedObservedIntoRunResult,
-        TryThinnedObservedRunResult,
+        BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, McmcError, Observable,
+        ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats, SampleBuffer,
+        Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult, ThinnedRunResult,
+        ThinningError, TryAccumulator, TryObservable, TryObservedIntoRunResult,
+        TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
     };
 
     /// Prelude for by-value proposals.
@@ -531,10 +501,10 @@ pub mod prelude {
     /// importing the in-place or delayed proposal traits.
     pub mod by_value {
         pub use crate::{
-            BinningAnalysis, BinningEstimate, Chain, McmcError, Observable, ObservedIntoRunResult,
-            ObservedStepError, ObservedStreamError, OnlineStats, Proposal, SampleBuffer, Sampler,
-            StatisticsError, Target, ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningError,
-            TryAccumulator, TryObservable, TryObservedDelayedIntoRunResult,
+            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, McmcError, Observable,
+            ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats, Proposal,
+            SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult,
+            ThinnedRunResult, ThinningError, TryAccumulator, TryObservable,
             TryObservedIntoRunResult, TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
         };
     }
@@ -545,11 +515,12 @@ pub mod prelude {
     /// importing the by-value or delayed proposal traits.
     pub mod in_place {
         pub use crate::{
-            BinningAnalysis, BinningEstimate, Chain, McmcError, Observable, ObservedIntoRunResult,
-            ObservedStepError, ObservedStreamError, OnlineStats, ProposalMut, SampleBuffer,
-            Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult, ThinnedRunResult,
-            ThinningError, TryAccumulator, TryObservable, TryObservedDelayedIntoRunResult,
-            TryObservedIntoRunResult, TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
+            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, McmcError, Observable,
+            ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats,
+            ProposalMut, SampleBuffer, Sampler, StatisticsError, Target,
+            ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningError, TryAccumulator,
+            TryObservable, TryObservedIntoRunResult, TryThinnedObservedIntoRunResult,
+            TryThinnedObservedRunResult,
         };
     }
 
@@ -559,12 +530,12 @@ pub mod prelude {
     /// errors, without importing the by-value or in-place proposal traits.
     pub mod delayed {
         pub use crate::{
-            BinningAnalysis, BinningEstimate, Chain, DelayedProposal, DelayedStep,
-            DelayedStepError, Observable, ObservedDelayedIntoRunResult, ObservedDelayedStep,
-            ObservedDelayedStepResult, ObservedStepError, ObservedStreamError, OnlineStats,
-            SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedDelayedIntoRunResult,
-            ThinnedRunResult, ThinningError, TryAccumulator, TryObservable,
-            TryObservedDelayedIntoRunResult, TryThinnedObservedDelayedIntoRunResult,
+            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DelayedProposal, DelayedStep,
+            DelayedStepError, McmcError, Observable, ObservedDelayedIntoRunResult,
+            ObservedDelayedStep, ObservedDelayedStepResult, ObservedStepError, ObservedStreamError,
+            OnlineStats, SampleBuffer, Sampler, StatisticsError, Target,
+            ThinnedObservedDelayedIntoRunResult, ThinnedRunResult, ThinningError, TryAccumulator,
+            TryObservable, TryObservedDelayedIntoRunResult, TryThinnedObservedDelayedIntoRunResult,
             TryThinnedObservedRunResult,
         };
     }
@@ -597,11 +568,12 @@ mod public_api_smoke_tests {
     use serde_json::{Error as JsonError, json, to_value};
 
     use super::{
-        BinningAnalysis, BinningEstimate, Chain, DelayedStep, DetailedBalanceBatchReport,
-        DetailedBalanceConfig, DetailedBalanceDelayedTransition, DetailedBalanceDirection,
-        DetailedBalanceError, DetailedBalanceFailure, DetailedBalanceReport, DetailedBalanceState,
-        McmcError, Observable, ObservedDelayedStep, OnlineStats, Proposal, ProposalMut,
-        SampleBuffer, Sampler, StatisticsError, Step, Target, ThinningError,
+        BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DelayedStep,
+        DetailedBalanceBatchReport, DetailedBalanceConfig, DetailedBalanceDelayedTransition,
+        DetailedBalanceDirection, DetailedBalanceError, DetailedBalanceFailure,
+        DetailedBalanceReport, DetailedBalanceState, McmcError, Observable, ObservedDelayedStep,
+        OnlineStats, Proposal, ProposalMut, SampleBuffer, Sampler, StatisticsError, Step, Target,
+        ThinningError,
         prelude::{self, by_value, delayed, in_place, testing},
     };
 
@@ -685,6 +657,7 @@ mod public_api_smoke_tests {
         needs_observable(&mut observable);
 
         let _: Option<Chain<f64>> = None;
+        let _: Option<ChainCheckpoint<f64>> = None;
         let _: Option<Step<()>> = None;
         let _: Option<DelayedStep<()>> = None;
         let _: Option<McmcError> = None;
@@ -711,18 +684,10 @@ mod public_api_smoke_tests {
             in_place::TryThinnedObservedIntoRunResult<McmcError, Infallible, Infallible>,
         > = None;
         let _: Option<delayed::ThinnedObservedDelayedIntoRunResult<Infallible, Infallible>> = None;
+        let _: Option<delayed::McmcError> = None;
         let _: Option<testing::DetailedBalanceConfig> = None;
         let _: Option<testing::DetailedBalanceError> = None;
         let _: Option<testing::DetailedBalanceReport> = None;
-        let _: Option<
-            prelude::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
-        > = None;
-        let _: Option<
-            by_value::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
-        > = None;
-        let _: Option<
-            in_place::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
-        > = None;
         let _: Option<
             delayed::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
         > = None;
@@ -737,12 +702,13 @@ mod public_api_smoke_tests {
         let Ok(chain) = Chain::new(1.0, &target) else {
             unreachable!("Smoke target always returns a finite log-probability");
         };
-        let sampler = Sampler::new(chain, &target, proposal, &mut rng);
+        let Ok(sampler) = Sampler::new(chain, &target, proposal, &mut rng) else {
+            unreachable!("Smoke target always returns a finite current log-probability");
+        };
 
         let checkpoint = to_value(&sampler)?;
 
         assert_eq!(checkpoint["chain"]["state"], json!(1.0));
-        assert_eq!(checkpoint["chain"]["log_prob"], json!(0.0));
         assert_eq!(checkpoint["chain"]["accepted"], json!(0));
         assert_eq!(checkpoint["chain"]["rejected"], json!(0));
         assert!(checkpoint.get("target").is_some());

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -392,6 +392,8 @@ impl<'a, T> IntoIterator for &'a SampleBuffer<T> {
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -413,7 +415,7 @@ mod tests {
     fn closure_observable_measures_state() {
         let mut squared = |state: &f64| state * state;
 
-        assert!((squared.observe(&3.0) - 9.0).abs() < f64::EPSILON);
+        assert_relative_eq!(squared.observe(&3.0), 9.0);
     }
 
     #[test]

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -167,11 +167,11 @@ fn thinned_capacity<E>(steps: usize, thin_interval: usize) -> Result<usize, Thin
 ///
 /// let mut rng = StdRng::seed_from_u64(42);
 /// let chain = Chain::new(Scalar(0.0), &Normal)?;
-/// let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng);
+/// let mut sampler = Sampler::new(chain, &Normal, &Walk, &mut rng)?;
 ///
 /// // Burn-in
 /// sampler.run(1000)?;
-/// sampler.chain_mut().reset_counters();
+/// sampler.reset_counters();
 ///
 /// // Production sampling
 /// sampler.run(10_000)?;
@@ -198,40 +198,11 @@ impl<S: fmt::Debug, T, P, R: ?Sized> fmt::Debug for Sampler<'_, S, T, P, R> {
 
 // --- Construction and decomposition (no trait bounds) ---
 
-impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
-    /// Create a new sampler from its components.
-    ///
-    /// ```
-    /// use markov_chain_monte_carlo::prelude::by_value::*;
-    /// use rand::{Rng, SeedableRng, rngs::StdRng};
-    ///
-    /// # struct T;
-    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
-    /// # struct P;
-    /// # impl Proposal<f64> for P {
-    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
-    /// #         current + 1.0
-    /// #     }
-    /// # }
-    /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0.0, &T)?;
-    /// let sampler = Sampler::new(chain, &T, &P, &mut rng);
-    ///
-    /// assert_eq!(sampler.chain_ref().total_steps(), 0);
-    /// # Ok::<(), McmcError>(())
-    /// ```
-    pub const fn new(chain: Chain<S>, target: &'a T, proposal: P, rng: &'a mut R) -> Self {
-        Self {
-            chain,
-            target,
-            proposal,
-            rng,
-        }
-    }
-
+impl<S, T, P, R: ?Sized> Sampler<'_, S, T, P, R> {
     /// Shared reference to the inner chain.
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -245,48 +216,19 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(1.0, &T)?;
-    /// let sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     ///
-    /// assert!((*sampler.chain_ref().state() - 1.0).abs() < f64::EPSILON);
+    /// assert_relative_eq!(*sampler.chain_ref().state(), 1.0);
     /// # Ok::<(), McmcError>(())
     /// ```
     pub const fn chain_ref(&self) -> &Chain<S> {
         &self.chain
     }
 
-    /// Mutable reference to the inner chain.
-    ///
-    /// This permits operations such as [`Chain::reset_counters`] or
-    /// [`Chain::replace_state`] without exposing `Sampler`'s fields as part of
-    /// its public representation.
-    ///
-    /// ```
-    /// use markov_chain_monte_carlo::prelude::by_value::*;
-    /// use rand::{Rng, SeedableRng, rngs::StdRng};
-    ///
-    /// # struct T;
-    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
-    /// # struct P;
-    /// # impl Proposal<f64> for P {
-    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
-    /// #         current + 1.0
-    /// #     }
-    /// # }
-    /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(1.0, &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
-    ///
-    /// sampler.chain_mut().replace_state(2.0, &T)?;
-    /// assert!((*sampler.chain_ref().state() - 2.0).abs() < f64::EPSILON);
-    /// # Ok::<(), McmcError>(())
-    /// ```
-    pub const fn chain_mut(&mut self) -> &mut Chain<S> {
-        &mut self.chain
-    }
-
     /// Shared reference to the stored proposal handle.
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -302,9 +244,9 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// let proposal = Walk { width: 1.0 };
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T)?;
-    /// let sampler = Sampler::new(chain, &T, &proposal, &mut rng);
+    /// let sampler = Sampler::new(chain, &T, &proposal, &mut rng)?;
     ///
-    /// assert!((sampler.proposal_ref().width - 1.0).abs() < f64::EPSILON);
+    /// assert_relative_eq!(sampler.proposal_ref().width, 1.0);
     /// # Ok::<(), McmcError>(())
     /// ```
     #[must_use]
@@ -315,6 +257,7 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// Mutable reference to the stored proposal handle.
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -329,10 +272,10 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, Walk { width: 1.0 }, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, Walk { width: 1.0 }, &mut rng)?;
     /// sampler.proposal_mut().width = 0.5;
     ///
-    /// assert!((sampler.proposal_ref().width - 0.5).abs() < f64::EPSILON);
+    /// assert_relative_eq!(sampler.proposal_ref().width, 0.5);
     /// # Ok::<(), McmcError>(())
     /// ```
     pub const fn proposal_mut(&mut self) -> &mut P {
@@ -342,6 +285,7 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// Consume the sampler and return the inner chain.
     ///
     /// ```
+    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{SeedableRng, rngs::StdRng};
     ///
@@ -353,13 +297,45 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(1.0_f64, &T)?;
-    /// let sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     /// let chain = sampler.into_chain();
-    /// assert!((chain.log_prob() - (-0.5)).abs() < 1e-12);
+    /// assert_relative_eq!(chain.log_prob(), -0.5, epsilon = 1e-12);
     /// # Ok::<(), McmcError>(())
     /// ```
     pub fn into_chain(self) -> Chain<S> {
         self.chain
+    }
+
+    /// Reset acceptance and rejection counters on the inner chain.
+    ///
+    /// Useful after burn-in to measure the acceptance rate of the production
+    /// phase only.
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, _: &f64) -> f64 { 0.0 } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    ///
+    /// sampler.run(4)?;
+    /// sampler.reset_counters();
+    ///
+    /// assert_eq!(sampler.chain_ref().total_steps(), 0);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub const fn reset_counters(&mut self) {
+        self.chain.reset_counters();
     }
 
     /// Run the shared validate/step/modulo-gate loop for thinned methods.
@@ -408,6 +384,112 @@ impl<'a, S, T, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     }
 }
 
+impl<'a, S, T: Target<S>, P, R: ?Sized> Sampler<'a, S, T, P, R> {
+    /// Create a new sampler from its components.
+    ///
+    /// The sampler refreshes the chain's cached log-probability from the
+    /// stored target. This prevents pairing a valid chain with a different
+    /// target and silently continuing from a stale cache.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T)?;
+    /// let sampler = Sampler::new(chain, &T, &P, &mut rng)?;
+    ///
+    /// assert_eq!(sampler.chain_ref().total_steps(), 0);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`McmcError::NanCurrentLogProb`] or
+    /// [`McmcError::InfiniteCurrentLogProb`] if the target returns NaN or +∞
+    /// for the chain's current state.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T)?;
+    /// let sampler = Sampler::new(chain, &T, &P, &mut rng)?;
+    ///
+    /// assert_eq!(sampler.chain_ref().total_steps(), 0);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub fn new(
+        mut chain: Chain<S>,
+        target: &'a T,
+        proposal: P,
+        rng: &'a mut R,
+    ) -> Result<Self, McmcError> {
+        chain.refresh_current_log_prob(target)?;
+        Ok(Self {
+            chain,
+            target,
+            proposal,
+            rng,
+        })
+    }
+
+    /// Replace the sampler's current chain state using the sampler target.
+    ///
+    /// This keeps the chain's cached log-probability synchronized with the
+    /// target that subsequent sampler steps will use.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`McmcError::NanReplacementLogProb`] or
+    /// [`McmcError::InfiniteReplacementLogProb`] if the sampler target returns
+    /// NaN or +∞ for `new_state`.
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
+    ///
+    /// sampler.replace_state(2.0)?;
+    ///
+    /// assert_eq!(*sampler.chain_ref().state(), 2.0);
+    /// assert_relative_eq!(sampler.chain_ref().log_prob(), -2.0, epsilon = 1e-12);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub fn replace_state(&mut self, new_state: S) -> Result<(), McmcError> {
+        self.chain.replace_state(new_state, self.target)
+    }
+}
+
 // --- By-value stepping ---
 
 impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
@@ -430,7 +512,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     /// sampler.step()?;
     /// assert_eq!(sampler.chain_ref().total_steps(), 1);
     /// # Ok::<(), McmcError>(())
@@ -462,7 +544,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     ///
     /// sampler.run(1000)?;
     /// assert_eq!(sampler.chain_ref().total_steps(), 1000);
@@ -504,7 +586,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     ///
     /// let states = sampler.run_with_thinning(5, 2)?;
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
@@ -551,7 +633,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     /// let mut energy = |state: &f64| 0.5 * state * state;
     ///
     /// let measurement = sampler.step_observing(&mut energy)?;
@@ -588,7 +670,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     /// let mut coordinate = |state: &S| state.0;
     ///
     /// let samples = sampler.run_observing(128, &mut coordinate)?;
@@ -634,7 +716,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| *state;
     ///
     /// let samples = sampler.run_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -686,7 +768,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
     /// let mut coordinate = |state: &S| state.0;
     /// let mut stats = OnlineStats::new();
     ///
@@ -746,7 +828,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// let chain = Chain::new(0, &Flat)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
     ///
@@ -803,7 +885,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
     /// let mut finite = |state: &f64| {
     ///     if state.is_finite() { Ok(*state) } else { Err("non-finite") }
     /// };
@@ -843,7 +925,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
     /// let mut nonnegative = |state: &f64| {
     ///     if *state >= 0.0 { Ok(*state) } else { Err("negative state") }
     /// };
@@ -893,7 +975,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// let chain = Chain::new(0, &Flat)
     ///     .map_err(ObservedStepError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| Ok::<i32, Infallible>(*state);
     ///
     /// let samples = sampler.try_run_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -940,7 +1022,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
     /// let mut nonnegative = |state: &f64| {
     ///     if *state >= 0.0 { Ok(*state) } else { Err("negative state") }
     /// };
@@ -1001,7 +1083,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// let chain = Chain::new(0, &Flat)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| Ok::<f64, Infallible>(f64::from(*state));
     /// let mut stats = OnlineStats::new();
     ///
@@ -1066,7 +1148,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     /// let accepted = sampler.step_mut()?;
     /// assert_eq!(sampler.chain_ref().total_steps(), 1);
     /// # Ok::<(), McmcError>(())
@@ -1105,7 +1187,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(Spins(vec![1; 20]), &Ising)?;
-    /// let mut sampler = Sampler::new(chain, &Ising, &Flip, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Ising, &Flip, &mut rng).unwrap();
     ///
     /// sampler.run_mut(1000)?;
     /// assert_eq!(sampler.chain_ref().total_steps(), 1000);
@@ -1150,7 +1232,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     ///
     /// let states = sampler.run_mut_with_thinning(5, 2)?;
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
@@ -1204,7 +1286,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     /// let mut coordinate = |state: &S| state.0;
     ///
     /// let (_accepted, sample) = sampler.step_mut_observing(&mut coordinate)?;
@@ -1243,7 +1325,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     /// let mut coordinate = |state: &S| state.0;
     ///
     /// let samples = sampler.run_mut_observing(16, &mut coordinate)?;
@@ -1294,7 +1376,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     /// let mut coordinate = |state: &S| state.0;
     ///
     /// let samples = sampler.run_mut_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -1346,7 +1428,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
     /// let mut coordinate = |state: &S| state.0;
     /// let mut bins = BinningAnalysis::new();
     ///
@@ -1411,7 +1493,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// let chain = Chain::new(S(0), &Flat)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     /// let mut coordinate = |state: &S| f64::from(state.0);
     /// let mut stats = OnlineStats::new();
     ///
@@ -1469,7 +1551,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
     /// let mut finite = |state: &S| {
     ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
     /// };
@@ -1513,7 +1595,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
     /// let mut finite = |state: &S| {
     ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
     /// };
@@ -1569,7 +1651,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// let chain = Chain::new(S(0), &Flat)
     ///     .map_err(ObservedStepError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     /// let mut coordinate = |state: &S| Ok::<i32, Infallible>(state.0);
     ///
     /// let samples = sampler.try_run_mut_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -1622,7 +1704,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
     /// let mut finite = |state: &S| {
     ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
     /// };
@@ -1688,7 +1770,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// let chain = Chain::new(S(0), &Flat)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
     /// let mut coordinate = |state: &S| Ok::<f64, Infallible>(f64::from(state.0));
     /// let mut stats = OnlineStats::new();
     ///
@@ -1789,7 +1871,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = MoveRight;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(-1, &target)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     ///
     /// let step = sampler.step_delayed()?;
     /// assert!(step.accepted);
@@ -1860,7 +1942,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     ///
     /// sampler.run_delayed(3)?;
     /// assert_eq!(*sampler.chain_ref().state(), 3);
@@ -1935,7 +2017,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(S(0), &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     ///
     /// let states = sampler.run_delayed_with_thinning(5, 2)?;
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
@@ -1994,7 +2076,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| *state;
     ///
     /// let (_step, sample) = sampler.step_delayed_observing(&mut coordinate)?;
@@ -2066,7 +2148,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| *state;
     ///
     /// let samples = sampler.run_delayed_observing(3, &mut coordinate)?;
@@ -2118,7 +2200,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| *state;
     ///
     /// let samples = sampler.run_delayed_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -2176,7 +2258,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
     ///
@@ -2240,7 +2322,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
     ///
@@ -2305,7 +2387,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut positive = |state: &i32| {
     ///     if *state > 0 { Ok(*state) } else { Err("not positive") }
     /// };
@@ -2355,7 +2437,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut positive = |state: &i32| {
     ///     if *state > 0 { Ok(*state) } else { Err("not positive") }
     /// };
@@ -2410,7 +2492,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStepError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| Ok::<i32, Infallible>(*state);
     ///
     /// let samples = sampler.try_run_delayed_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -2474,7 +2556,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut positive = |state: &i32| {
     ///     if *state > 0 { Ok(f64::from(*state)) } else { Err("not positive") }
     /// };
@@ -2539,7 +2621,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     /// let mut coordinate = |state: &i32| Ok::<f64, Infallible>(f64::from(*state));
     /// let mut stats = OnlineStats::new();
     ///
@@ -2613,7 +2695,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Iterator for Sampler<'_, 
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(Val(0.0), &Flat)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Walk, &mut rng);
+    /// let mut sampler = Sampler::new(chain, &Flat, &Walk, &mut rng).unwrap();
     ///
     /// // Take exactly 100 steps using iterator
     /// let errors: Vec<_> = sampler.by_ref().take(100).filter_map(Result::err).collect();
@@ -2630,9 +2712,11 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Iterator for Sampler<'_, 
 mod tests {
     use core::convert::Infallible;
 
+    use approx::assert_relative_eq;
+    use rand::{RngExt, SeedableRng, rngs::StdRng};
+
     use super::*;
     use crate::{BinningAnalysis, OnlineStats, StatisticsError};
-    use rand::{RngExt, SeedableRng, rngs::StdRng};
 
     // --- Shared fixtures ---
 
@@ -2730,13 +2814,19 @@ mod tests {
         Chain::new(MutScalar(initial), &Normal).unwrap()
     }
 
+    macro_rules! sampler {
+        ($($arg:tt)*) => {
+            Sampler::new($($arg)*).unwrap()
+        };
+    }
+
     // --- Construction ---
 
     #[test]
     fn new_and_into_chain() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
-        let sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
         let chain = sampler.into_chain();
         assert_eq!(chain.state, Scalar(1.0));
     }
@@ -2745,18 +2835,81 @@ mod tests {
     fn accessors_expose_components() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, Walk { width: 1.0 }, &mut rng);
 
         assert_eq!(sampler.chain_ref().state(), &Scalar(1.0));
-        sampler
-            .chain_mut()
-            .replace_state(Scalar(2.0), &Normal)
-            .unwrap();
+        sampler.replace_state(Scalar(2.0)).unwrap();
         assert_eq!(sampler.chain_ref().state(), &Scalar(2.0));
 
-        assert!((sampler.proposal_ref().width - 1.0).abs() < f64::EPSILON);
+        assert_relative_eq!(sampler.proposal_ref().width, 1.0);
         sampler.proposal_mut().width = 0.5;
-        assert!((sampler.proposal_ref().width - 0.5).abs() < f64::EPSILON);
+        assert_relative_eq!(sampler.proposal_ref().width, 0.5);
+    }
+
+    #[test]
+    fn new_recomputes_chain_log_prob_from_sampler_target() {
+        struct ShiftedNormal;
+        impl Target<Scalar> for ShiftedNormal {
+            fn log_prob(&self, state: &Scalar) -> f64 {
+                -0.5 * (state.0 - 10.0) * (state.0 - 10.0)
+            }
+        }
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
+        assert_relative_eq!(chain.log_prob(), -0.5, epsilon = 1e-12);
+
+        let sampler = sampler!(chain, &ShiftedNormal, &Walk { width: 1.0 }, &mut rng);
+
+        assert_relative_eq!(sampler.chain_ref().log_prob(), -40.5, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn new_rejects_invalid_current_log_prob() {
+        struct NanTarget;
+        impl Target<Scalar> for NanTarget {
+            fn log_prob(&self, _: &Scalar) -> f64 {
+                f64::NAN
+            }
+        }
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
+        let result = Sampler::new(chain, &NanTarget, &Walk { width: 1.0 }, &mut rng);
+
+        assert!(matches!(result, Err(McmcError::NanCurrentLogProb)));
+    }
+
+    #[test]
+    fn new_rejects_infinite_current_log_prob() {
+        struct InfTarget;
+        impl Target<Scalar> for InfTarget {
+            fn log_prob(&self, _: &Scalar) -> f64 {
+                f64::INFINITY
+            }
+        }
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
+        let result = Sampler::new(chain, &InfTarget, &Walk { width: 1.0 }, &mut rng);
+
+        assert!(matches!(result, Err(McmcError::InfiniteCurrentLogProb)));
+    }
+
+    #[test]
+    fn new_rejects_invalid_current_log_prob_without_reusing_cache() {
+        struct NanTarget;
+        impl Target<Scalar> for NanTarget {
+            fn log_prob(&self, _: &Scalar) -> f64 {
+                f64::NAN
+            }
+        }
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
+        let result = Sampler::new(chain, &NanTarget, &Walk { width: 1.0 }, &mut rng);
+
+        assert!(matches!(result, Err(McmcError::NanCurrentLogProb)));
     }
 
     // --- Debug ---
@@ -2765,7 +2918,7 @@ mod tests {
     fn debug_output_contains_chain() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
-        let sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
         let debug = format!("{sampler:?}");
         assert!(debug.contains("Sampler"));
         assert!(debug.contains("chain"));
@@ -2796,7 +2949,7 @@ mod tests {
     fn step_advances_chain() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
 
         sampler.step().unwrap();
         assert_eq!(sampler.chain_ref().total_steps(), 1);
@@ -2806,7 +2959,7 @@ mod tests {
     fn run_n_steps() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
 
         sampler.run(500).unwrap();
         assert_eq!(sampler.chain_ref().total_steps(), 500);
@@ -2815,7 +2968,7 @@ mod tests {
     #[test]
     fn run_with_thinning_collects_every_kth_state() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
 
         let states = sampler.run_with_thinning(5, 2).unwrap();
 
@@ -2826,7 +2979,7 @@ mod tests {
     #[test]
     fn run_with_thinning_skips_collection_when_interval_exceeds_steps() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
 
         let states = sampler.run_with_thinning(3, 4).unwrap();
 
@@ -2837,7 +2990,7 @@ mod tests {
     #[test]
     fn run_with_thinning_reports_zero_interval() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
 
         let result = sampler.run_with_thinning(5, 0);
 
@@ -2852,7 +3005,7 @@ mod tests {
     fn run_with_thinning_reports_step_error_without_collecting() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &NanLogQProposal, &mut rng);
 
         let result = sampler.run_with_thinning(5, 2);
 
@@ -2867,7 +3020,7 @@ mod tests {
     fn run_observing_collects() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut energy = |state: &Scalar| 0.5 * state.0 * state.0;
 
         let measurements = sampler.run_observing(25, &mut energy).unwrap();
@@ -2881,7 +3034,7 @@ mod tests {
     fn run_observing_into_streams_to_online_stats() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &Scalar| state.0;
         let mut stats = OnlineStats::new();
 
@@ -2897,7 +3050,7 @@ mod tests {
     #[test]
     fn run_observing_with_thinning_collects_every_kth_step() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut calls = 0;
         let mut coordinate = |state: &Scalar| {
             calls += 1;
@@ -2916,7 +3069,7 @@ mod tests {
     #[test]
     fn run_observing_with_thinning_skips_observation_when_interval_exceeds_steps() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut calls = 0;
         let mut coordinate = |state: &Scalar| {
             calls += 1;
@@ -2935,7 +3088,7 @@ mod tests {
     #[test]
     fn run_observing_into_with_thinning_streams_every_kth_step() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &Scalar| state.0;
         let mut stats = OnlineStats::new();
 
@@ -2950,7 +3103,7 @@ mod tests {
     #[test]
     fn try_run_observing_with_thinning_observes_only_thinned_steps() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut calls = 0;
         let mut observable = |_state: &Scalar| {
             calls += 1;
@@ -2972,7 +3125,7 @@ mod tests {
     #[test]
     fn try_run_observing_into_with_thinning_streams_every_kth_step() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &Scalar| Ok::<f64, ObservationFailure>(state.0);
         let mut stats = OnlineStats::new();
 
@@ -2987,7 +3140,7 @@ mod tests {
     #[test]
     fn run_observing_with_thinning_reports_zero_interval() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &Scalar| state.0;
 
         let result = sampler.run_observing_with_thinning(5, 0, &mut coordinate);
@@ -3002,7 +3155,7 @@ mod tests {
     #[test]
     fn run_observing_into_with_thinning_reports_zero_interval() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &Scalar| state.0;
         let mut stats = OnlineStats::new();
 
@@ -3020,7 +3173,7 @@ mod tests {
     fn run_observing_into_with_thinning_reports_step_error_without_accumulating() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &NanLogQProposal, &mut rng);
         let mut observed = false;
         let mut coordinate = |state: &Scalar| {
             observed = true;
@@ -3047,7 +3200,7 @@ mod tests {
     fn try_run_observing_reports_error() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut calls = 0;
         let mut observable = |state: &Scalar| {
             calls += 1;
@@ -3071,7 +3224,7 @@ mod tests {
     fn try_run_observing_into_stops_on_observation_error() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut calls = 0;
         let mut observable = |state: &Scalar| {
             calls += 1;
@@ -3097,7 +3250,7 @@ mod tests {
     fn run_observing_into_reports_accumulation_error() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
         let mut invalid = |_state: &Scalar| f64::NAN;
         let mut stats = OnlineStats::new();
 
@@ -3117,7 +3270,7 @@ mod tests {
     fn run_observing_into_reports_step_error_without_accumulating() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &NanLogQProposal, &mut rng);
         let mut observed = false;
         let mut observable = |state: &Scalar| {
             observed = true;
@@ -3139,7 +3292,7 @@ mod tests {
     fn try_run_observing_into_reports_step_error_without_accumulating() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &NanLogQProposal, &mut rng);
         let mut observed = false;
         let mut observable = |state: &Scalar| {
             observed = true;
@@ -3161,7 +3314,7 @@ mod tests {
     fn try_step_observing_skips_error() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &NanLogQProposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &NanLogQProposal, &mut rng);
         let mut observed = false;
         let mut observable = |state: &Scalar| {
             observed = true;
@@ -3183,7 +3336,7 @@ mod tests {
     fn step_mut_advances_chain() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
 
         sampler.step_mut().unwrap();
         assert_eq!(sampler.chain_ref().total_steps(), 1);
@@ -3193,7 +3346,7 @@ mod tests {
     fn run_mut_n_steps() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
 
         sampler.run_mut(500).unwrap();
         assert_eq!(sampler.chain_ref().total_steps(), 500);
@@ -3202,7 +3355,7 @@ mod tests {
     #[test]
     fn run_mut_with_thinning_collects_every_kth_state() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(
+        let mut sampler = sampler!(
             scalar_chain(0.0),
             &Normal,
             &MutWalk { width: 1.0 },
@@ -3218,7 +3371,7 @@ mod tests {
     #[test]
     fn run_mut_with_thinning_skips_collection_when_interval_exceeds_steps() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(
+        let mut sampler = sampler!(
             scalar_chain(0.0),
             &Normal,
             &MutWalk { width: 1.0 },
@@ -3234,7 +3387,7 @@ mod tests {
     #[test]
     fn run_mut_with_thinning_reports_zero_interval() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(
+        let mut sampler = sampler!(
             scalar_chain(0.0),
             &Normal,
             &MutWalk { width: 1.0 },
@@ -3254,7 +3407,7 @@ mod tests {
     fn run_mut_observing_collects() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &MutScalar| state.0;
 
         let measurements = sampler.run_mut_observing(25, &mut coordinate).unwrap();
@@ -3267,7 +3420,7 @@ mod tests {
     fn run_mut_observing_into_streams_to_binning_analysis() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &MutScalar| state.0;
         let mut bins = BinningAnalysis::new();
 
@@ -3283,7 +3436,7 @@ mod tests {
     #[test]
     fn run_mut_observing_with_thinning_collects_every_kth_step() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(
+        let mut sampler = sampler!(
             mut_scalar_chain(0.0),
             &Normal,
             &MutWalk { width: 1.0 },
@@ -3307,7 +3460,7 @@ mod tests {
     #[test]
     fn run_mut_observing_into_with_thinning_streams_every_kth_step() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(
+        let mut sampler = sampler!(
             mut_scalar_chain(0.0),
             &Normal,
             &MutWalk { width: 1.0 },
@@ -3327,7 +3480,7 @@ mod tests {
     #[test]
     fn try_run_mut_observing_with_thinning_observes_only_thinned_steps() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(
+        let mut sampler = sampler!(
             mut_scalar_chain(0.0),
             &Normal,
             &MutWalk { width: 1.0 },
@@ -3354,7 +3507,7 @@ mod tests {
     #[test]
     fn try_run_mut_observing_into_with_thinning_streams_every_kth_step() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(
+        let mut sampler = sampler!(
             mut_scalar_chain(0.0),
             &Normal,
             &MutWalk { width: 1.0 },
@@ -3374,7 +3527,7 @@ mod tests {
     #[test]
     fn run_mut_observing_with_thinning_reports_zero_interval() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(
+        let mut sampler = sampler!(
             mut_scalar_chain(0.0),
             &Normal,
             &MutWalk { width: 1.0 },
@@ -3395,7 +3548,7 @@ mod tests {
     fn try_step_mut_observing_collects() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
 
         let (_accepted, sample) = sampler.try_step_mut_observing(&mut coordinate).unwrap();
@@ -3408,7 +3561,7 @@ mod tests {
     fn try_run_mut_observing_errors() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
         let mut observable = |_state: &MutScalar| Err::<f64, _>(ObservationFailure::Failed);
 
         let result = sampler.try_run_mut_observing(1, &mut observable);
@@ -3424,7 +3577,7 @@ mod tests {
     fn try_run_mut_observing_into_streams_successes() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
         let mut stats = OnlineStats::new();
 
@@ -3440,7 +3593,7 @@ mod tests {
     fn try_run_mut_observing_into_reports_accumulation_error() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
         let mut invalid = |_state: &MutScalar| Ok::<f64, ObservationFailure>(f64::INFINITY);
         let mut stats = OnlineStats::new();
 
@@ -3538,7 +3691,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
 
         let step = sampler.step_delayed().unwrap();
 
@@ -3552,7 +3705,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
 
         sampler.run_delayed(10).unwrap();
 
@@ -3564,7 +3717,7 @@ mod tests {
     fn run_delayed_with_thinning_collects_every_kth_state() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
 
         let states = sampler.run_delayed_with_thinning(6, 2).unwrap();
 
@@ -3576,7 +3729,7 @@ mod tests {
     fn run_delayed_with_thinning_skips_collection_when_interval_exceeds_steps() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
 
         let states = sampler.run_delayed_with_thinning(3, 4).unwrap();
 
@@ -3588,7 +3741,7 @@ mod tests {
     fn run_delayed_with_thinning_reports_zero_interval() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
 
         let result = sampler.run_delayed_with_thinning(5, 0);
 
@@ -3604,7 +3757,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
         let mut coordinate = |state: &MutScalar| state.0;
 
         let measurements = sampler.run_delayed_observing(5, &mut coordinate).unwrap();
@@ -3618,7 +3771,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
         let mut coordinate = |state: &MutScalar| state.0;
         let mut stats = OnlineStats::new();
 
@@ -3635,7 +3788,7 @@ mod tests {
     fn run_delayed_observing_with_thinning_collects_every_kth_step() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
         let mut calls = 0;
         let mut coordinate = |state: &MutScalar| {
             calls += 1;
@@ -3655,7 +3808,7 @@ mod tests {
     fn run_delayed_observing_into_with_thinning_streams_every_kth_step() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
         let mut coordinate = |state: &MutScalar| state.0;
         let mut stats = OnlineStats::new();
 
@@ -3672,7 +3825,7 @@ mod tests {
     fn run_delayed_observing_into_with_thinning_reports_zero_interval() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
         let mut coordinate = |state: &MutScalar| state.0;
         let mut stats = OnlineStats::new();
 
@@ -3692,7 +3845,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
         let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
 
         let measurements = sampler
@@ -3707,7 +3860,7 @@ mod tests {
     fn try_run_delayed_observing_with_thinning_observes_only_thinned_steps() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
         let mut calls = 0;
         let mut observable = |_state: &MutScalar| {
             calls += 1;
@@ -3730,7 +3883,7 @@ mod tests {
     fn try_run_delayed_observing_into_with_thinning_streams_every_kth_step() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
         let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
         let mut stats = OnlineStats::new();
 
@@ -3748,7 +3901,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
         let mut observable = |_state: &MutScalar| Err::<f64, _>(ObservationFailure::Failed);
 
         let result = sampler.try_run_delayed_observing(1, &mut observable);
@@ -3765,7 +3918,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let mut proposal = DelayedToZero;
-        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
         let mut calls = 0;
         let mut observable = |state: &MutScalar| {
             calls += 1;
@@ -3843,7 +3996,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
         let mut proposal = StopAfterFirstDelayed { calls: 0 };
-        let mut sampler = Sampler::new(chain, &Normal, &mut proposal, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
 
         let result = sampler.run_delayed(3);
 
@@ -3861,7 +4014,7 @@ mod tests {
     fn iterator_take_n() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
 
         // Use Iterator::take for burn-in
         for result in sampler.by_ref().take(200) {
@@ -3874,7 +4027,7 @@ mod tests {
     fn iterator_is_infinite() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
-        let mut sampler = Sampler::new(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
 
         // next() always returns Some
         assert!(sampler.next().is_some());
@@ -3899,7 +4052,7 @@ mod tests {
         // Sampler
         let chain2 = Chain::new(Scalar(0.0), &Normal).unwrap();
         let mut rng2 = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2);
+        let mut sampler = sampler!(chain2, &Normal, &proposal, &mut rng2);
         sampler.run(steps).unwrap();
 
         assert_eq!(chain.state, *sampler.chain_ref().state());
@@ -3922,7 +4075,7 @@ mod tests {
         // Sampler
         let chain2 = Chain::new(MutScalar(0.0), &Normal).unwrap();
         let mut rng2 = StdRng::seed_from_u64(42);
-        let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2);
+        let mut sampler = sampler!(chain2, &Normal, &proposal, &mut rng2);
         sampler.run_mut(steps).unwrap();
 
         assert_eq!(chain.state, *sampler.chain_ref().state());

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -417,12 +417,19 @@ impl<'a, S, T: Target<S>, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// [`McmcError::InfiniteCurrentLogProb`] if the target returns NaN or +∞
     /// for the chain's current state.
     ///
-    /// ```
+    /// ```should_panic
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
-    /// # struct T;
-    /// # impl Target<f64> for T { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// struct NanTarget;
+    /// impl Target<f64> for NanTarget {
+    ///     fn log_prob(&self, _: &f64) -> f64 {
+    ///         f64::NAN
+    ///     }
+    /// }
+    ///
+    /// # struct ValidTarget;
+    /// # impl Target<f64> for ValidTarget { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
     /// # struct P;
     /// # impl Proposal<f64> for P {
     /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
@@ -430,11 +437,34 @@ impl<'a, S, T: Target<S>, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// #     }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0.0, &T)?;
-    /// let sampler = Sampler::new(chain, &T, &P, &mut rng)?;
+    /// let chain = Chain::new(0.0, &ValidTarget).unwrap();
+    /// // This will return Err(McmcError::NanCurrentLogProb)
+    /// let sampler = Sampler::new(chain, &NanTarget, &P, &mut rng).unwrap();
+    /// ```
     ///
-    /// assert_eq!(sampler.chain_ref().total_steps(), 0);
-    /// # Ok::<(), McmcError>(())
+    /// ```should_panic
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct InfTarget;
+    /// impl Target<f64> for InfTarget {
+    ///     fn log_prob(&self, _: &f64) -> f64 {
+    ///         f64::INFINITY
+    ///     }
+    /// }
+    ///
+    /// # struct ValidTarget;
+    /// # impl Target<f64> for ValidTarget { fn log_prob(&self, x: &f64) -> f64 { -0.5 * x * x } }
+    /// # struct P;
+    /// # impl Proposal<f64> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &f64, _rng: &mut R) -> f64 {
+    /// #         current + 1.0
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0.0, &ValidTarget).unwrap();
+    /// // This will return Err(McmcError::InfiniteCurrentLogProb)
+    /// let sampler = Sampler::new(chain, &InfTarget, &P, &mut rng).unwrap();
     /// ```
     pub fn new(
         mut chain: Chain<S>,

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1794,23 +1794,22 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
         O: TryObservable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        validate_thin_interval(thin_interval)?;
-        for step in 1..=steps {
-            self.step_mut()
-                .map_err(ObservedStreamError::Step)
-                .map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
+        self.run_thinning_core(
+            steps,
+            thin_interval,
+            |sampler| {
+                sampler.step_mut().map_err(ObservedStreamError::Step)?;
+                Ok(())
+            },
+            |sampler| {
                 let sample = observable
-                    .try_observe(self.chain.state())
-                    .map_err(ObservedStreamError::Observation)
-                    .map_err(ThinningError::Run)?;
+                    .try_observe(sampler.chain.state())
+                    .map_err(ObservedStreamError::Observation)?;
                 accumulator
                     .try_push(sample)
                     .map_err(ObservedStreamError::Accumulation)
-                    .map_err(ThinningError::Run)?;
-            }
-        }
-        Ok(())
+            },
+        )
     }
 }
 
@@ -2039,16 +2038,15 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     where
         S: Clone,
     {
-        let mut samples = SampleBuffer::with_capacity(thinned_capacity::<
-            DelayedStepError<P::Error>,
-        >(steps, thin_interval)?);
-        for step in 1..=steps {
-            let _ = self.step_delayed().map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
-                samples.push(self.chain.state().clone());
-            }
-        }
-        Ok(samples)
+        self.collect_with_thinning_core(
+            steps,
+            thin_interval,
+            |sampler| {
+                let _ = sampler.step_delayed()?;
+                Ok(())
+            },
+            |sampler| Ok(sampler.chain.state().clone()),
+        )
     }
 
     /// Perform one delayed-commit step and observe the resulting chain state.
@@ -2218,16 +2216,15 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
         thin_interval: usize,
         observable: &mut O,
     ) -> ThinnedRunResult<SampleBuffer<O::Output>, DelayedStepError<P::Error>> {
-        let mut samples = SampleBuffer::with_capacity(thinned_capacity::<
-            DelayedStepError<P::Error>,
-        >(steps, thin_interval)?);
-        for step in 1..=steps {
-            let _ = self.step_delayed().map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
-                samples.push(observable.observe(self.chain.state()));
-            }
-        }
-        Ok(samples)
+        self.collect_with_thinning_core(
+            steps,
+            thin_interval,
+            |sampler| {
+                let _ = sampler.step_delayed()?;
+                Ok(())
+            },
+            |sampler| Ok(observable.observe(sampler.chain.state())),
+        )
     }
 
     /// Run delayed-commit steps and stream observations into an accumulator.
@@ -2346,20 +2343,19 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
         O: Observable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        validate_thin_interval(thin_interval)?;
-        for step in 1..=steps {
-            let _ = self
-                .step_delayed()
-                .map_err(ObservedStreamError::Step)
-                .map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
+        self.run_thinning_core(
+            steps,
+            thin_interval,
+            |sampler| {
+                let _ = sampler.step_delayed().map_err(ObservedStreamError::Step)?;
+                Ok(())
+            },
+            |sampler| {
                 accumulator
-                    .try_push(observable.observe(self.chain.state()))
+                    .try_push(observable.observe(sampler.chain.state()))
                     .map_err(ObservedStreamError::Accumulation)
-                    .map_err(ThinningError::Run)?;
-            }
-        }
-        Ok(())
+            },
+        )
     }
 
     /// Perform one delayed-commit step and fallibly observe the resulting state.
@@ -2511,24 +2507,19 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
         thin_interval: usize,
         observable: &mut O,
     ) -> TryThinnedObservedRunResult<O::Output, DelayedStepError<P::Error>, O::Error> {
-        let mut samples = SampleBuffer::with_capacity(thinned_capacity::<
-            ObservedStepError<DelayedStepError<P::Error>, O::Error>,
-        >(steps, thin_interval)?);
-        for step in 1..=steps {
-            let _ = self
-                .step_delayed()
-                .map_err(ObservedStepError::Step)
-                .map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
-                samples.push(
-                    observable
-                        .try_observe(self.chain.state())
-                        .map_err(ObservedStepError::Observation)
-                        .map_err(ThinningError::Run)?,
-                );
-            }
-        }
-        Ok(samples)
+        self.collect_with_thinning_core(
+            steps,
+            thin_interval,
+            |sampler| {
+                let _ = sampler.step_delayed().map_err(ObservedStepError::Step)?;
+                Ok(())
+            },
+            |sampler| {
+                observable
+                    .try_observe(sampler.chain.state())
+                    .map_err(ObservedStepError::Observation)
+            },
+        )
     }
 
     /// Run delayed-commit steps and stream fallible observations into an accumulator.
@@ -2645,24 +2636,22 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
         O: TryObservable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        validate_thin_interval(thin_interval)?;
-        for step in 1..=steps {
-            let _ = self
-                .step_delayed()
-                .map_err(ObservedStreamError::Step)
-                .map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
+        self.run_thinning_core(
+            steps,
+            thin_interval,
+            |sampler| {
+                let _ = sampler.step_delayed().map_err(ObservedStreamError::Step)?;
+                Ok(())
+            },
+            |sampler| {
                 let sample = observable
-                    .try_observe(self.chain.state())
-                    .map_err(ObservedStreamError::Observation)
-                    .map_err(ThinningError::Run)?;
+                    .try_observe(sampler.chain.state())
+                    .map_err(ObservedStreamError::Observation)?;
                 accumulator
                     .try_push(sample)
                     .map_err(ObservedStreamError::Accumulation)
-                    .map_err(ThinningError::Run)?;
-            }
-        }
-        Ok(())
+            },
+        )
     }
 }
 
@@ -2898,18 +2887,19 @@ mod tests {
 
     #[test]
     fn new_rejects_invalid_current_log_prob_without_reusing_cache() {
-        struct NanTarget;
-        impl Target<Scalar> for NanTarget {
+        struct ValidTarget;
+        impl Target<Scalar> for ValidTarget {
             fn log_prob(&self, _: &Scalar) -> f64 {
-                f64::NAN
+                0.0
             }
         }
 
         let mut rng = StdRng::seed_from_u64(42);
-        let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
-        let result = Sampler::new(chain, &NanTarget, &Walk { width: 1.0 }, &mut rng);
+        let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
+        chain.set_cached_log_prob_for_testing(f64::NAN);
+        let sampler = Sampler::new(chain, &ValidTarget, &Walk { width: 1.0 }, &mut rng).unwrap();
 
-        assert!(matches!(result, Err(McmcError::NanCurrentLogProb)));
+        assert_relative_eq!(sampler.chain_ref().log_prob(), 0.0);
     }
 
     // --- Debug ---
@@ -3031,6 +3021,20 @@ mod tests {
     }
 
     #[test]
+    fn try_run_observing_collects_successes() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut coordinate = |state: &Scalar| Ok::<f64, ObservationFailure>(state.0);
+
+        let measurements = sampler.try_run_observing(5, &mut coordinate).unwrap();
+
+        assert_eq!(measurements.len(), 5);
+        assert_eq!(sampler.chain_ref().total_steps(), 5);
+        assert!(measurements.iter().all(|sample| sample.is_finite()));
+    }
+
+    #[test]
     fn run_observing_into_streams_to_online_stats() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
@@ -3045,6 +3049,22 @@ mod tests {
         assert_eq!(stats.count(), 25);
         assert_eq!(sampler.chain_ref().total_steps(), 25);
         assert!(stats.mean().unwrap().is_finite());
+    }
+
+    #[test]
+    fn try_run_observing_into_streams_successes() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
+        let mut sampler = sampler!(chain, &Normal, &Walk { width: 1.0 }, &mut rng);
+        let mut coordinate = |state: &Scalar| Ok::<f64, ObservationFailure>(state.0);
+        let mut stats = OnlineStats::new();
+
+        sampler
+            .try_run_observing_into(5, &mut coordinate, &mut stats)
+            .unwrap();
+
+        assert_eq!(stats.count(), 5);
+        assert_eq!(sampler.chain_ref().total_steps(), 5);
     }
 
     #[test]
@@ -3574,6 +3594,20 @@ mod tests {
     }
 
     #[test]
+    fn try_run_mut_observing_collects_successes() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
+
+        let measurements = sampler.try_run_mut_observing(5, &mut coordinate).unwrap();
+
+        assert_eq!(measurements.len(), 5);
+        assert_eq!(sampler.chain_ref().total_steps(), 5);
+        assert!(measurements.iter().all(|sample| sample.is_finite()));
+    }
+
+    #[test]
     fn try_run_mut_observing_into_streams_successes() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
@@ -3853,6 +3887,24 @@ mod tests {
             .unwrap();
 
         assert_eq!(measurements.as_slice(), &[0.0; 3]);
+        assert_eq!(sampler.chain_ref().total_steps(), 3);
+    }
+
+    #[test]
+    fn try_run_delayed_observing_into_streams_successes() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = DelayedToZero;
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
+        let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
+        let mut stats = OnlineStats::new();
+
+        sampler
+            .try_run_delayed_observing_into(3, &mut coordinate, &mut stats)
+            .unwrap();
+
+        assert_eq!(stats.count(), 3);
+        assert_eq!(stats.mean(), Some(0.0));
         assert_eq!(sampler.chain_ref().total_steps(), 3);
     }
 

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1035,6 +1035,63 @@ mod tests {
     }
 
     #[test]
+    fn online_stats_try_push_rejects_infinite_variance_accumulator_atomically() {
+        let mut stats = OnlineStats::new();
+        stats.try_push(f64::MAX).unwrap();
+
+        assert_eq!(
+            stats.try_push(0.0),
+            Err(StatisticsError::InfiniteVarianceAccumulator)
+        );
+        assert_eq!(stats.count(), 1);
+        assert_eq!(stats.mean(), Some(f64::MAX));
+        assert_eq!(stats.sample_variance(), None);
+    }
+
+    #[test]
+    fn online_stats_try_push_rejects_stale_nan_mean_atomically() {
+        let mut stats = OnlineStats {
+            count: 1,
+            mean: f64::NAN,
+            m2: 0.0,
+        };
+
+        assert_eq!(stats.try_push(1.0), Err(StatisticsError::NanMean));
+        assert_eq!(stats.count, 1);
+        assert!(stats.mean.is_nan());
+        assert_close(stats.m2, 0.0);
+    }
+
+    #[test]
+    fn online_stats_try_push_rejects_stale_nan_variance_accumulator_atomically() {
+        let mut stats = OnlineStats {
+            count: 1,
+            mean: 1.0,
+            m2: f64::NAN,
+        };
+
+        assert_eq!(
+            stats.try_push(2.0),
+            Err(StatisticsError::NanVarianceAccumulator)
+        );
+        assert_eq!(stats.count, 1);
+        assert_close(stats.mean, 1.0);
+        assert!(stats.m2.is_nan());
+    }
+
+    #[test]
+    fn online_stats_try_extend_keeps_prior_successes() {
+        let mut stats = OnlineStats::new();
+
+        assert_eq!(
+            stats.try_extend([1.0, 2.0, f64::NAN, 4.0]),
+            Err(StatisticsError::NanSample)
+        );
+        assert_eq!(stats.count(), 2);
+        assert_eq!(stats.mean(), Some(1.5));
+    }
+
+    #[test]
     fn binning_analysis_builds_power_of_two_levels() {
         let bins: BinningAnalysis = (1..=8).map(f64::from).collect();
         let estimates: Vec<_> = bins.estimates().collect();

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,5 +1,7 @@
 //! Streaming statistics for MCMC measurements.
 
+use core::hint::cold_path;
+
 use std::error::Error;
 use std::fmt;
 use std::iter;
@@ -70,9 +72,11 @@ impl Error for StatisticsError {}
 /// orthogonal error variants.
 const fn check_sample(sample: f64) -> Result<(), StatisticsError> {
     if sample.is_nan() {
+        cold_path();
         return Err(StatisticsError::NanSample);
     }
     if sample.is_infinite() {
+        cold_path();
         return Err(StatisticsError::InfiniteSample);
     }
     Ok(())
@@ -84,15 +88,19 @@ const fn check_sample(sample: f64) -> Result<(), StatisticsError> {
 /// accumulator state, which makes streaming errors more useful to debug.
 const fn check_stats(stats: &OnlineStats) -> Result<(), StatisticsError> {
     if stats.mean.is_nan() {
+        cold_path();
         return Err(StatisticsError::NanMean);
     }
     if stats.mean.is_infinite() {
+        cold_path();
         return Err(StatisticsError::InfiniteMean);
     }
     if stats.m2.is_nan() {
+        cold_path();
         return Err(StatisticsError::NanVarianceAccumulator);
     }
     if stats.m2.is_infinite() {
+        cold_path();
         return Err(StatisticsError::InfiniteVarianceAccumulator);
     }
     Ok(())
@@ -104,14 +112,15 @@ const fn check_stats(stats: &OnlineStats) -> Result<(), StatisticsError> {
 /// production runs where retaining every measurement would be expensive.
 ///
 /// ```
+/// use approx::assert_relative_eq;
 /// use markov_chain_monte_carlo::OnlineStats;
 ///
 /// let mut stats = OnlineStats::new();
 /// stats.extend([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]);
 ///
 /// assert_eq!(stats.count(), 8);
-/// assert!((stats.mean().unwrap() - 5.0).abs() < 1e-12);
-/// assert!((stats.population_variance().unwrap() - 4.0).abs() < 1e-12);
+/// assert_relative_eq!(stats.mean().unwrap(), 5.0, epsilon = 1e-12);
+/// assert_relative_eq!(stats.population_variance().unwrap(), 4.0, epsilon = 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[must_use]
@@ -924,13 +933,12 @@ impl iter::Sum<f64> for BinningAnalysis {
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
 
     fn assert_close(actual: f64, expected: f64) {
-        assert!(
-            (actual - expected).abs() < 1e-12,
-            "expected {expected}, got {actual}"
-        );
+        assert_relative_eq!(actual, expected, epsilon = 1e-12);
     }
 
     #[test]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -14,7 +14,7 @@
 //! [`DetailedBalanceBatchReport`] so callers can inspect every failed
 //! transition instead of stopping at the first violation.
 
-use core::convert::Infallible;
+use core::{convert::Infallible, hint::cold_path};
 use std::error::Error;
 use std::fmt;
 
@@ -1133,6 +1133,7 @@ const fn check_log_prob<E>(
     log_prob: f64,
 ) -> Result<(), DetailedBalanceError<E>> {
     if log_prob.is_nan() || log_prob == f64::INFINITY {
+        cold_path();
         Err(DetailedBalanceError::InvalidTargetLogProb { state, log_prob })
     } else {
         Ok(())
@@ -1145,6 +1146,7 @@ const fn check_log_q_ratio<E>(
     log_q_ratio: f64,
 ) -> Result<(), DetailedBalanceError<E>> {
     if log_q_ratio.is_nan() || log_q_ratio == f64::INFINITY {
+        cold_path();
         Err(DetailedBalanceError::InvalidLogQRatio {
             direction,
             log_q_ratio,
@@ -1412,6 +1414,7 @@ fn acceptance_probability<E>(
     log_acceptance_ratio: f64,
 ) -> Result<f64, DetailedBalanceError<E>> {
     if log_acceptance_ratio.is_nan() {
+        cold_path();
         Err(DetailedBalanceError::InvalidLogAcceptanceRatio {
             direction,
             log_acceptance_ratio,
@@ -1451,6 +1454,7 @@ mod tests {
     use core::convert::Infallible;
     use std::error::Error as _;
 
+    use approx::{assert_relative_eq, relative_eq};
     use rand::{Rng, SeedableRng, rngs::StdRng};
 
     use super::*;
@@ -2007,11 +2011,10 @@ mod tests {
         assert_eq!(report.forward_hits, 128);
         assert_eq!(report.reverse_hits, 128);
         assert!(report.is_within_tolerance(1e-12));
-        if let Some(score) = report.z_score() {
-            assert!(score.abs() < 1e-6);
-        } else {
+        let Some(score) = report.z_score() else {
             panic!("z_score returned None (standard error == 0.0) for report: {report:?}");
-        }
+        };
+        assert_relative_eq!(score, 0.0, epsilon = 1e-6);
     }
 
     #[test]
@@ -2071,7 +2074,7 @@ mod tests {
                 residual,
                 tolerance: 1e-12,
                 ..
-            } if (residual - 1.0).abs() < 1e-12
+            } if relative_eq!(residual, 1.0, epsilon = 1e-12)
         ));
     }
 
@@ -2094,7 +2097,7 @@ mod tests {
                 residual,
                 tolerance: 1e-12,
                 ..
-            } if (residual - 1.0).abs() < 1e-12
+            } if relative_eq!(residual, 1.0, epsilon = 1e-12)
         ));
     }
 
@@ -2274,7 +2277,7 @@ mod tests {
 
         assert_eq!(report.forward_hits, 128);
         assert_eq!(report.reverse_hits, 128);
-        assert!(report.log_balance_residual.abs() < f64::EPSILON);
+        assert_relative_eq!(report.log_balance_residual, 0.0);
         assert!(report.log_balance_standard_error.is_infinite());
         assert_eq!(report.z_score(), None);
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -284,8 +284,10 @@ impl<S, P: DelayedProposal<S> + ?Sized> DelayedProposal<S> for &mut P {
 mod tests {
     use core::convert::Infallible;
 
-    use super::*;
+    use approx::assert_relative_eq;
     use rand::rng;
+
+    use super::*;
 
     // --- Fixtures ---
 
@@ -320,10 +322,7 @@ mod tests {
     fn proposal_default_log_q_zero() {
         let p = SymmetricProposal;
         let ratio = p.log_q_ratio(&Scalar(0.0), &Scalar(1.0));
-        assert!(
-            ratio.abs() < f64::EPSILON,
-            "Default Proposal::log_q_ratio should be 0.0"
-        );
+        assert_relative_eq!(ratio, 0.0);
     }
 
     #[test]
@@ -332,8 +331,8 @@ mod tests {
         let shared = &proposal;
         let proposed = shared.propose(&Scalar(2.0), &mut rng());
 
-        assert!((proposed.0 - 3.0).abs() < f64::EPSILON);
-        assert!(shared.log_q_ratio(&Scalar(2.0), &proposed).abs() < f64::EPSILON);
+        assert_relative_eq!(proposed.0, 3.0);
+        assert_relative_eq!(shared.log_q_ratio(&Scalar(2.0), &proposed), 0.0);
     }
 
     #[test]
@@ -343,11 +342,11 @@ mod tests {
         let mut state = Scalar(2.0);
         let token = shared.propose_mut(&mut state, &mut rng()).unwrap();
 
-        assert!((state.0 - 3.0).abs() < f64::EPSILON);
-        assert!(shared.log_q_ratio(&state, &token).abs() < f64::EPSILON);
+        assert_relative_eq!(state.0, 3.0);
+        assert_relative_eq!(shared.log_q_ratio(&state, &token), 0.0);
 
         shared.undo(&mut state, token);
-        assert!((state.0 - 2.0).abs() < f64::EPSILON);
+        assert_relative_eq!(state.0, 2.0);
     }
 
     #[test]
@@ -357,21 +356,18 @@ mod tests {
         let mut state = Scalar(2.0);
         let token = shared.propose_mut(&mut state, &mut rng()).unwrap();
 
-        assert!((state.0 - 3.0).abs() < f64::EPSILON);
-        assert!(shared.log_q_ratio(&state, &token).abs() < f64::EPSILON);
+        assert_relative_eq!(state.0, 3.0);
+        assert_relative_eq!(shared.log_q_ratio(&state, &token), 0.0);
 
         shared.undo(&mut state, token);
-        assert!((state.0 - 2.0).abs() < f64::EPSILON);
+        assert_relative_eq!(state.0, 2.0);
     }
 
     #[test]
     fn proposal_mut_default_log_q_zero() {
         let p = SymmetricMutProposal;
         let ratio = p.log_q_ratio(&Scalar(1.0), &0.0_f64);
-        assert!(
-            ratio.abs() < f64::EPSILON,
-            "Default ProposalMut::log_q_ratio should be 0.0"
-        );
+        assert_relative_eq!(ratio, 0.0);
     }
 
     #[test]
@@ -380,8 +376,8 @@ mod tests {
         let shared = &mut proposal;
         let proposed = shared.propose(&Scalar(2.0), &mut rng());
 
-        assert!((proposed.0 - 3.0).abs() < f64::EPSILON);
-        assert!(shared.log_q_ratio(&Scalar(2.0), &proposed).abs() < f64::EPSILON);
+        assert_relative_eq!(proposed.0, 3.0);
+        assert_relative_eq!(shared.log_q_ratio(&Scalar(2.0), &proposed), 0.0);
     }
 
     struct SymmetricDelayedProposal;
@@ -426,10 +422,7 @@ mod tests {
     fn delayed_default_log_q_zero() {
         let p = SymmetricDelayedProposal;
         let ratio = p.log_q_ratio(&Scalar(0.0), &1.0).unwrap();
-        assert!(
-            ratio.abs() < f64::EPSILON,
-            "Default DelayedProposal::log_q_ratio should be 0.0"
-        );
+        assert_relative_eq!(ratio, 0.0);
     }
 
     #[test]
@@ -446,20 +439,18 @@ mod tests {
         let state = Scalar(0.0);
         let plan = shared.propose_plan(&state, &mut rng()).unwrap().unwrap();
 
-        assert!((plan - 1.0).abs() < f64::EPSILON);
-        assert!(
-            (shared
+        assert_relative_eq!(plan, 1.0);
+        assert_relative_eq!(
+            shared
                 .proposed_log_prob(&state, &plan, &ZeroTarget)
-                .unwrap()
-                + 1.0)
-                .abs()
-                < f64::EPSILON
+                .unwrap(),
+            -1.0
         );
-        assert!(shared.log_q_ratio(&state, &plan).unwrap().abs() < f64::EPSILON);
-        assert!((shared.info(&plan) - 1.0).abs() < f64::EPSILON);
+        assert_relative_eq!(shared.log_q_ratio(&state, &plan).unwrap(), 0.0);
+        assert_relative_eq!(shared.info(&plan), 1.0);
 
         let mut committed = Scalar(0.0);
         shared.commit(&mut committed, plan, &mut rng()).unwrap();
-        assert!((committed.0 - 1.0).abs() < f64::EPSILON);
+        assert_relative_eq!(committed.0, 1.0);
     }
 }

--- a/tests/proptest_chain.rs
+++ b/tests/proptest_chain.rs
@@ -5,6 +5,7 @@
 
 use core::convert::Infallible;
 
+use approx::relative_eq;
 use markov_chain_monte_carlo::prelude::by_value::Proposal;
 use markov_chain_monte_carlo::prelude::delayed::DelayedProposal;
 use markov_chain_monte_carlo::prelude::in_place::ProposalMut;
@@ -122,7 +123,7 @@ proptest! {
 
         let expected = Normal.log_prob(chain.state());
         prop_assert!(
-            (chain.log_prob() - expected).abs() < 1e-12,
+            relative_eq!(chain.log_prob(), expected, epsilon = 1e-12),
             "log_prob {:.15} != target {:.15} after {} steps",
             chain.log_prob(), expected, steps,
         );
@@ -146,7 +147,7 @@ proptest! {
 
         let expected = Normal.log_prob(chain.state());
         prop_assert!(
-            (chain.log_prob() - expected).abs() < 1e-12,
+            relative_eq!(chain.log_prob(), expected, epsilon = 1e-12),
             "log_prob {:.15} != target {:.15} after {} steps",
             chain.log_prob(), expected, steps,
         );
@@ -181,7 +182,7 @@ proptest! {
             "Final states diverged after {} steps", steps,
         );
         prop_assert!(
-            (chain_clone.log_prob() - chain_mut.log_prob()).abs() < 1e-12,
+            relative_eq!(chain_clone.log_prob(), chain_mut.log_prob(), epsilon = 1e-12),
             "log_prob diverged: clone={:.15}, mut={:.15}",
             chain_clone.log_prob(), chain_mut.log_prob(),
         );
@@ -219,7 +220,7 @@ proptest! {
             "Final states diverged after {} steps", steps,
         );
         prop_assert!(
-            (chain_clone.log_prob() - chain_delayed.log_prob()).abs() < 1e-12,
+            relative_eq!(chain_clone.log_prob(), chain_delayed.log_prob(), epsilon = 1e-12),
             "log_prob diverged: clone={:.15}, delayed={:.15}",
             chain_clone.log_prob(), chain_delayed.log_prob(),
         );
@@ -296,7 +297,7 @@ proptest! {
         // Sampler
         let chain2 = Chain::new(Scalar(initial), &Normal).unwrap();
         let mut rng2 = StdRng::seed_from_u64(seed);
-        let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2);
+        let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2).unwrap();
         sampler.run(steps as usize).unwrap();
 
         prop_assert_eq!(chain.state(), sampler.chain_ref().state());
@@ -325,7 +326,7 @@ proptest! {
         // Sampler
         let chain2 = Chain::new(Scalar(initial), &Normal).unwrap();
         let mut rng2 = StdRng::seed_from_u64(seed);
-        let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2);
+        let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2).unwrap();
         sampler.run_mut(steps as usize).unwrap();
 
         prop_assert_eq!(chain.state(), sampler.chain_ref().state());


### PR DESCRIPTION
- Add ChainCheckpoint as the portable restore format and recompute cached log-probabilities through Chain::from_checkpoint.
- Make Sampler::new validate the chain against the sampler target and return Result.
- Add sampler-level reset and replacement helpers so callers do not need mutable access to the underlying Chain.
- Report checkpoint and current-state cache failures with dedicated McmcError variants.
- Refresh README organization and run coverage with all crate features enabled in local CI.

BREAKING CHANGE: Sampler::new now returns Result<Self, McmcError>, Sampler::chain_mut has been removed, and serde resumes should deserialize ChainCheckpoint and restore with Chain::from_checkpoint instead of deserializing Chain directly.

Closes #45