### PR TITLE
ci: cache cargo-installed CI tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,17 +83,40 @@ jobs:
       - name: Sync Python tooling
         run: uv sync --locked --group dev
 
-      - name: Install cargo-managed tools
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo install --locked just --version "${JUST_VERSION}"
-          cargo install --locked dprint --version "${DPRINT_VERSION}"
-          cargo install --locked rumdl --version "${RUMDL_VERSION}"
-          cargo install --locked taplo-cli --version "${TAPLO_VERSION}"
-          cargo install --locked typos-cli --version "${TYPOS_VERSION}"
-          cargo install --locked zizmor --version "${ZIZMOR_VERSION}"
-          cargo install --locked cargo-nextest --version "${CARGO_NEXTEST_VERSION}"
+      - name: Install just
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: just@${{ env.JUST_VERSION }}
+
+      - name: Install dprint
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: dprint@${{ env.DPRINT_VERSION }}
+
+      - name: Install rumdl
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: rumdl@${{ env.RUMDL_VERSION }}
+
+      - name: Install taplo
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: taplo-cli@${{ env.TAPLO_VERSION }}
+
+      - name: Install typos
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: typos-cli@${{ env.TYPOS_VERSION }}
+
+      - name: Install zizmor
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: zizmor@${{ env.ZIZMOR_VERSION }}
+
+      - name: Install cargo-nextest
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: cargo-nextest@${{ env.CARGO_NEXTEST_VERSION }}
 
       - name: Run CI checks
         run: just ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -38,45 +38,15 @@ jobs:
       - name: Install LLVM coverage tools
         run: rustup component add llvm-tools-preview
 
-      - name: Cache cargo-llvm-cov
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cargo/bin/cargo-llvm-cov
-          key: cargo-llvm-cov-${{ runner.os }}-${{ env.CARGO_LLVM_COV_VERSION }}
-          restore-keys: |
-            cargo-llvm-cov-${{ runner.os }}-
-
       - name: Install cargo-llvm-cov
-        run: |
-          installed_version=""
-          if command -v cargo-llvm-cov &> /dev/null; then
-            installed_version="$(cargo llvm-cov --version)"
-            installed_version="${installed_version#cargo-llvm-cov }"
-          fi
-
-          if [ "${installed_version}" != "${CARGO_LLVM_COV_VERSION}" ]; then
-            cargo install cargo-llvm-cov --locked --force --version "${CARGO_LLVM_COV_VERSION}"
-          fi
-
-      - name: Cache just
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          path: ~/.cargo/bin/just
-          key: just-${{ runner.os }}-${{ env.JUST_VERSION }}
-          restore-keys: |
-            just-${{ runner.os }}-
+          tool: cargo-llvm-cov@${{ env.CARGO_LLVM_COV_VERSION }}
 
       - name: Install just
-        run: |
-          installed_version=""
-          if command -v just &> /dev/null; then
-            installed_version="$(just --version)"
-            installed_version="${installed_version#just }"
-          fi
-
-          if [ "${installed_version}" != "${JUST_VERSION}" ]; then
-            cargo install --locked --force just --version "${JUST_VERSION}"
-          fi
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: just@${{ env.JUST_VERSION }}
 
       - name: Run coverage
         run: |

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -37,23 +37,15 @@ jobs:
         with:
           cache: true # toolchain/components are specified in rust-toolchain.toml
 
-      - name: Cache clippy tools
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Install clippy-sarif
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          path: |
-            ~/.cargo/bin/clippy-sarif
-            ~/.cargo/bin/sarif-fmt
-          key: clippy-sarif-${{ runner.os }}-${{ env.CLIPPY_SARIF_VERSION }}-sarif-fmt-${{ env.SARIF_FMT_VERSION }}
+          tool: clippy-sarif@${{ env.CLIPPY_SARIF_VERSION }}
 
-      - name: Install clippy-sarif tools
-        run: |
-          if ! command -v clippy-sarif &> /dev/null; then
-            cargo install clippy-sarif --locked --version "${CLIPPY_SARIF_VERSION}"
-          fi
-
-          if ! command -v sarif-fmt &> /dev/null; then
-            cargo install sarif-fmt --locked --version "${SARIF_FMT_VERSION}"
-          fi
+      - name: Install sarif-fmt
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: sarif-fmt@${{ env.SARIF_FMT_VERSION }}
 
       - name: Run clippy with SARIF output
         run: |

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -136,8 +136,8 @@ The lightweight tooling layer mirrors the useful parts of the `delaunay` repo:
 - `.coderabbit.yml` configures CodeRabbit to use focused Rust, Actions, secret-scan, and Semgrep checks.
 - `.codecov.yml` configures coverage thresholds and ignores examples.
 - `.github/workflows/codeql.yml` runs CodeQL for Rust and GitHub Actions.
