### PR TITLE
build: bump Rust MSRV to 1.96.0 (#65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,16 @@ jobs:
           tool: rumdl@${{ env.RUMDL_VERSION }}
 
       - name: Install taplo
+        id: install-taplo
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: taplo-cli@${{ env.TAPLO_VERSION }}
+
+      - name: Install taplo on Windows after cached install failure
+        if: matrix.os == 'windows-latest' && steps.install-taplo.outcome == 'failure'
+        shell: pwsh
+        run: cargo install --locked taplo-cli --version $env:TAPLO_VERSION
 
       - name: Install typos
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ This project is governed by [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). The comm
 
 Before you begin, ensure you have:
 
-1. **Rust 1.95.0** (pinned via [`rust-toolchain.toml`](rust-toolchain.toml) — automatically handled by rustup)
+1. **Rust 1.96.0** (pinned via [`rust-toolchain.toml`](rust-toolchain.toml) — automatically handled by rustup)
 2. **Git** for version control
 3. **Just** (command runner): `cargo install just`
 4. **uv** (Python tooling): install from [astral.sh/uv][uv]
@@ -89,9 +89,9 @@ Before you begin, ensure you have:
 
 This project pins its Rust toolchain via [`rust-toolchain.toml`](rust-toolchain.toml). When you enter the project directory, `rustup` will automatically:
 
-- install the correct Rust version (1.95.0) if you don't have it
+- install the correct Rust version (1.96.0) if you don't have it
 - switch to the pinned version for this project
-- install required components (clippy, rustfmt, rust-docs, rust-src, llvm-tools-preview)
+- install required components (clippy, rustfmt, rust-docs, rust-std, rust-src, rust-analyzer)
 
 **No manual toolchain setup is needed** — just have `rustup` installed ([rustup.rs][rustup]).
 
@@ -196,7 +196,7 @@ just help-workflows  # Detailed workflow guidance
 ### Rust Code Style
 
 - **Edition**: Rust 2024
-- **MSRV**: 1.95.0 (pinned in `rust-toolchain.toml`)
+- **MSRV**: 1.96.0 (pinned in `rust-toolchain.toml`)
 - **Formatting**: `cargo fmt --all` (configured in `rustfmt.toml`)
 - **Linting**: strict clippy with warnings as errors
 
@@ -342,6 +342,9 @@ Performance guidelines:
 - be honest about what hot-path work crosses the API boundary as log weights vs. internal exact arithmetic
 
 Coverage:
+
+`just setup` and the Codecov workflow install `llvm-tools-preview` because `cargo-llvm-cov` needs the LLVM coverage tools. The pinned toolchain keeps
+that coverage-only component out of the default `rustup` install path.
 
 ```bash
 just coverage        # local HTML report (target/llvm-cov/html/index.html)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "markov-chain-monte-carlo"
 version = "0.3.0"
 authors = [ "Adam Getchell" ]
 edition = "2024"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 
 description = "A composable Markov Chain Monte Carlo (MCMC) framework for arbitrary state spaces in Rust"
 homepage = "https://github.com/acgetchell/markov-chain-monte-carlo"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Enable checkpoint serialization when needed:
 cargo add markov-chain-monte-carlo --features serde
 ```
 
-Rust 1.95.0 or newer is required.
+Rust 1.96.0 or newer is required.
 
 Minimal by-value Metropolis-Hastings sampler:
 

--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -332,7 +332,8 @@ fn bench_observing(c: &mut Criterion) {
                 let mut sum = 0.0;
                 for _ in 0..black_box(BULK_STEPS) {
                     chain.step(&target, &proposal, &mut rng).unwrap();
-                    sum += chain.state().0 * chain.state().0;
+                    let sample = chain.state().0;
+                    sum = sample.mul_add(sample, sum);
                 }
                 black_box(sum);
             },

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
 # Clippy configuration for IDE and local consistency.
 
 # Minimum Supported Rust Version - matches Cargo.toml and rust-toolchain.toml.
-msrv = "1.95"
+msrv = "1.96.0"

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -1,6 +1,6 @@
 # Rust Development
 
-This repository is a single Rust library crate using Rust 1.95.0 and edition 2024.
+This repository is a single Rust library crate using Rust 1.96.0 and edition 2024.
 
 ## Core Commands
 
@@ -113,6 +113,8 @@ The initial `benches/stepping.rs` suite protects core transition costs:
 ## Coverage
 
 Coverage uses `cargo llvm-cov` with all crate features enabled.
+`just setup` and the Codecov workflow install `llvm-tools-preview`, which provides the LLVM coverage tools used by `cargo-llvm-cov`. It stays out of
+`rust-toolchain.toml` because normal build, lint, doc, and test workflows do not need it.
 
 - Local HTML report: `just coverage`
 - CI Cobertura XML: `just coverage-ci`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@ The v0.3.0 milestone made the crate useful as the sampling layer for downstream 
 ### v0.4.0 Resumable CDT Integration
 
 The next feature release should focus on downstream sampler integration rather than a grab bag of diagnostics. This is the right place for the Rust 1.96.0
-MSRV/toolchain refresh once Rust 1.96.0 is released.
+MSRV/toolchain refresh.
 
 - [#65](https://github.com/acgetchell/markov-chain-monte-carlo/issues/65) - Update Rust toolchain and MSRV to 1.96.0
 - [#60](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60) - Expose resumable sampler state for chunked runs

--- a/examples/normal_1d.rs
+++ b/examples/normal_1d.rs
@@ -64,8 +64,9 @@ fn main() -> Result<(), McmcError> {
     let mut sum_sq = 0.0;
     for _ in 0..n_samples {
         sampler.step()?;
-        sum += sampler.chain_ref().state().0;
-        sum_sq += sampler.chain_ref().state().0 * sampler.chain_ref().state().0;
+        let sample = sampler.chain_ref().state().0;
+        sum += sample;
+        sum_sq = sample.mul_add(sample, sum_sq);
     }
 
     let mean = sum / f64::from(n_samples);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Pin to MSRV as specified in Cargo.toml
-channel = "1.95.0"
+channel = "1.96.0"
 
 # Essential components for development
 components = [

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -965,6 +965,8 @@ impl<S> Chain<S> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use approx::assert_relative_eq;
     use rand::{SeedableRng, rngs::StdRng};
 
@@ -1080,7 +1082,7 @@ mod tests {
         let checkpoint = ChainCheckpoint::new(Scalar(0.0), 1, 2);
         let result = Chain::from_checkpoint(checkpoint, &NanTarget);
 
-        assert!(matches!(result, Err(McmcError::NanCheckpointLogProb)));
+        assert_matches!(result, Err(McmcError::NanCheckpointLogProb));
     }
 
     #[test]
@@ -1095,7 +1097,7 @@ mod tests {
         let checkpoint = ChainCheckpoint::new(Scalar(0.0), 1, 2);
         let result = Chain::from_checkpoint(checkpoint, &InfTarget);
 
-        assert!(matches!(result, Err(McmcError::InfiniteCheckpointLogProb)));
+        assert_matches!(result, Err(McmcError::InfiniteCheckpointLogProb));
     }
 
     #[cfg(feature = "serde")]
@@ -1197,7 +1199,7 @@ mod tests {
             }
         }
         let result = Chain::new(Scalar(0.0), &NanTarget);
-        assert!(matches!(result, Err(McmcError::NanInitialLogProb)));
+        assert_matches!(result, Err(McmcError::NanInitialLogProb));
     }
 
     #[test]
@@ -1217,7 +1219,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step(&NanAtOrigin, &proposal, &mut rng);
-        assert!(matches!(result, Err(McmcError::NanProposedLogProb)));
+        assert_matches!(result, Err(McmcError::NanProposedLogProb));
     }
 
     #[test]
@@ -1235,7 +1237,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step(&Normal, &NanProposal, &mut rng);
-        assert!(matches!(result, Err(McmcError::NanLogQRatio)));
+        assert_matches!(result, Err(McmcError::NanLogQRatio));
     }
 
     #[test]
@@ -1247,7 +1249,7 @@ mod tests {
             }
         }
         let result = Chain::new(Scalar(0.0), &InfTarget);
