### PR TITLE
feat!: add constructors for fallible stats and public reports

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -87,7 +87,7 @@ just ci
 just publish-check
 ```
 
-`just fix` reruns formatters and auto-fixes. `just ci` covers formatting, Clippy, Python tooling checks, benchmark harness compilation, docs, tests, examples, example output validation, YAML, TOML, Markdown, spelling, GitHub Actions, and Semgrep checks. `just publish-check` validates crates.io metadata and runs `cargo publish --locked --allow-dirty --dry-run`.
+`just fix` reruns formatters and auto-fixes. `just ci` covers formatting, Clippy, Python tooling checks, benchmark harness compilation, docs, tests, example output validation, YAML, TOML, Markdown, spelling, GitHub Actions, and Semgrep checks. `just publish-check` validates crates.io metadata and runs `cargo publish --locked --allow-dirty --dry-run`.
 
 ### 5. Commit, push, and open the PR
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -42,7 +42,7 @@ For cross-repo muscle memory, the same checks are also available through grouped
 - `just lint-config` - JSON, TOML, YAML, GitHub Actions, and Actions security validation
 - `just lint-docs` - Markdown formatting and spellcheck
 
-`just ci` runs `just check` (including `zizmor`), benchmark harness compilation, documentation, tests, examples, and deterministic example-output validation.
+`just ci` runs `just check` (including `zizmor`), benchmark harness compilation, documentation, tests, and deterministic example-output validation.
 
 ## Setup
 
@@ -73,7 +73,7 @@ Non-Rust tooling uses a 160-column policy: Ruff for Python support scripts, dpri
 - Integration tests through nextest: `just test-integration`
 - Python tooling tests: `just test-python`
 - Single runnable test by name filter: `cargo nextest run chain_samples_near_mode`
-- Examples: `just examples`
+- Examples: `just examples` builds all examples once, then runs the compiled binaries.
 
 ## Benchmarks
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,13 @@
 
 This roadmap records likely directions for the `markov-chain-monte-carlo` crate. It is not a stability promise; release scope depends on scientific need, API maturity, and validation quality.
 
-## v0.3.0 Scientific Foundations
+Pre-1.0 releases may still revise public APIs when that makes the crate more correct, but patch releases should stay boring: fixes, documentation, and tooling hardening that are compatible with the current minor line. New sampler APIs, changed acceptance semantics, and MSRV bumps belong in minor releases so Cargo users on `0.x` ranges are not surprised by patch updates.
 
-The v0.3.0 milestone focuses on making the crate useful as the sampling layer for downstream research crates:
+## Completed
+
+### v0.3.0 Scientific Foundations
+
+The v0.3.0 milestone made the crate useful as the sampling layer for downstream research crates:
 
 - [x] Delayed-commit proposals for accept-before-mutation workflows
 - [x] Observable measurement framework
@@ -13,26 +17,54 @@ The v0.3.0 milestone focuses on making the crate useful as the sampling layer fo
 - [x] Optional `serde` checkpointing
 - [x] Detailed-balance verification for by-value, in-place, and delayed proposals
 
-## Near-Term Candidates
+## Planned Milestones
 
-Likely follow-up work:
+### v0.4.0 Resumable CDT Integration
 
-- More convergence diagnostics, such as effective sample size, autocorrelation reports, and R-hat helpers
-- Parallel-chain utilities that keep random-stream management explicit
-- Additional examples showing multi-chain analysis and checkpoint/resume workflows
-- More ergonomic detailed-balance fixtures for common discrete proposal patterns
-- Continuous-proposal diagnostics that avoid exact-hit assumptions ([#42](https://github.com/acgetchell/markov-chain-monte-carlo/issues/42))
-- Documentation that connects this crate to `causal-triangulations` proposal validation
+The next feature release should focus on downstream sampler integration rather than a grab bag of diagnostics. This is the right place for the Rust 1.96.0 MSRV/toolchain refresh once Rust 1.96.0 is released.
 
-## Longer-Term Ideas
+- [#65](https://github.com/acgetchell/markov-chain-monte-carlo/issues/65) - Update Rust toolchain and MSRV to 1.96.0
+- [#60](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60) - Expose resumable sampler state for chunked runs
+- [#61](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61) - Expose delayed-step hooks or telemetry for domain-specific sampler integration
+- [#59](https://github.com/acgetchell/markov-chain-monte-carlo/issues/59) - Support additive target bias terms in Metropolis-Hastings acceptance
+- [#48](https://github.com/acgetchell/markov-chain-monte-carlo/issues/48) - Investigate detailed balance for delayed proposals with variable valid-site counts
+- [#62](https://github.com/acgetchell/markov-chain-monte-carlo/issues/62) - Clean up doctest/example unwraps and enforce with Semgrep
 
-Exploratory directions:
+### v0.5.0 Adaptive Diagnostics
 
-- Adaptive Metropolis-Hastings with explicit adaptation windows and post-adaptation freezing
-- Simulated annealing or tempering workflows
-- Learned or data-informed proposal kernels
-- More structured diagnostic reports for publication-quality simulation workflows
-- Optional integrations with downstream geometry and physics crates
+After the CDT-facing continuation and acceptance APIs settle, invest in classical adaptive sampling and diagnostics that help users decide whether a run is scientifically trustworthy. This should happen before learned-proposal work so there is a baseline to compare against.
+
+- [#10](https://github.com/acgetchell/markov-chain-monte-carlo/issues/10) - Adaptive Metropolis-Hastings
+- [#13](https://github.com/acgetchell/markov-chain-monte-carlo/issues/13) - Diagnostics: ESS, autocorrelation, and R-hat
+- [#42](https://github.com/acgetchell/markov-chain-monte-carlo/issues/42) - Continuous proposal diagnostics
+- [#20](https://github.com/acgetchell/markov-chain-monte-carlo/issues/20) - Benchmark distributions
+- [#21](https://github.com/acgetchell/markov-chain-monte-carlo/issues/21) - Tracing integration for long-running simulations
+
+### v0.6.0 Multi-Chain, Tempering, and Learned Proposals
+
+Multi-chain execution and tempering are natural prerequisites for serious learned-proposal experiments: they provide independent-chain comparison, ensemble diagnostics, and rugged-target baselines. Learned proposals align with near-term AI doctorate work, so they should land while the research context is active rather than being deferred until the end of the pre-1.0 cycle.
+
+- [#12](https://github.com/acgetchell/markov-chain-monte-carlo/issues/12) - Parallel chains
+- [#11](https://github.com/acgetchell/markov-chain-monte-carlo/issues/11) - Simulated annealing / tempering
+- [#14](https://github.com/acgetchell/markov-chain-monte-carlo/issues/14) - Learned proposals
+
+### v0.7.0 Portability
+
+Portability work should be done after optional integrations are clearer, so the `std` feature boundary can be designed around real dependencies.
+
+- [#22](https://github.com/acgetchell/markov-chain-monte-carlo/issues/22) - `no_std` support
+
+### v1.0.0 Stabilization
+
+The v1.0.0 release should be about stabilizing the API surface, documentation contract, and compatibility story after the pre-1.0 milestones have shaken out the sampler, diagnostics, and feature-gating design.
+
+## Maintenance Backlog
+
+These issues can land whenever they are useful and do not need to drive the public release sequence:
+
+- [#53](https://github.com/acgetchell/markov-chain-monte-carlo/issues/53) - Replace Node markdown and YAML tooling with Rust-native tools
+- [#56](https://github.com/acgetchell/markov-chain-monte-carlo/issues/56) - Speed up CI without reducing coverage
+- [#57](https://github.com/acgetchell/markov-chain-monte-carlo/issues/57) - Evaluate CI shape changes for faster builds
 
 ## Non-Goals
 

--- a/examples/detailed_balance.rs
+++ b/examples/detailed_balance.rs
@@ -78,11 +78,7 @@ impl DelayedProposal<bool> for DelayedFlip {
 
 fn main() -> Result<(), DetailedBalanceError> {
     let target = TwoStateTarget;
-    let config = DetailedBalanceConfig {
-        samples: 256,
-        tolerance: 1e-10,
-        min_hits: 1,
-    };
+    let config = DetailedBalanceConfig::new(256, 1e-10, 1);
 
     let mut rng = StdRng::seed_from_u64(42);
     let by_value = verify_detailed_balance(&false, &true, &target, &Flip, &mut rng, config)?;
@@ -102,12 +98,9 @@ fn main() -> Result<(), DetailedBalanceError> {
 
     let forward = |plan: &bool| *plan;
     let reverse = |plan: &bool| !*plan;
-    let delayed_transitions = [DetailedBalanceDelayedTransition {
-        current: &false,
-        proposed: &true,
-        forward_plan_matches: &forward,
-        reverse_plan_matches: &reverse,
-    }];
+    let delayed_transitions = [DetailedBalanceDelayedTransition::new(
+        &false, &true, &forward, &reverse,
+    )];
     let mut rng = StdRng::seed_from_u64(42);
     let mut delayed_proposal = DelayedFlip;
     let delayed = verify_detailed_balance_delayed_many(

--- a/justfile
+++ b/justfile
@@ -12,6 +12,7 @@ git_cliff_version := "2.13.1"
 taplo_version := "0.10.0"
 typos_version := "1.46.3"
 zizmor_version := "1.25.2"
+example_names := "detailed_balance normal_1d ising_1d iterator_sampling"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes examples from reports while allowing tests to exercise library code.
@@ -183,7 +184,7 @@ check-fast:
 
 # CI simulation: comprehensive validation.
 # Depends on `check`, which includes `zizmor` GitHub Actions security analysis.
-ci: check bench-compile doc test-all examples validate-examples
+ci: check bench-compile doc test-all validate-examples
     @echo "🎯 CI checks complete!"
 
 # Clean build artifacts
@@ -222,11 +223,19 @@ doc:
     cargo doc --locked --no-deps --document-private-items
 
 # Examples
-examples:
-    cargo run --locked --quiet --example detailed_balance
-    cargo run --locked --quiet --example normal_1d
-    cargo run --locked --quiet --example ising_1d
-    cargo run --locked --quiet --example iterator_sampling
+_build-examples:
+    cargo build --locked --examples
+
+examples: _build-examples
+    #!/usr/bin/env bash
+    set -euo pipefail
+    suffix=""
+    if [[ "${OS:-}" == "Windows_NT" ]]; then
+        suffix=".exe"
+    fi
+    for example in {{example_names}}; do
+        "target/debug/examples/${example}${suffix}"
+    done
 
 # Fix (mutating): apply formatters
 fix: fmt markdown-fix python-fix toml-fmt
@@ -569,29 +578,35 @@ toml-lint: _ensure-taplo
     fi
 
 # Validate example output (seeded, deterministic)
-validate-examples:
+validate-examples: _build-examples
     #!/usr/bin/env bash
     set -euo pipefail
-    output=$(cargo run --locked --quiet --example detailed_balance)
-    echo "$output"
-    echo "$output" | grep -q "Detailed balance checks passed" || { echo "❌ detailed_balance: Missing success marker"; exit 1; }
-    echo "$output" | grep -q "by-value residual" || { echo "❌ detailed_balance: Missing by-value residual"; exit 1; }
-    echo "✅ detailed_balance validated"
-    output=$(cargo run --locked --quiet --example normal_1d)
-    echo "$output"
-    echo "$output" | grep -q "Sample mean" || { echo "❌ normal_1d: Missing sample mean"; exit 1; }
-    echo "$output" | grep -q "Acceptance rate" || { echo "❌ normal_1d: Missing acceptance rate"; exit 1; }
-    echo "✅ normal_1d validated"
-    output=$(cargo run --locked --quiet --example ising_1d)
-    echo "$output"
-    echo "$output" | grep -q "<m>" || { echo "❌ ising_1d: Missing magnetization"; exit 1; }
-    echo "$output" | grep -q "acceptance rate" || { echo "❌ ising_1d: Missing acceptance rate"; exit 1; }
-    echo "✅ ising_1d validated"
-    output=$(cargo run --locked --quiet --example iterator_sampling)
-    echo "$output"
-    echo "$output" | grep -q "Sample mean" || { echo "❌ iterator_sampling: Missing sample mean"; exit 1; }
-    echo "$output" | grep -q "Acceptance rate" || { echo "❌ iterator_sampling: Missing acceptance rate"; exit 1; }
-    echo "✅ iterator_sampling validated"
+
+    example_binary() {
+        local example="$1"
+        local suffix=""
+        if [[ "${OS:-}" == "Windows_NT" ]]; then
+            suffix=".exe"
+        fi
+        printf 'target/debug/examples/%s%s' "$example" "$suffix"
+    }
+
+    validate_example() {
+        local example="$1"
+        shift
+        local output
+        output=$("$(example_binary "$example")")
+        echo "$output"
+        for marker in "$@"; do
+            echo "$output" | grep -q "$marker" || { echo "❌ ${example}: Missing marker '${marker}'"; exit 1; }
+        done
+        echo "✅ ${example} validated"
+    }
+
+    validate_example detailed_balance "Detailed balance checks passed" "by-value residual"
+    validate_example normal_1d "Sample mean" "Acceptance rate"
+    validate_example ising_1d "<m>" "acceptance rate"
+    validate_example iterator_sampling "Sample mean" "Acceptance rate"
 
 validate-json: _ensure-jq
     #!/usr/bin/env bash

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -74,6 +74,7 @@ fn check_log_q_ratio(log_q: f64) -> Result<(), McmcError> {
 
 /// Telemetry for a single Metropolis-Hastings step.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 #[must_use]
 pub struct Step<I> {
     /// Whether the move was accepted and committed.

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -110,6 +110,9 @@ const fn check_stats(stats: &OnlineStats) -> Result<(), StatisticsError> {
 ///
 /// `OnlineStats` updates in constant memory and is suitable for long
 /// production runs where retaining every measurement would be expensive.
+/// Use [`try_push`](Self::try_push), [`try_extend`](Self::try_extend), or
+/// [`try_from_iter`](Self::try_from_iter) when non-finite measurements should be
+/// rejected instead of becoming part of the accumulator state.
 ///
 /// ```
 /// use approx::assert_relative_eq;