-- `.github/workflows/ci.yml` runs `just ci` on Linux, macOS, and Windows, with Cargo-installed CI tools cached through
-  `taiki-e/cache-cargo-install-action`.
+- `.github/workflows/ci.yml` runs `just ci` on Linux, macOS, and Windows.
+- PR-running workflows cache Cargo-installed CI, coverage, and SARIF helper tools through `taiki-e/cache-cargo-install-action`.
 - `.github/workflows/semgrep-sarif.yml` uploads repository-owned Semgrep rule results to GitHub Code Scanning.
 - `.github/workflows/zizmor.yml` runs zizmor for GitHub Actions security analysis.
 - `clippy.toml` pins Clippy's MSRV to the crate MSRV.

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -8,6 +8,9 @@ This repository is a single Rust library crate using Rust 1.95.0 and edition 202
 just check            # Non-mutating validation gate
 just check-fast       # Fast compile check
 just ci               # Full CI simulation
+just ci-rust          # Rust correctness subset
+just ci-portability   # Portability subset
+just ci-repository-tooling  # Repository tooling subset
 just fix              # Apply formatters/auto-fixes (mutating)
 just lint             # All lint groups
 just setup            # Install/verify external dev tools
@@ -42,7 +45,18 @@ For cross-repo muscle memory, the same checks are also available through grouped
 - `just lint-config` - JSON, TOML, YAML, GitHub Actions, and Actions security validation
 - `just lint-docs` - Markdown formatting and spellcheck
 
-`just ci` runs `just check` (including `zizmor`), benchmark harness compilation, documentation, tests, and deterministic example-output validation.
+`just ci` remains the comprehensive local and GitHub Actions entrypoint. It runs repository tooling checks, Python support-script tests, Rust correctness
+checks, documentation, library tests, doctests, integration tests, deterministic example-output validation, and benchmark harness compilation.
+
+The full command is factored into named subsets so CI-shape trade-offs are explicit and easy to time without changing coverage:
+
+- `just ci-rust` - Rust formatting, Clippy, documentation, library tests, doctests, integration tests, and deterministic example-output validation.
+- `just ci-portability` - fast compile checking, library tests, doctests, integration tests, and deterministic example-output validation for platform smoke
+  checks.
+- `just ci-repository-tooling` - Python, YAML, GitHub Actions, TOML, Markdown, spelling, Semgrep, Semgrep rule tests, and Python support-script tests.
+
+The GitHub Actions `CI` workflow intentionally runs `just ci` on Linux, macOS, and Windows so all supported development platforms exercise the same
+comprehensive validation gate.
 
 ## Setup
 