-        assert!(matches!(result, Err(McmcError::InfiniteInitialLogProb)));
+        assert_matches!(result, Err(McmcError::InfiniteInitialLogProb));
     }
 
     #[test]
@@ -1267,7 +1269,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step(&InfAtOrigin, &proposal, &mut rng);
-        assert!(matches!(result, Err(McmcError::InfiniteProposedLogProb)));
+        assert_matches!(result, Err(McmcError::InfiniteProposedLogProb));
     }
 
     #[test]
@@ -1285,7 +1287,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step(&Normal, &InfQProposal, &mut rng);
-        assert!(matches!(result, Err(McmcError::InfiniteLogQRatio)));
+        assert_matches!(result, Err(McmcError::InfiniteLogQRatio));
     }
 
     #[test]
@@ -1313,7 +1315,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step_mut(&Normal, &InfQMutProposal, &mut rng);
-        assert!(matches!(result, Err(McmcError::InfiniteLogQRatio)));
+        assert_matches!(result, Err(McmcError::InfiniteLogQRatio));
         assert_eq!(
             chain.state,
             MutScalar(1.0),
@@ -1338,7 +1340,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step_mut(&InfAtOrigin, &proposal, &mut rng);
-        assert!(matches!(result, Err(McmcError::InfiniteProposedLogProb)));
+        assert_matches!(result, Err(McmcError::InfiniteProposedLogProb));
         assert_eq!(
             chain.state,
             MutScalar(1.0),
@@ -1559,7 +1561,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step_mut(&NanAtOrigin, &proposal, &mut rng);
-        assert!(matches!(result, Err(McmcError::NanProposedLogProb)));
+        assert_matches!(result, Err(McmcError::NanProposedLogProb));
         assert_eq!(
             chain.state,
             MutScalar(1.0),
@@ -1592,7 +1594,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step_mut(&Normal, &NanQProposal, &mut rng);
-        assert!(matches!(result, Err(McmcError::NanLogQRatio)));
+        assert_matches!(result, Err(McmcError::NanLogQRatio));
         assert_eq!(
             chain.state,
             MutScalar(1.0),
@@ -1934,10 +1936,10 @@ mod tests {
 
         let result = chain.step_delayed(&NanAtOrigin, &mut proposal, &mut rng);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelayedStepError::Mcmc(McmcError::NanProposedLogProb))
-        ));
+        );
         assert_eq!(chain.state, MutScalar(1.0));
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 0);
@@ -1962,10 +1964,10 @@ mod tests {
 
         let result = chain.step_delayed(&InfAtOrigin, &mut proposal, &mut rng);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelayedStepError::Mcmc(McmcError::InfiniteProposedLogProb))