@@ -145,6 +148,34 @@ impl OnlineStats {
             mean: 0.0,
             m2: 0.0,
         }
+    }
+
+    /// Build an accumulator from finite samples.
+    ///
+    /// Unlike [`FromIterator`], this validates every sample and leaves no
+    /// partially constructed accumulator behind on error.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
+    ///
+    /// assert_eq!(
+    ///     OnlineStats::try_from_iter([1.0, f64::NAN]),
+    ///     Err(StatisticsError::NanSample)
+    /// );
+    ///
+    /// let stats = OnlineStats::try_from_iter([1.0, 3.0])?;
+    /// assert_eq!(stats.mean(), Some(2.0));
+    /// # Ok::<(), StatisticsError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StatisticsError`] on the first invalid sample or non-finite
+    /// accumulator update.
+    pub fn try_from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Result<Self, StatisticsError> {
+        let mut stats = Self::new();
+        stats.try_extend(iter)?;
+        Ok(stats)
     }
 
     /// Add one sample to the accumulator.
@@ -557,6 +588,10 @@ impl BinningLevel {
 /// once the estimates plateau, that value is the usual binning estimate for the
 /// standard error of an MCMC mean.
 ///
+/// Use [`try_push`](Self::try_push), [`try_extend`](Self::try_extend), or
+/// [`try_from_iter`](Self::try_from_iter) when non-finite measurements should be
+/// rejected instead of becoming part of the binning hierarchy.
+///
 /// ```
 /// use markov_chain_monte_carlo::BinningAnalysis;
 ///
@@ -574,6 +609,7 @@ impl BinningLevel {
 pub struct BinningAnalysis {
     count: usize,
     levels: Vec<BinningLevel>,
+    staged_levels: Vec<(usize, BinningLevel)>,
 }
 
 impl BinningAnalysis {
@@ -589,7 +625,36 @@ impl BinningAnalysis {
         Self {
             count: 0,
             levels: Vec::new(),
+            staged_levels: Vec::new(),
         }
+    }
+
+    /// Build a binning analysis from finite samples.
+    ///
+    /// Unlike [`FromIterator`], this validates every sample and leaves no
+    /// partially constructed analysis behind on error.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
+    ///
+    /// assert_eq!(
+    ///     BinningAnalysis::try_from_iter([1.0, f64::INFINITY]),
+    ///     Err(StatisticsError::InfiniteSample)
+    /// );
+    ///
+    /// let bins = BinningAnalysis::try_from_iter([1.0, 2.0, 3.0])?;
+    /// assert_eq!(bins.mean(), Some(2.0));
+    /// # Ok::<(), StatisticsError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StatisticsError`] on the first invalid sample or non-finite
+    /// accumulator update.
+    pub fn try_from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Result<Self, StatisticsError> {
+        let mut analysis = Self::new();
+        analysis.try_extend(iter)?;
+        Ok(analysis)
     }
 
     /// Add one measurement.
@@ -635,10 +700,10 @@ impl BinningAnalysis {
     /// online binning accumulator becomes non-finite while updating.
     pub fn try_push(&mut self, sample: f64) -> Result<(), StatisticsError> {
         check_sample(sample)?;
-        let staged_levels = self.staged_push(sample)?;
+        self.stage_push(sample)?;
 
         self.count += 1;
-        for (level_index, level) in staged_levels {
+        for (level_index, level) in self.staged_levels.drain(..) {
             if level_index == self.levels.len() {
                 self.levels.push(level);
             } else {
@@ -689,6 +754,7 @@ impl BinningAnalysis {
     pub fn clear(&mut self) {
         self.count = 0;
         self.levels.clear();
+        self.staged_levels.clear();
     }
 
     /// Number of original measurements pushed into the analysis.
@@ -828,8 +894,8 @@ impl BinningAnalysis {
     /// A single sample only touches a prefix of the binning hierarchy.  Staging
     /// that prefix keeps `try_push` failure-atomic without cloning untouched
     /// coarser levels.
-    fn staged_push(&self, sample: f64) -> Result<Vec<(usize, BinningLevel)>, StatisticsError> {
-        let mut staged_levels = Vec::new();
+    fn stage_push(&mut self, sample: f64) -> Result<(), StatisticsError> {
+        self.staged_levels.clear();
         let mut level_index = 0;
         let mut block_mean = sample;
 
@@ -838,10 +904,13 @@ impl BinningAnalysis {
                 .levels
                 .get(level_index)
                 .cloned()
-                .unwrap_or_else(|| self.new_staged_level(level_index, &staged_levels));
+                .unwrap_or_else(|| self.new_staged_level(level_index));
             let next_block_mean = level.push_block_mean(block_mean);
-            level.check()?;
-            staged_levels.push((level_index, level));
+            if let Err(err) = level.check() {
+                self.staged_levels.clear();
+                return Err(err);
+            }
+            self.staged_levels.push((level_index, level));
 
             if let Some(mean) = next_block_mean {
                 block_mean = mean;
@@ -851,21 +920,17 @@ impl BinningAnalysis {
             }
         }
 
-        Ok(staged_levels)
+        Ok(())
     }
 
     /// Create a lazily allocated level without mutating the visible hierarchy.
     ///
     /// This mirrors `ensure_level` for staged updates, deriving the next block
     /// size from either the latest staged level or the existing hierarchy.
-    fn new_staged_level(
-        &self,
-        level_index: usize,
-        staged_levels: &[(usize, BinningLevel)],
-    ) -> BinningLevel {
+    fn new_staged_level(&self, level_index: usize) -> BinningLevel {
         let block_size = if level_index == 0 {
             1
-        } else if let Some((_, previous)) = staged_levels.last() {
+        } else if let Some((_, previous)) = self.staged_levels.last() {
             previous.block_size.saturating_mul(2)
         } else {
             self.levels[level_index - 1].block_size.saturating_mul(2)
@@ -1092,6 +1157,18 @@ mod tests {
     }
 
     #[test]
+    fn online_stats_try_from_iter_validates_all_samples() {
+        let stats = OnlineStats::try_from_iter([1.0, 3.0]).unwrap();
+        assert_eq!(stats.count(), 2);
+        assert_eq!(stats.mean(), Some(2.0));
+
+        assert_eq!(
+            OnlineStats::try_from_iter([1.0, f64::NAN, 3.0]),
+            Err(StatisticsError::NanSample)
+        );
+    }
+
+    #[test]
     fn binning_analysis_builds_power_of_two_levels() {
         let bins: BinningAnalysis = (1..=8).map(f64::from).collect();
         let estimates: Vec<_> = bins.estimates().collect();
@@ -1185,6 +1262,7 @@ mod tests {
         assert_eq!(bins.count(), 1);
         assert_eq!(bins.mean(), Some(f64::MAX));
         assert_eq!(bins.estimates().next().unwrap().block_count(), 1);
+        assert!(bins.staged_levels.is_empty());
     }
 
     #[test]
@@ -1227,5 +1305,23 @@ mod tests {
         );
         assert_eq!(bins.count(), 2);
         assert_eq!(bins.mean(), Some(1.5));
+    }
+
+    #[test]
+    fn binning_analysis_try_from_iter_validates_all_samples() {
+        let bins = BinningAnalysis::try_from_iter([1.0, 2.0, 3.0, 4.0]).unwrap();
+        let estimates: Vec<_> = bins.estimates().collect();
+
+        assert_eq!(bins.count(), 4);
+        assert_eq!(bins.mean(), Some(2.5));
+        assert_eq!(estimates.len(), 3);
+        assert_eq!(estimates[0].block_count(), 4);
+        assert_eq!(estimates[1].block_count(), 2);
+        assert_eq!(estimates[2].block_count(), 1);
+
+        assert_eq!(
+            BinningAnalysis::try_from_iter([1.0, f64::INFINITY, 3.0]),
+            Err(StatisticsError::InfiniteSample)
+        );
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -24,6 +24,7 @@ use crate::{DelayedProposal, Proposal, ProposalMut, Target};
 
 /// Configuration for empirical detailed-balance verification.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 #[must_use]
 pub struct DetailedBalanceConfig {
     /// Number of proposal samples drawn in each direction.
@@ -34,13 +35,34 @@ pub struct DetailedBalanceConfig {
     pub min_hits: usize,
 }
 
+impl DetailedBalanceConfig {
+    /// Create detailed-balance verification configuration.
+    ///
+    /// The verification functions validate these values before sampling.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DetailedBalanceConfig;
+    ///
+    /// let config = DetailedBalanceConfig::new(128, 1e-12, 1);
+    ///
+    /// assert_eq!(config.samples, 128);
+    /// assert_eq!(config.tolerance, 1e-12);
+    /// assert_eq!(config.min_hits, 1);
+    /// ```
+    pub const fn new(samples: usize, tolerance: f64, min_hits: usize) -> Self {
+        Self {
+            samples,
+            tolerance,
+            min_hits,
+        }
+    }
+}
+
 impl Default for DetailedBalanceConfig {
     fn default() -> Self {
-        Self {
-            samples: 10_000,
-            tolerance: 0.1,
-            min_hits: 30,
-        }
+        Self::new(10_000, 0.1, 30)
     }
 }
 
@@ -82,6 +104,7 @@ impl fmt::Display for DetailedBalanceState {
 
 /// Empirical detailed-balance verification report.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 #[must_use]
 pub struct DetailedBalanceReport {
     /// Number of proposal samples drawn in each direction.
@@ -105,6 +128,53 @@ pub struct DetailedBalanceReport {
 }
 
 impl DetailedBalanceReport {
+    /// Create a synthetic detailed-balance report from already-computed fields.
+    ///
+    /// Most callers receive reports from [`verify_detailed_balance`] or one of
+    /// its variants.  This constructor is mainly useful for tests and downstream
+    /// tooling that need to exercise report helpers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use markov_chain_monte_carlo::DetailedBalanceReport;
+    ///
+    /// let report = DetailedBalanceReport::new(
+    ///     128, 64, 64, 0.0, 0.0, 0.0, 0.0, 0.01, 0.05,
+    /// );
+    ///
+    /// assert_eq!(report.samples, 128);
+    /// assert_relative_eq!(report.z_score().unwrap(), 0.2, epsilon = 1e-12);
+    /// ```
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "constructor mirrors the public report fields for synthetic reports"
+    )]
+    pub const fn new(
+        samples: usize,
+        forward_hits: usize,
+        reverse_hits: usize,
+        forward_log_proposal: f64,
+        reverse_log_proposal: f64,
+        forward_log_transition: f64,
+        reverse_log_transition: f64,
+        log_balance_residual: f64,
+        log_balance_standard_error: f64,
+    ) -> Self {
+        Self {
+            samples,
+            forward_hits,
+            reverse_hits,
+            forward_log_proposal,
+            reverse_log_proposal,
+            forward_log_transition,
+            reverse_log_transition,
+            log_balance_residual,
+            log_balance_standard_error,
+        }
+    }
+
     /// Return true when the absolute residual is within `tolerance`.
     ///
     /// # Examples
@@ -112,17 +182,9 @@ impl DetailedBalanceReport {
     /// ```
     /// use markov_chain_monte_carlo::DetailedBalanceReport;
     ///
-    /// let report = DetailedBalanceReport {
-    ///     samples: 128,
-    ///     forward_hits: 128,
-    ///     reverse_hits: 128,
-    ///     forward_log_proposal: 0.0,
-    ///     reverse_log_proposal: 0.0,
-    ///     forward_log_transition: 0.0,
-    ///     reverse_log_transition: 0.0,
-    ///     log_balance_residual: 1e-3,
-    ///     log_balance_standard_error: 0.01,
-    /// };
+    /// let report = DetailedBalanceReport::new(
+    ///     128, 128, 128, 0.0, 0.0, 0.0, 0.0, 1e-3, 0.01,
+    /// );
     ///
     /// assert!(report.is_within_tolerance(0.01));
     /// assert!(!report.is_within_tolerance(1e-4));
@@ -142,17 +204,9 @@ impl DetailedBalanceReport {
     /// ```
     /// use markov_chain_monte_carlo::DetailedBalanceReport;
     ///
-    /// let report = DetailedBalanceReport {
-    ///     samples: 128,
-    ///     forward_hits: 128,
-    ///     reverse_hits: 128,
-    ///     forward_log_proposal: 0.0,
-    ///     reverse_log_proposal: 0.0,
-    ///     forward_log_transition: 0.0,
-    ///     reverse_log_transition: 0.0,
-    ///     log_balance_residual: 0.02,
-    ///     log_balance_standard_error: 0.01,
-    /// };
+    /// let report = DetailedBalanceReport::new(
+    ///     128, 128, 128, 0.0, 0.0, 0.0, 0.0, 0.02, 0.01,
+    /// );
     ///
     /// assert_eq!(report.z_score(), Some(2.0));
     /// ```
@@ -337,6 +391,7 @@ where
 
 /// One failed detailed-balance check in a batch.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 #[must_use]
 pub struct DetailedBalanceFailure<E = Infallible> {
     /// Zero-based index of the checked transition.
@@ -345,8 +400,29 @@ pub struct DetailedBalanceFailure<E = Infallible> {
     pub error: DetailedBalanceError<E>,
 }
 
+impl<E> DetailedBalanceFailure<E> {
+    /// Create a batch failure entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{DetailedBalanceError, DetailedBalanceFailure};
+    ///
+    /// let failure = DetailedBalanceFailure::new(
+    ///     2,
+    ///     DetailedBalanceError::<()>::InvalidSamples { samples: 0 },
+    /// );
+    ///
+    /// assert_eq!(failure.index, 2);
+    /// ```
+    pub const fn new(index: usize, error: DetailedBalanceError<E>) -> Self {
+        Self { index, error }
+    }
+}
+
 /// Batch detailed-balance report that preserves every failure.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 #[must_use]
 pub struct DetailedBalanceBatchReport<E = Infallible> {
     /// Successful transition reports.
@@ -356,6 +432,31 @@ pub struct DetailedBalanceBatchReport<E = Infallible> {
 }
 
 impl<E> DetailedBalanceBatchReport<E> {
+    /// Create a batch report from successful reports and failures.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{DetailedBalanceBatchReport, DetailedBalanceReport};
+    ///
+    /// let report = DetailedBalanceReport::new(
+    ///     128, 128, 128, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01,
+    /// );
+    /// let batch: DetailedBalanceBatchReport = DetailedBalanceBatchReport::new(
+    ///     vec![report],
+    ///     Vec::new(),
+    /// );
+    ///
+    /// assert!(batch.is_success());
+    /// assert_eq!(batch.reports.len(), 1);
+    /// ```
+    pub const fn new(
+        reports: Vec<DetailedBalanceReport>,
+        failures: Vec<DetailedBalanceFailure<E>>,
+    ) -> Self {
+        Self { reports, failures }
+    }
+
     /// Return true when every transition passed.
     ///
     /// # Examples
@@ -363,10 +464,8 @@ impl<E> DetailedBalanceBatchReport<E> {
     /// ```
     /// use markov_chain_monte_carlo::DetailedBalanceBatchReport;
     ///
-    /// let batch: DetailedBalanceBatchReport = DetailedBalanceBatchReport {
-    ///     reports: Vec::new(),
-    ///     failures: Vec::new(),
-    /// };
+    /// let batch: DetailedBalanceBatchReport =
+    ///     DetailedBalanceBatchReport::new(Vec::new(), Vec::new());
     ///
     /// assert!(batch.is_success());
     /// ```
@@ -377,6 +476,7 @@ impl<E> DetailedBalanceBatchReport<E> {
 }
 
 /// One delayed-commit transition to check in a batch.
+#[non_exhaustive]
 #[must_use]
 pub struct DetailedBalanceDelayedTransition<'a, S, Plan> {
     /// Current endpoint for the transition.
@@ -387,6 +487,41 @@ pub struct DetailedBalanceDelayedTransition<'a, S, Plan> {
     pub forward_plan_matches: &'a dyn Fn(&Plan) -> bool,
     /// Predicate identifying sampled reverse plans from `proposed` to `current`.
     pub reverse_plan_matches: &'a dyn Fn(&Plan) -> bool,
+}
+
+impl<'a, S, Plan> DetailedBalanceDelayedTransition<'a, S, Plan> {
+    /// Create a delayed-transition batch item from endpoint states and plan predicates.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DetailedBalanceDelayedTransition;
+    ///
+    /// let forward = |plan: &bool| *plan;
+    /// let reverse = |plan: &bool| !*plan;
+    /// let transition = DetailedBalanceDelayedTransition::new(
+    ///     &false,
+    ///     &true,
+    ///     &forward,
+    ///     &reverse,
+    /// );
+    ///
+    /// assert_eq!(transition.current, &false);
+    /// assert!((transition.forward_plan_matches)(&true));
+    /// ```
+    pub const fn new(
+        current: &'a S,
+        proposed: &'a S,
+        forward_plan_matches: &'a dyn Fn(&Plan) -> bool,
+        reverse_plan_matches: &'a dyn Fn(&Plan) -> bool,
+    ) -> Self {
+        Self {
+            current,
+            proposed,
+            forward_plan_matches,
+            reverse_plan_matches,
+        }
+    }
 }
 
 /// Empirically verify detailed balance for one discrete by-value transition.
@@ -425,11 +560,7 @@ pub struct DetailedBalanceDelayedTransition<'a, S, Plan> {
 ///     &Flat,
 ///     &Flip,
 ///     &mut rng,
-///     DetailedBalanceConfig {
-///         samples: 128,
-///         tolerance: 1e-12,
-///         min_hits: 1,
-///     },
+///     DetailedBalanceConfig::new(128, 1e-12, 1),
 /// )?;
 ///
 /// assert_eq!(report.forward_hits, 128);
@@ -491,11 +622,7 @@ where
 ///     &Flat,
 ///     &Flip,
 ///     &mut rng,
-///     DetailedBalanceConfig {
-///         samples: 128,
-///         tolerance: 1e-12,
-///         min_hits: 1,
-///     },
+///     DetailedBalanceConfig::new(128, 1e-12, 1),
 /// )?;
 ///
 /// assert!(batch.is_success());
@@ -521,17 +648,16 @@ where
     R: Rng + ?Sized,
     I: IntoIterator<Item = (&'a S, &'a S)>,
 {
-    let mut batch = DetailedBalanceBatchReport {
-        reports: Vec::new(),
-        failures: Vec::new(),
-    };
+    let mut batch = DetailedBalanceBatchReport::new(Vec::new(), Vec::new());
 
     validate_config(config)?;
 
     for (index, (current, proposed)) in pairs.into_iter().enumerate() {
         match verify_detailed_balance_unchecked(current, proposed, target, proposal, rng, config) {
             Ok(report) => batch.reports.push(report),
-            Err(error) => batch.failures.push(DetailedBalanceFailure { index, error }),
+            Err(error) => batch
+                .failures
+                .push(DetailedBalanceFailure::new(index, error)),
         }
     }
 
@@ -579,11 +705,7 @@ where
 ///     &Flat,
 ///     &Flip,
 ///     &mut rng,
-///     DetailedBalanceConfig {
-///         samples: 128,
-///         tolerance: 1e-12,
-///         min_hits: 1,
-///     },
+///     DetailedBalanceConfig::new(128, 1e-12, 1),
 /// )?;
 ///
 /// assert!(report.is_within_tolerance(1e-12));
@@ -649,11 +771,7 @@ where
 ///     &Flat,
 ///     &Flip,
 ///     &mut rng,
-///     DetailedBalanceConfig {
-///         samples: 128,
-///         tolerance: 1e-12,
-///         min_hits: 1,
-///     },
+///     DetailedBalanceConfig::new(128, 1e-12, 1),
 /// )?;
 ///
 /// assert!(batch.is_success());
@@ -679,10 +797,7 @@ where
     R: Rng + ?Sized,
     I: IntoIterator<Item = (&'a S, &'a S)>,
 {
-    let mut batch = DetailedBalanceBatchReport {
-        reports: Vec::new(),
-        failures: Vec::new(),
-    };
+    let mut batch = DetailedBalanceBatchReport::new(Vec::new(), Vec::new());
 
     validate_config(config)?;
 
@@ -691,7 +806,9 @@ where
             current, proposed, target, proposal, rng, config,
         ) {
             Ok(report) => batch.reports.push(report),
-            Err(error) => batch.failures.push(DetailedBalanceFailure { index, error }),
+            Err(error) => batch
+                .failures
+                .push(DetailedBalanceFailure::new(index, error)),
         }
     }
 
@@ -770,11 +887,7 @@ where
 ///     &Flat,
 ///     &mut proposal,
 ///     &mut rng,
-///     DetailedBalanceConfig {
-///         samples: 128,
-///         tolerance: 1e-12,
-///         min_hits: 1,
-///     },
+///     DetailedBalanceConfig::new(128, 1e-12, 1),
 ///     (|plan| *plan, |plan| !*plan),
 /// )?;
 ///
@@ -863,12 +976,9 @@ where
 ///
 /// let forward = |plan: &bool| *plan;
 /// let reverse = |plan: &bool| !*plan;
-/// let transitions = [DetailedBalanceDelayedTransition {
-///     current: &false,
-///     proposed: &true,
-///     forward_plan_matches: &forward,
-///     reverse_plan_matches: &reverse,
-/// }];
+/// let transitions = [DetailedBalanceDelayedTransition::new(
+///     &false, &true, &forward, &reverse,
+/// )];
 /// let mut proposal = FlipPlan;
 /// let mut rng = StdRng::seed_from_u64(42);
 /// let batch = verify_detailed_balance_delayed_many(
@@ -876,11 +986,7 @@ where
 ///     &Flat,
 ///     &mut proposal,
 ///     &mut rng,
-///     DetailedBalanceConfig {
-///         samples: 128,
-///         tolerance: 1e-12,
-///         min_hits: 1,
-///     },
+///     DetailedBalanceConfig::new(128, 1e-12, 1),
 /// )?;
 ///
 /// assert!(batch.is_success());
@@ -907,10 +1013,7 @@ where
     R: Rng + ?Sized,
     I: IntoIterator<Item = DetailedBalanceDelayedTransition<'a, S, P::Plan>>,
 {
-    let mut batch = DetailedBalanceBatchReport {
-        reports: Vec::new(),
-        failures: Vec::new(),
-    };
+    let mut batch = DetailedBalanceBatchReport::new(Vec::new(), Vec::new());
 
     validate_config(config)?;
 
@@ -928,7 +1031,9 @@ where
             ),
         ) {
             Ok(report) => batch.reports.push(report),
-            Err(error) => batch.failures.push(DetailedBalanceFailure { index, error }),
+            Err(error) => batch
+                .failures
+                .push(DetailedBalanceFailure::new(index, error)),
         }
     }
 
@@ -1842,26 +1947,22 @@ mod tests {
 
     /// Return a fast deterministic configuration for exact two-state tests.
     fn small_config() -> DetailedBalanceConfig {
-        DetailedBalanceConfig {
-            samples: 128,
-            tolerance: 1e-12,
-            min_hits: 1,
-        }
+        DetailedBalanceConfig::new(128, 1e-12, 1)
     }
 
     /// Build a minimal report with a configurable standard error for helper API tests.
     fn report_with_standard_error(log_balance_standard_error: f64) -> DetailedBalanceReport {
-        DetailedBalanceReport {
-            samples: 128,
-            forward_hits: 64,
-            reverse_hits: 64,
-            forward_log_proposal: 0.0,
-            reverse_log_proposal: 0.0,
-            forward_log_transition: 0.0,
-            reverse_log_transition: 0.0,
-            log_balance_residual: 0.0,
+        DetailedBalanceReport::new(
+            128,
+            64,
+            64,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
             log_balance_standard_error,
-        }
+        )
     }
 
     #[test]
@@ -2492,12 +2593,9 @@ mod tests {
         let mut proposal = DelayedFlip;
         let forward = |plan: &bool| *plan;
         let reverse = |plan: &bool| !*plan;
-        let transitions = [DetailedBalanceDelayedTransition {
-            current: &false,
-            proposed: &true,
-            forward_plan_matches: &forward,
-            reverse_plan_matches: &reverse,
-        }];
+        let transitions = [DetailedBalanceDelayedTransition::new(
+            &false, &true, &forward, &reverse,
+        )];
 
         let batch = verify_detailed_balance_delayed_many(
             transitions,
@@ -2520,12 +2618,9 @@ mod tests {
         };
         let forward = |plan: &bool| *plan;
         let reverse = |plan: &bool| !*plan;
-        let transitions = [DetailedBalanceDelayedTransition {
-            current: &false,
-            proposed: &true,
-            forward_plan_matches: &forward,
-            reverse_plan_matches: &reverse,
-        }];
+        let transitions = [DetailedBalanceDelayedTransition::new(
+            &false, &true, &forward, &reverse,
+        )];
         let batch = verify_detailed_balance_delayed_many(
             transitions,
             &TwoStateTarget,
@@ -2556,11 +2651,7 @@ mod tests {
             &TwoStateTarget,
             &Flip,
             &mut rng,
-            DetailedBalanceConfig {
-                samples: 0,
-                tolerance: 1e-12,
-                min_hits: 1,
-            },
+            DetailedBalanceConfig::new(0, 1e-12, 1),
         )
         .unwrap_err();
 
@@ -2572,24 +2663,16 @@ mod tests {
 
     #[test]
     fn rejects_invalid_config() {
-        let err: DetailedBalanceError = validate_config(DetailedBalanceConfig {
-            samples: 0,
-            tolerance: 0.0,
-            min_hits: 1,
-        })
-        .unwrap_err();
+        let err: DetailedBalanceError =
+            validate_config(DetailedBalanceConfig::new(0, 0.0, 1)).unwrap_err();
 
         assert!(matches!(
             err,
             DetailedBalanceError::InvalidSamples { samples: 0 }
         ));
 
-        let err = validate_config::<Infallible>(DetailedBalanceConfig {
-            samples: 1,
-            tolerance: -1.0,
-            min_hits: 1,
-        })
-        .unwrap_err();
+        let err =
+            validate_config::<Infallible>(DetailedBalanceConfig::new(1, -1.0, 1)).unwrap_err();
 
         assert!(matches!(
             err,
@@ -2597,24 +2680,16 @@ mod tests {
                 if tolerance.to_bits() == (-1.0_f64).to_bits()
         ));
 
-        let err = validate_config::<Infallible>(DetailedBalanceConfig {
-            samples: 1,
-            tolerance: f64::NAN,
-            min_hits: 1,
-        })
-        .unwrap_err();
+        let err =
+            validate_config::<Infallible>(DetailedBalanceConfig::new(1, f64::NAN, 1)).unwrap_err();
 
         assert!(matches!(
             err,
             DetailedBalanceError::InvalidTolerance { tolerance } if tolerance.is_nan()
         ));
 
-        let err = validate_config::<Infallible>(DetailedBalanceConfig {
-            samples: 1,
-            tolerance: f64::INFINITY,
-            min_hits: 1,
-        })
-        .unwrap_err();
+        let err = validate_config::<Infallible>(DetailedBalanceConfig::new(1, f64::INFINITY, 1))
+            .unwrap_err();
 
         assert!(matches!(
             err,
@@ -2622,12 +2697,7 @@ mod tests {
                 if tolerance.is_infinite() && tolerance.is_sign_positive()
         ));
 
-        let err = validate_config::<Infallible>(DetailedBalanceConfig {
-            samples: 1,
-            tolerance: 0.0,
-            min_hits: 0,
-        })
-        .unwrap_err();
+        let err = validate_config::<Infallible>(DetailedBalanceConfig::new(1, 0.0, 0)).unwrap_err();
 
         assert!(matches!(
             err,
@@ -2637,12 +2707,7 @@ mod tests {
             }
         ));
 
-        let err = validate_config::<Infallible>(DetailedBalanceConfig {
-            samples: 1,
-            tolerance: 0.0,
-            min_hits: 2,
-        })
-        .unwrap_err();
+        let err = validate_config::<Infallible>(DetailedBalanceConfig::new(1, 0.0, 2)).unwrap_err();
 
         assert!(matches!(
             err,


### PR DESCRIPTION
- Add checked bulk constructors for streaming statistics so callers can reject non-finite samples without retaining partial accumulator state.
- Add constructors for detailed-balance config, reports, failures, batches, and delayed transitions before making those public structs non-exhaustive.
- Reuse compiled example binaries during local validation to avoid rebuilding examples twice.
- Refresh the pre-1.0 roadmap around v0.4.0, adaptive diagnostics, learned proposals, and portability.

BREAKING CHANGE: Public telemetry and detailed-balance structs are now non-exhaustive, so downstream callers should construct them through the provided constructors instead of direct struct literals.

Closes #56