@@ -85,7 +99,8 @@ Benchmarks use Criterion and are intentionally deterministic. Run all benchmarks
 just bench
 ```
 
-The full CI simulation (`just ci`) compiles benchmark harnesses with `just bench-compile`, but it does not run Criterion measurements.
+The full CI simulation (`just ci`) compiles benchmark harnesses with `just bench-compile`, but it does not run Criterion measurements. Benchmark harness
+compilation uses all crate features so optional feature paths stay covered.
 
 The initial `benches/stepping.rs` suite protects core transition costs:
 
@@ -121,6 +136,8 @@ The lightweight tooling layer mirrors the useful parts of the `delaunay` repo:
 - `.coderabbit.yml` configures CodeRabbit to use focused Rust, Actions, secret-scan, and Semgrep checks.
 - `.codecov.yml` configures coverage thresholds and ignores examples.
 - `.github/workflows/codeql.yml` runs CodeQL for Rust and GitHub Actions.
+- `.github/workflows/ci.yml` runs `just ci` on Linux, macOS, and Windows, with Cargo-installed CI tools cached through
+  `taiki-e/cache-cargo-install-action`.
 - `.github/workflows/semgrep-sarif.yml` uploads repository-owned Semgrep rule results to GitHub Code Scanning.
 - `.github/workflows/zizmor.yml` runs zizmor for GitHub Actions security analysis.
 - `clippy.toml` pins Clippy's MSRV to the crate MSRV.

--- a/justfile
+++ b/justfile
@@ -162,7 +162,7 @@ bench:
 
 # Compile benchmark harnesses without running Criterion measurements.
 bench-compile:
-    cargo bench --locked --no-run
+    cargo bench --locked --all-features --no-run
 
 # Build
 build:
@@ -182,17 +182,37 @@ changelog-unreleased version: _ensure-git-cliff python-sync
     GIT_CLIFF_OFFLINE=true git-cliff --tag {{version}} -o CHANGELOG.md
     uv run postprocess-changelog
 
+# Rust validation that is meaningful for source portability and user-facing API correctness.
+check-rust: fmt-check clippy
+    @echo "✅ Rust checks complete!"
+
+# Repository tooling that does not need to be repeated across operating systems.
+check-repository-tooling: python-check yaml-check action-lint zizmor toml-fmt-check toml-lint markdown-check spell-check semgrep semgrep-test
+    @echo "✅ Repository tooling checks complete!"
+
 # Non-mutating validation gate
-check: fmt-check clippy python-check yaml-check action-lint zizmor toml-fmt-check toml-lint markdown-check spell-check semgrep semgrep-test
+check: check-rust check-repository-tooling
     @echo "✅ Checks complete!"
 
 # Fast compile check (no binary produced)
 check-fast:
     cargo check --locked
 
+# CI subset for Rust correctness.
+ci-rust: check-rust doc test test-integration validate-examples
+    @echo "✅ Rust CI checks complete!"
+
+# CI subset for macOS and Windows portability confidence.
+ci-portability: check-fast test test-integration validate-examples
+    @echo "✅ Portability CI checks complete!"
+
+# CI subset for repository tooling and support-script tests.
+ci-repository-tooling: check-repository-tooling test-python
+    @echo "✅ Repository tooling CI checks complete!"
+
 # CI simulation: comprehensive validation.
-# Depends on `check`, which includes `zizmor` GitHub Actions security analysis.
-ci: check bench-compile doc test-all validate-examples
+# Depends on repository tooling, including `zizmor` GitHub Actions security analysis.
+ci: ci-repository-tooling ci-rust bench-compile
     @echo "🎯 CI checks complete!"
 
 # Clean build artifacts
@@ -261,6 +281,9 @@ help-workflows:
     @echo "Common Just workflows:"
     @echo "  just check          # Run lint/validators (non-mutating)"
     @echo "  just check-fast     # Fast compile check (cargo check)"
+    @echo "  just ci-rust        # Rust correctness subset for CI-shape timing"
+    @echo "  just ci-portability # Portability subset for CI-shape timing"
+    @echo "  just ci-repository-tooling # Repository tooling subset for CI-shape timing"
     @echo "  just ci             # Full CI simulation, including zizmor and benchmark compile"
     @echo "  just fix            # Apply formatters/auto-fixes (mutating)"
     @echo "  just setup          # Install/verify external dev tools"

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -261,7 +261,7 @@ rules:
         - "/tests/semgrep/github-actions/**/*.yml"
         - "/tests/semgrep/github-actions/**/*.yaml"
     patterns:
-      - pattern-regex: '(?m)^\s*uses:\s*(?!\./)(?!docker://)(?!(?:actions/checkout|actions/cache|actions/upload-artifact|actions/setup-python|actions-rust-lang/setup-rust-toolchain|astral-sh/setup-uv|swatinem/rust-cache|github/codeql-action/(?:upload-sarif|init|analyze)|codecov/codecov-action|zizmorcore/zizmor-action)@)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@'
+      - pattern-regex: '(?m)^\s*uses:\s*(?!\./)(?!docker://)(?!(?:actions/checkout|actions/cache|actions/upload-artifact|actions/setup-python|actions-rust-lang/setup-rust-toolchain|astral-sh/setup-uv|swatinem/rust-cache|taiki-e/cache-cargo-install-action|github/codeql-action/(?:upload-sarif|init|analyze)|codecov/codecov-action|zizmorcore/zizmor-action)@)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@'
 
   - id: mcmc.github-actions.external-action-version-comment
     languages:

--- a/tests/semgrep/github-actions/workflow_actions.yml
+++ b/tests/semgrep/github-actions/workflow_actions.yml
@@ -31,6 +31,12 @@ jobs:
         # ok: mcmc.github-actions.external-action-version-comment
         uses: swatinem/rust-cache@0123456789abcdef0123456789abcdef01234567 # v2.8.1
 
+      - name: Approved cargo install cache action
+        # ok: mcmc.github-actions.external-action-sha-pinned
+        # ok: mcmc.github-actions.external-action-approved-allowlist
+        # ok: mcmc.github-actions.external-action-version-comment
+        uses: taiki-e/cache-cargo-install-action@0123456789abcdef0123456789abcdef01234567 # v3.0.7
+
       - name: Local action
         # ok: mcmc.github-actions.external-action-sha-pinned
         # ok: mcmc.github-actions.external-action-approved-allowlist


### PR DESCRIPTION
- Install Cargo-managed CI tools through taiki-e/cache-cargo-install-action instead of rebuilding them in each matrix job.
- Keep full just ci coverage on Linux, macOS, and Windows while exposing smaller CI subsets for timing and local diagnosis.
- Compile benchmark harnesses with all crate features enabled and allow the pinned cache action in the repository workflow policy.

Refs: #57