-        ));
+        );
         assert_eq!(chain.state, MutScalar(1.0));
     }
 
@@ -1980,18 +1982,15 @@ mod tests {
 
         let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
 
-        assert!(matches!(
-            result,
-            Err(DelayedStepError::Mcmc(McmcError::NanLogQRatio))
-        ));
+        assert_matches!(result, Err(DelayedStepError::Mcmc(McmcError::NanLogQRatio)));
         assert_eq!(chain.state, MutScalar(1.0));
 
         proposal.log_q = Ok(f64::INFINITY);
         let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelayedStepError::Mcmc(McmcError::InfiniteLogQRatio))
-        ));
+        );
         assert_eq!(chain.state, MutScalar(1.0));
     }
 
@@ -2005,28 +2004,28 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
 
         let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelayedStepError::Plan(DelayedFixtureError::Plan))
-        ));
+        );
 
         proposal.plan_error = None;
         proposal.score_error = Some(DelayedFixtureError::Score);
         let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelayedStepError::ProposedLogProb(
                 DelayedFixtureError::Score
             ))
-        ));
+        );
 
         proposal.score_error = None;
         proposal.log_q = Err(DelayedFixtureError::Ratio);
         let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelayedStepError::LogQRatio(DelayedFixtureError::Ratio))
-        ));
+        );
     }
 
     #[test]
@@ -2056,10 +2055,7 @@ mod tests {
     #[test]
     fn delayed_error_sources() {
         let mcmc: DelayedStepError<DelayedFixtureError> = McmcError::NanLogQRatio.into();
-        assert!(matches!(
-            mcmc,
-            DelayedStepError::Mcmc(McmcError::NanLogQRatio)
-        ));
+        assert_matches!(mcmc, DelayedStepError::Mcmc(McmcError::NanLogQRatio));
         assert_eq!(
             mcmc.source().map(ToString::to_string),
             Some("proposal returned NaN log q-ratio".to_owned())
@@ -2101,10 +2097,10 @@ mod tests {
 
         let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelayedStepError::Commit(DelayedFixtureError::Commit))
-        ));
+        );
         assert_eq!(chain.state, MutScalar(2.0));
         assert_relative_eq!(chain.log_prob(), log_prob);
         assert_eq!(chain.accepted(), 0);
@@ -2161,10 +2157,10 @@ mod tests {
 
         let result = chain.step_delayed(&Normal, &mut proposal, &mut rng);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelayedStepError::Commit(DelayedFixtureError::Commit))
-        ));
+        );
         assert_eq!(chain.state, MutScalar(2.0));
         assert_relative_eq!(chain.log_prob(), log_prob);
         assert_eq!(chain.accepted(), 0);
@@ -2191,7 +2187,7 @@ mod tests {
         }
         let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
         let result = chain.replace_state(Scalar(0.0), &NanTarget);
-        assert!(matches!(result, Err(McmcError::NanReplacementLogProb)));
+        assert_matches!(result, Err(McmcError::NanReplacementLogProb));
         // State should be unchanged on error
         assert_eq!(chain.state, Scalar(1.0));
     }
@@ -2206,7 +2202,7 @@ mod tests {
         }
         let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
         let result = chain.replace_state(Scalar(0.0), &InfTarget);
-        assert!(matches!(result, Err(McmcError::InfiniteReplacementLogProb)));
+        assert_matches!(result, Err(McmcError::InfiniteReplacementLogProb));
         assert_eq!(chain.state, Scalar(1.0));
     }
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -598,6 +598,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// `thin_interval = 2` collects states after steps 2 and 4.
     ///
     /// ```
+    /// # use std::assert_matches;
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -622,7 +623,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
     ///
     /// let err = sampler.run_with_thinning(1, 0).unwrap_err();
-    /// assert!(matches!(err, ThinningError::InvalidInterval { thin_interval: 0 }));
+    /// assert_matches!(err, ThinningError::InvalidInterval { thin_interval: 0 });
     /// # Ok::<(), ThinningError<McmcError>>(())
     /// ```
     ///
@@ -730,6 +731,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// `thin_interval = 2` observes after steps 2 and 4.
     ///
     /// ```
+    /// # use std::assert_matches;
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -755,7 +757,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// let err = sampler
     ///     .run_observing_with_thinning(1, 0, &mut coordinate)
     ///     .unwrap_err();
-    /// assert!(matches!(err, ThinningError::InvalidInterval { thin_interval: 0 }));
+    /// assert_matches!(err, ThinningError::InvalidInterval { thin_interval: 0 });
     /// # Ok::<(), ThinningError<McmcError>>(())
     /// ```
     ///
@@ -1240,6 +1242,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// divisible by `thin_interval`.
     ///
     /// ```
+    /// # use std::assert_matches;
     /// use markov_chain_monte_carlo::prelude::in_place::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -1268,7 +1271,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
     ///
     /// let err = sampler.run_mut_with_thinning(1, 0).unwrap_err();
-    /// assert!(matches!(err, ThinningError::InvalidInterval { thin_interval: 0 }));
+    /// assert_matches!(err, ThinningError::InvalidInterval { thin_interval: 0 });
     /// # Ok::<(), ThinningError<McmcError>>(())
     /// ```
     ///
@@ -1994,6 +1997,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// divisible by `thin_interval`.
     ///
     /// ```
+    /// # use std::assert_matches;
     /// use core::convert::Infallible;
     /// use markov_chain_monte_carlo::prelude::delayed::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -2052,7 +2056,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
     ///
     /// let err = sampler.run_delayed_with_thinning(1, 0).unwrap_err();
-    /// assert!(matches!(err, ThinningError::InvalidInterval { thin_interval: 0 }));
+    /// assert_matches!(err, ThinningError::InvalidInterval { thin_interval: 0 });
     /// # Ok::<(), ThinningError<DelayedStepError<Infallible>>>(())
     /// ```
     ///
@@ -2730,6 +2734,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Iterator for Sampler<'_, 
 #[cfg(test)]
 mod tests {
     use core::convert::Infallible;
+    use std::assert_matches;
 
     use approx::assert_relative_eq;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
@@ -2896,7 +2901,7 @@ mod tests {
         let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
         let result = Sampler::new(chain, &NanTarget, &Walk { width: 1.0 }, &mut rng);
 
-        assert!(matches!(result, Err(McmcError::NanCurrentLogProb)));
+        assert_matches!(result, Err(McmcError::NanCurrentLogProb));
     }
 
     #[test]
@@ -2912,7 +2917,7 @@ mod tests {
         let chain = Chain::new(Scalar(1.0), &Normal).unwrap();
         let result = Sampler::new(chain, &InfTarget, &Walk { width: 1.0 }, &mut rng);
 
-        assert!(matches!(result, Err(McmcError::InfiniteCurrentLogProb)));
+        assert_matches!(result, Err(McmcError::InfiniteCurrentLogProb));
     }
 
     #[test]
@@ -3014,10 +3019,10 @@ mod tests {
 
         let result = sampler.run_with_thinning(5, 0);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        ));
+        );
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
@@ -3029,10 +3034,7 @@ mod tests {
 
         let result = sampler.run_with_thinning(5, 2);
 
-        assert!(matches!(
-            result,
-            Err(ThinningError::Run(McmcError::NanLogQRatio))
-        ));
+        assert_matches!(result, Err(ThinningError::Run(McmcError::NanLogQRatio)));
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
@@ -3162,12 +3164,12 @@ mod tests {
 
         let result = sampler.try_run_observing_with_thinning(5, 2, &mut observable);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::Run(ObservedStepError::Observation(
                 ObservationFailure::Failed
             )))
-        ));
+        );
         assert_eq!(calls, 1);
         assert_eq!(sampler.chain_ref().total_steps(), 2);
     }
@@ -3195,10 +3197,10 @@ mod tests {
 
         let result = sampler.run_observing_with_thinning(5, 0, &mut coordinate);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        ));
+        );
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
@@ -3211,10 +3213,10 @@ mod tests {
 
         let result = sampler.run_observing_into_with_thinning(5, 0, &mut coordinate, &mut stats);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        ));
+        );
         assert_eq!(stats.count(), 0);
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
@@ -3235,12 +3237,12 @@ mod tests {
         // the first step, proving the step error is reported before emission.
         let result = sampler.run_observing_into_with_thinning(5, 1, &mut coordinate, &mut stats);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::Run(ObservedStreamError::Step(
                 McmcError::NanLogQRatio
             )))
-        ));
+        );
         assert!(!observed);
         assert_eq!(stats.count(), 0);
         assert_eq!(sampler.chain_ref().total_steps(), 0);
@@ -3263,10 +3265,10 @@ mod tests {
 
         let result = sampler.try_run_observing(3, &mut observable);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStepError::Observation(ObservationFailure::Failed))
-        ));
+        );
         assert_eq!(sampler.chain_ref().total_steps(), 2);
     }
 
@@ -3288,10 +3290,10 @@ mod tests {
 
         let result = sampler.try_run_observing_into(3, &mut observable, &mut stats);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStreamError::Observation(ObservationFailure::Failed))
-        ));
+        );
         assert_eq!(stats.count(), 1);
         assert_eq!(sampler.chain_ref().total_steps(), 2);
     }
@@ -3306,12 +3308,12 @@ mod tests {
 
         let result = sampler.run_observing_into(1, &mut invalid, &mut stats);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStreamError::Accumulation(
                 StatisticsError::NanSample
             ))
-        ));
+        );
         assert_eq!(stats.count(), 0);
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
@@ -3330,10 +3332,10 @@ mod tests {
 
         let result = sampler.run_observing_into(1, &mut observable, &mut accumulator);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStreamError::Step(McmcError::NanLogQRatio))
-        ));
+        );
         assert!(!observed);
         assert_eq!(accumulator.pushes, 0);
     }
@@ -3352,10 +3354,10 @@ mod tests {
 
         let result = sampler.try_run_observing_into(1, &mut observable, &mut accumulator);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStreamError::Step(McmcError::NanLogQRatio))
-        ));
+        );
         assert!(!observed);
         assert_eq!(accumulator.pushes, 0);
     }
@@ -3373,10 +3375,10 @@ mod tests {
 
         let result = sampler.try_step_observing(&mut observable);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStepError::Step(McmcError::NanLogQRatio))
-        ));
+        );
         assert!(!observed);
     }
 
@@ -3446,10 +3448,10 @@ mod tests {
 
         let result = sampler.run_mut_with_thinning(5, 0);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        ));
+        );
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
@@ -3544,12 +3546,12 @@ mod tests {
 
         let result = sampler.try_run_mut_observing_with_thinning(7, 3, &mut observable);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::Run(ObservedStepError::Observation(
                 ObservationFailure::Failed
             )))
-        ));
+        );
         assert_eq!(calls, 1);
         assert_eq!(sampler.chain_ref().total_steps(), 3);
     }
@@ -3587,10 +3589,10 @@ mod tests {
 
         let result = sampler.run_mut_observing_with_thinning(5, 0, &mut coordinate);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        ));
+        );
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
@@ -3616,10 +3618,10 @@ mod tests {
 
         let result = sampler.try_run_mut_observing(1, &mut observable);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStepError::Observation(ObservationFailure::Failed))
-        ));
+        );
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
 
@@ -3663,12 +3665,12 @@ mod tests {
 
         let result = sampler.try_run_mut_observing_into(1, &mut invalid, &mut stats);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStreamError::Accumulation(
                 StatisticsError::InfiniteSample
             ))
-        ));
+        );
         assert_eq!(stats.count(), 0);
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
@@ -3809,10 +3811,10 @@ mod tests {
 
         let result = sampler.run_delayed_with_thinning(5, 0);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        ));
+        );
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
@@ -3896,10 +3898,10 @@ mod tests {
         let result =
             sampler.run_delayed_observing_into_with_thinning(5, 0, &mut coordinate, &mut stats);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        ));
+        );
         assert_eq!(stats.count(), 0);
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
@@ -3951,12 +3953,12 @@ mod tests {
 
         let result = sampler.try_run_delayed_observing_with_thinning(6, 2, &mut observable);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ThinningError::Run(ObservedStepError::Observation(
                 ObservationFailure::Failed
             )))
-        ));
+        );
         assert_eq!(calls, 1);
         assert_eq!(sampler.chain_ref().total_steps(), 2);
     }
@@ -3988,10 +3990,10 @@ mod tests {
 
         let result = sampler.try_run_delayed_observing(1, &mut observable);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStepError::Observation(ObservationFailure::Failed))
-        ));
+        );
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
 
@@ -4014,10 +4016,10 @@ mod tests {
 
         let result = sampler.try_run_delayed_observing_into(3, &mut observable, &mut stats);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(ObservedStreamError::Observation(ObservationFailure::Failed))
-        ));
+        );
         assert_eq!(stats.count(), 1);
         assert_eq!(sampler.chain_ref().total_steps(), 2);
     }
@@ -4082,10 +4084,10 @@ mod tests {
 
         let result = sampler.run_delayed(3);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelayedStepError::Plan(DelayedRunError::PlannedStop))
-        ));
+        );
         assert_eq!(sampler.chain_ref().state(), &MutScalar(0.0));
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -206,7 +206,7 @@ impl OnlineStats {
         let delta = sample - self.mean;
         self.mean += delta / count_as_f64(self.count);
         let delta_after = sample - self.mean;
-        self.m2 += delta * delta_after;
+        self.m2 = delta.mul_add(delta_after, self.m2);
     }
 
     /// Add one finite sample to the accumulator.
@@ -1058,6 +1058,25 @@ mod tests {
         assert_close(stats.sample_variance().unwrap(), 32.0 / 7.0);
         assert_close(stats.population_std_dev().unwrap(), 2.0);
         assert_close(stats.standard_error().unwrap(), (4.0_f64 / 7.0).sqrt());
+    }
+
+    #[test]
+    fn online_stats_pins_fused_variance_update() {
+        let stats: OnlineStats = [1.0, 1.0e12, -1.0e12, 3.5, -2.25, 8.125]
+            .into_iter()
+            .collect();
+
+        assert_eq!(stats.count(), 6);
+        assert_eq!(stats.mean.to_bits(), 0x3ffb_aaa0_0000_0000);
+        assert_eq!(stats.m2.to_bits(), 0x44fa_7843_79d9_9db4);
+        assert_eq!(
+            stats.population_variance().unwrap().to_bits(),
+            0x44d1_a582_513b_be78
+        );
+        assert_eq!(
+            stats.sample_variance().unwrap().to_bits(),
+            0x44d5_2d02_c7e1_4af6
+        );
     }
 
     #[test]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1309,7 +1309,8 @@ impl TransitionEstimate {
     fn push(&mut self, acceptance_probability: f64) {
         self.hits += 1;
         self.weight_sum += acceptance_probability;
-        self.weight_square_sum += acceptance_probability * acceptance_probability;
+        self.weight_square_sum =
+            acceptance_probability.mul_add(acceptance_probability, self.weight_square_sum);
     }
 
     /// Estimate the log proposal probability from exact endpoint hits.
@@ -1557,7 +1558,7 @@ const fn usize_to_f64(value: usize) -> f64 {
 #[cfg(test)]
 mod tests {
     use core::convert::Infallible;
-    use std::error::Error as _;
+    use std::{assert_matches, error::Error as _};
 
     use approx::{assert_relative_eq, relative_eq};
     use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -2169,14 +2170,14 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::Violation {
                 residual,
                 tolerance: 1e-12,
                 ..
             } if relative_eq!(residual, 1.0, epsilon = 1e-12)
-        ));
+        );
     }
 
     #[test]
@@ -2192,14 +2193,14 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::Violation {
                 residual,
                 tolerance: 1e-12,
                 ..
             } if relative_eq!(residual, 1.0, epsilon = 1e-12)
-        ));
+        );
     }
 
     #[test]
@@ -2219,13 +2220,13 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::Plan {
                 direction: DetailedBalanceDirection::Forward,
                 source: DelayedFailure::Plan,
             }
-        ));
+        );
     }
 
     #[test]
@@ -2245,13 +2246,13 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::ProposedLogProb {
                 direction: DetailedBalanceDirection::Forward,
                 source: DelayedFailure::ProposedLogProb,
             }
-        ));
+        );
     }
 
     #[test]
@@ -2271,13 +2272,13 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::LogQRatio {
                 direction: DetailedBalanceDirection::Forward,
                 source: DelayedFailure::LogQRatio,
             }
-        ));
+        );
     }
 
     #[test]
@@ -2286,24 +2287,24 @@ mod tests {
         let err =
             verify_detailed_balance(&true, &false, &NanOnTrue, &Flip, &mut rng, small_config())
                 .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidTargetLogProb {
                 state: DetailedBalanceState::Current,
                 log_prob,
             } if log_prob.is_nan()
-        ));
+        );
 
         let err =
             verify_detailed_balance(&false, &true, &NanOnTrue, &Flip, &mut rng, small_config())
                 .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidTargetLogProb {
                 state: DetailedBalanceState::Proposed,
                 log_prob,
             } if log_prob.is_nan()
-        ));
+        );
     }
 
     #[test]
@@ -2318,13 +2319,13 @@ mod tests {
             small_config(),
         )
         .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidLogQRatio {
                 direction: DetailedBalanceDirection::Forward,
                 log_q_ratio,
             } if log_q_ratio.is_infinite() && log_q_ratio.is_sign_positive()
-        ));
+        );
 
         let err = verify_detailed_balance_mut(
             &false,
@@ -2335,13 +2336,13 @@ mod tests {
             small_config(),
         )
         .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidLogQRatio {
                 direction: DetailedBalanceDirection::Forward,
                 log_q_ratio,
             } if log_q_ratio.is_infinite() && log_q_ratio.is_sign_positive()
-        ));
+        );
 
         let mut proposal = InfiniteLogQDelayed;
         let err = verify_detailed_balance_delayed(
@@ -2354,13 +2355,13 @@ mod tests {
             (|plan| *plan, |plan| !*plan),
         )
         .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidLogQRatio {
                 direction: DetailedBalanceDirection::Forward,
                 log_q_ratio,
             } if log_q_ratio.is_infinite() && log_q_ratio.is_sign_positive()
-        ));
+        );
     }
 
     #[test]
@@ -2395,14 +2396,14 @@ mod tests {
             small_config(),
         )
         .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InsufficientHits {
                 direction: DetailedBalanceDirection::Forward,
                 hits: 0,
                 min_hits: 1,
             }
-        ));
+        );
 
         let mut proposal = NoPlanDelayed;
         let err = verify_detailed_balance_delayed(
@@ -2415,14 +2416,14 @@ mod tests {
             (|plan| *plan, |plan| !*plan),
         )
         .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InsufficientHits {
                 direction: DetailedBalanceDirection::Forward,
                 hits: 0,
                 min_hits: 1,
             }
-        ));
+        );
     }
 
     #[test]
@@ -2442,13 +2443,13 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::Plan {
                 direction: DetailedBalanceDirection::Reverse,
                 source: DelayedFailure::Plan,
             }
-        ));
+        );
     }
 
     #[test]
@@ -2468,13 +2469,13 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::ProposedLogProb {
                 direction: DetailedBalanceDirection::Reverse,
                 source: DelayedFailure::ProposedLogProb,
             }
-        ));
+        );
     }
 
     #[test]
@@ -2494,13 +2495,13 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::LogQRatio {
                 direction: DetailedBalanceDirection::Reverse,
                 source: DelayedFailure::LogQRatio,
             }
-        ));
+        );
     }
 
     #[test]
@@ -2516,14 +2517,14 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InsufficientHits {
                 direction: DetailedBalanceDirection::Forward,
                 hits: 0,
                 min_hits: 1,
             }
-        ));
+        );
     }
 
     #[test]
@@ -2539,13 +2540,13 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidLogAcceptanceRatio {
                 direction: DetailedBalanceDirection::Forward,
                 log_acceptance_ratio,
             } if log_acceptance_ratio.is_nan()
-        ));
+        );
     }
 
     #[test]
@@ -2634,13 +2635,13 @@ mod tests {
         assert_eq!(batch.reports.len(), 0);
         assert_eq!(batch.failures.len(), 1);
         assert_eq!(batch.failures[0].index, 0);
-        assert!(matches!(
+        assert_matches!(
             batch.failures[0].error,
             DetailedBalanceError::Plan {
                 direction: DetailedBalanceDirection::Forward,
                 source: DelayedFailure::Plan,
             }
-        ));
+        );
     }
 
     #[test]
@@ -2655,10 +2656,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
-            err,
-            DetailedBalanceError::InvalidSamples { samples: 0 }
-        ));
+        assert_matches!(err, DetailedBalanceError::InvalidSamples { samples: 0 });
     }
 
     #[test]
@@ -2666,55 +2664,52 @@ mod tests {
         let err: DetailedBalanceError =
             validate_config(DetailedBalanceConfig::new(0, 0.0, 1)).unwrap_err();
 
-        assert!(matches!(
-            err,
-            DetailedBalanceError::InvalidSamples { samples: 0 }
-        ));
+        assert_matches!(err, DetailedBalanceError::InvalidSamples { samples: 0 });
 
         let err =
             validate_config::<Infallible>(DetailedBalanceConfig::new(1, -1.0, 1)).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidTolerance { tolerance }
                 if tolerance.to_bits() == (-1.0_f64).to_bits()
-        ));
+        );
 
         let err =
             validate_config::<Infallible>(DetailedBalanceConfig::new(1, f64::NAN, 1)).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidTolerance { tolerance } if tolerance.is_nan()
-        ));
+        );
 
         let err = validate_config::<Infallible>(DetailedBalanceConfig::new(1, f64::INFINITY, 1))
             .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidTolerance { tolerance }
                 if tolerance.is_infinite() && tolerance.is_sign_positive()
-        ));
+        );
 
         let err = validate_config::<Infallible>(DetailedBalanceConfig::new(1, 0.0, 0)).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidMinHits {
                 min_hits: 0,
                 samples: 1,
             }
-        ));
+        );
 
         let err = validate_config::<Infallible>(DetailedBalanceConfig::new(1, 0.0, 2)).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DetailedBalanceError::InvalidMinHits {
                 min_hits: 2,
                 samples: 1,
             }
-        ));
+        );
     }
 }


### PR DESCRIPTION
- Pin Cargo, rustup, Clippy, and contributor docs to Rust 1.96.0.
- Adopt 1.96-compatible numeric updates with fused multiply-add in statistics, examples, and benchmarks.
- Refresh typed error assertions and doctests to use `std::assert_matches!`.
- Clarify that LLVM coverage tools are installed by setup and Codecov rather than the default pinned toolchain.

Closes #65