### PR TITLE
feat!: validate delayed commits after acceptance

### DIFF
--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -7,7 +7,7 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use markov_chain_monte_carlo::prelude::by_value::Proposal;
 use markov_chain_monte_carlo::prelude::delayed::DelayedProposal;
 use markov_chain_monte_carlo::prelude::in_place::ProposalMut;
-use markov_chain_monte_carlo::prelude::{Chain, Sampler, Target};
+use markov_chain_monte_carlo::prelude::{BinningAnalysis, Chain, OnlineStats, Sampler, Target};
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
 
@@ -336,6 +336,38 @@ fn bench_observing(c: &mut Criterion) {
                     sum = sample.mul_add(sample, sum);
                 }
                 black_box(sum);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("observing/run_observing_into_online_stats_100", |b| {
+        b.iter_batched(
+            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
+            |(chain, mut rng)| {
+                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng).unwrap();
+                let mut square = |state: &Scalar| state.0 * state.0;
+                let mut stats = OnlineStats::new();
+                sampler
+                    .run_observing_into(black_box(BULK_STEPS), &mut square, &mut stats)
+                    .unwrap();
+                black_box(stats.count());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("observing/run_observing_into_binning_100", |b| {
+        b.iter_batched(
+            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
+            |(chain, mut rng)| {
+                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng).unwrap();
+                let mut square = |state: &Scalar| state.0 * state.0;
+                let mut bins = BinningAnalysis::new();
+                sampler
+                    .run_observing_into(black_box(BULK_STEPS), &mut square, &mut bins)
+                    .unwrap();
+                black_box(bins.standard_error());
             },
             BatchSize::SmallInput,
         );

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,6 +1,6 @@
 //! MCMC chain implementation.
 
-use core::hint::cold_path;
+use core::{cmp::Ordering, hint::cold_path};
 
 use std::error::Error;
 use std::fmt;
@@ -68,6 +68,27 @@ fn check_log_q_ratio(log_q: f64) -> Result<(), McmcError> {
     if log_q == f64::INFINITY {
         cold_path();
         return Err(McmcError::InfiniteLogQRatio);
+    }
+    Ok(())
+}
+
+/// Check that a delayed commit produced the state scored before acceptance.
+///
+/// The checked delayed path recomputes the committed state's log-probability so
+/// proposal authors can catch plan/commit mismatches without leaving the chain's
+/// cached log-probability stale.
+fn check_committed_log_prob(scored: f64, committed: f64) -> Result<(), McmcError> {
+    if committed.is_nan() {
+        cold_path();
+        return Err(McmcError::NanCommittedLogProb);
+    }
+    if committed == f64::INFINITY {
+        cold_path();
+        return Err(McmcError::InfiniteCommittedLogProb);
+    }
+    if committed.partial_cmp(&scored) != Some(Ordering::Equal) {
+        cold_path();
+        return Err(McmcError::InconsistentDelayedCommitLogProb);
     }
     Ok(())
 }
@@ -662,6 +683,171 @@ impl<S> Chain<S> {
                 info: Some(info),
                 log_prob_before,
                 log_prob_after: Some(log_prob_new),
+                log_alpha: Some(log_alpha),
+            })
+        } else {
+            self.rejected = self.rejected.saturating_add(1);
+            Ok(Step {
+                accepted: false,
+                proposed: true,
+                info: Some(info),
+                log_prob_before,
+                log_prob_after: None,
+                log_alpha: Some(log_alpha),
+            })
+        }
+    }
+
+    /// Perform a delayed-commit step and verify the committed state afterward.
+    ///
+    /// This variant is intended for proposal development and invariant-heavy
+    /// state spaces.  It follows the same Metropolis-Hastings decision as
+    /// [`step_delayed`](Self::step_delayed), then recomputes the target
+    /// log-probability after an accepted commit.  If the committed state's
+    /// log-probability is invalid or differs from the value used for the
+    /// acceptance decision, the original state is restored and an
+    /// [`McmcError`] is returned through [`DelayedStepError::Mcmc`].
+    ///
+    /// The method requires `S: Clone` so it can restore the prior state when a
+    /// proposal violates the delayed-commit contract.
+    ///
+    /// If [`DelayedProposal::commit`] returns an error, the chain state and
+    /// cached log-probability are restored before the error is returned.  The
+    /// proposal remains responsible for its own internal state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct TargetLine;
+    /// impl Target<i32> for TargetLine {
+    ///     fn log_prob(&self, state: &i32) -> f64 {
+    ///         -f64::from(state.abs())
+    ///     }
+    /// }
+    ///
+    /// struct MoveRight;
+    /// impl DelayedProposal<i32> for MoveRight {
+    ///     type Plan = i32;
+    ///     type Info = i32;
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _state: &i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<Option<i32>, Self::Error> {
+    ///         Ok(Some(1))
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<i32>>(
+    ///         &self,
+    ///         state: &i32,
+    ///         plan: &i32,
+    ///         target: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         Ok(target.log_prob(&(*state + *plan)))
+    ///     }
+    ///
+    ///     fn info(&self, plan: &i32) -> i32 {
+    ///         *plan
+    ///     }
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         state: &mut i32,
+    ///         plan: i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         *state += plan;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let target = TargetLine;
+    /// let mut proposal = MoveRight;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let mut chain = Chain::new(-1, &target)?;
+    ///
+    /// let step = chain.step_delayed_checked(&target, &mut proposal, &mut rng)?;
+    /// assert!(step.accepted);
+    /// assert_eq!(*chain.state(), 0);
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`step_delayed`](Self::step_delayed), plus
+    /// [`McmcError::NanCommittedLogProb`],
+    /// [`McmcError::InfiniteCommittedLogProb`], or
+    /// [`McmcError::InconsistentDelayedCommitLogProb`] when post-commit
+    /// validation fails.
+    pub fn step_delayed_checked<T, P, R>(
+        &mut self,
+        target: &T,
+        proposal: &mut P,
+        rng: &mut R,
+    ) -> Result<DelayedStep<P::Info>, DelayedStepError<P::Error>>
+    where
+        S: Clone,
+        T: Target<S>,
+        P: DelayedProposal<S> + ?Sized,
+        R: Rng + ?Sized,
+    {
+        let log_prob_before = self.log_prob;
+        let Some(plan) = proposal
+            .propose_plan(&self.state, rng)
+            .map_err(DelayedStepError::Plan)?
+        else {
+            self.rejected = self.rejected.saturating_add(1);
+            return Ok(Step {
+                accepted: false,
+                proposed: false,
+                info: None,
+                log_prob_before,
+                log_prob_after: None,
+                log_alpha: None,
+            });
+        };
+
+        let log_prob_new = proposal
+            .proposed_log_prob(&self.state, &plan, target)
+            .map_err(DelayedStepError::ProposedLogProb)?;
+        check_proposed_log_prob(log_prob_new).map_err(DelayedStepError::Mcmc)?;
+
+        let log_q = proposal
+            .log_q_ratio(&self.state, &plan)
+            .map_err(DelayedStepError::LogQRatio)?;
+        check_log_q_ratio(log_q).map_err(DelayedStepError::Mcmc)?;
+
+        let log_alpha = log_prob_new - self.log_prob + log_q;
+        let accept = accept_log_alpha(log_alpha, rng);
+        let info = proposal.info(&plan);
+
+        if accept {
+            let state_before_commit = self.state.clone();
+            if let Err(err) = proposal.commit(&mut self.state, plan, rng) {
+                self.state = state_before_commit;
+                return Err(DelayedStepError::Commit(err));
+            }
+
+            let committed_log_prob = target.log_prob(&self.state);
+            if let Err(err) = check_committed_log_prob(log_prob_new, committed_log_prob) {
+                self.state = state_before_commit;
+                return Err(DelayedStepError::Mcmc(err));
+            }
+
+            self.log_prob = committed_log_prob;
+            self.accepted = self.accepted.saturating_add(1);
+            Ok(Step {
+                accepted: true,
+                proposed: true,
+                info: Some(info),
+                log_prob_before,
+                log_prob_after: Some(committed_log_prob),
                 log_alpha: Some(log_alpha),
             })
         } else {
@@ -1853,6 +2039,48 @@ mod tests {
         }
     }
 
+    struct CheckedCommitProposal {
+        scored: f64,
+        committed: f64,
+    }
+
+    impl DelayedProposal<Scalar> for CheckedCommitProposal {
+        type Plan = f64;
+        type Info = f64;
+        type Error = DelayedFixtureError;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            _state: &Scalar,
+            _rng: &mut R,
+        ) -> Result<Option<f64>, Self::Error> {
+            Ok(Some(self.scored))
+        }
+
+        fn proposed_log_prob<T: Target<Scalar>>(
+            &self,
+            _state: &Scalar,
+            plan: &f64,
+            target: &T,
+        ) -> Result<f64, Self::Error> {
+            Ok(target.log_prob(&Scalar(*plan)))
+        }
+
+        fn info(&self, plan: &f64) -> f64 {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut Scalar,
+            _plan: f64,
+            _rng: &mut R,
+        ) -> Result<(), Self::Error> {
+            state.0 = self.committed;
+            Ok(())
+        }
+    }
+
     #[test]
     fn delayed_accepts_uphill() {
         let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
@@ -2162,6 +2390,243 @@ mod tests {
             Err(DelayedStepError::Commit(DelayedFixtureError::Commit))
         );
         assert_eq!(chain.state, MutScalar(2.0));
+        assert_relative_eq!(chain.log_prob(), log_prob);
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 0);
+    }
+
+    #[test]
+    fn delayed_checked_accepts_consistent_commit() {
+        struct CheckedMove;
+        impl DelayedProposal<Scalar> for CheckedMove {
+            type Plan = f64;
+            type Info = f64;
+            type Error = DelayedFixtureError;
+
+            fn propose_plan<R: Rng + ?Sized>(
+                &mut self,
+                _state: &Scalar,
+                _rng: &mut R,
+            ) -> Result<Option<f64>, Self::Error> {
+                Ok(Some(0.0))
+            }
+
+            fn proposed_log_prob<T: Target<Scalar>>(
+                &self,
+                _state: &Scalar,
+                plan: &f64,
+                target: &T,
+            ) -> Result<f64, Self::Error> {
+                Ok(target.log_prob(&Scalar(*plan)))
+            }
+
+            fn info(&self, plan: &f64) -> f64 {
+                *plan
+            }
+
+            fn commit<R: Rng + ?Sized>(
+                &mut self,
+                state: &mut Scalar,
+                plan: f64,
+                _rng: &mut R,
+            ) -> Result<(), Self::Error> {
+                state.0 = plan;
+                Ok(())
+            }
+        }
+
+        let mut chain = Chain::new(Scalar(2.0), &Normal).unwrap();
+        let mut proposal = CheckedMove;
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let step = chain
+            .step_delayed_checked(&Normal, &mut proposal, &mut rng)
+            .unwrap();
+
+        assert!(step.accepted);
+        assert_eq!(chain.state, Scalar(0.0));
+        assert_relative_eq!(chain.log_prob(), 0.0);
+        assert_eq!(chain.accepted(), 1);
+        assert_eq!(chain.rejected(), 0);
+    }
+
+    #[test]
+    fn delayed_checked_restores_after_mismatched_commit() {
+        struct MismatchedCommit;
+        impl DelayedProposal<Scalar> for MismatchedCommit {
+            type Plan = f64;
+            type Info = f64;
+            type Error = DelayedFixtureError;
+
+            fn propose_plan<R: Rng + ?Sized>(
+                &mut self,
+                _state: &Scalar,
+                _rng: &mut R,
+            ) -> Result<Option<f64>, Self::Error> {
+                Ok(Some(0.0))
+            }
+
+            fn proposed_log_prob<T: Target<Scalar>>(
+                &self,
+                _state: &Scalar,
+                plan: &f64,
+                target: &T,
+            ) -> Result<f64, Self::Error> {
+                Ok(target.log_prob(&Scalar(*plan)))
+            }
+
+            fn info(&self, plan: &f64) -> f64 {
+                *plan
+            }
+
+            fn commit<R: Rng + ?Sized>(
+                &mut self,
+                state: &mut Scalar,
+                _plan: f64,
+                _rng: &mut R,
+            ) -> Result<(), Self::Error> {
+                state.0 = 2.0;
+                Ok(())
+            }
+        }
+
+        let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
+        let log_prob = chain.log_prob();
+        let mut proposal = MismatchedCommit;
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed_checked(&Normal, &mut proposal, &mut rng);
+
+        assert_matches!(
+            result,
+            Err(DelayedStepError::Mcmc(
+                McmcError::InconsistentDelayedCommitLogProb
+            ))
+        );
+        assert_eq!(chain.state, Scalar(1.0));
+        assert_relative_eq!(chain.log_prob(), log_prob);
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 0);
+    }
+
+    #[test]
+    fn delayed_checked_restores_after_nan_committed_log_prob() {
+        struct NanAtTwo;
+        impl Target<Scalar> for NanAtTwo {
+            fn log_prob(&self, state: &Scalar) -> f64 {
+                if state.0.to_bits() == 2.0_f64.to_bits() {
+                    f64::NAN
+                } else {
+                    Normal.log_prob(state)
+                }
+            }
+        }
+
+        let mut chain = Chain::new(Scalar(1.0), &NanAtTwo).unwrap();
+        let log_prob = chain.log_prob();
+        let mut proposal = CheckedCommitProposal {
+            scored: 0.0,
+            committed: 2.0,
+        };
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed_checked(&NanAtTwo, &mut proposal, &mut rng);
+
+        assert_matches!(
+            result,
+            Err(DelayedStepError::Mcmc(McmcError::NanCommittedLogProb))
+        );
+        assert_eq!(chain.state, Scalar(1.0));
+        assert_relative_eq!(chain.log_prob(), log_prob);
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 0);
+    }
+
+    #[test]
+    fn delayed_checked_restores_after_infinite_committed_log_prob() {
+        struct InfiniteAtTwo;
+        impl Target<Scalar> for InfiniteAtTwo {
+            fn log_prob(&self, state: &Scalar) -> f64 {
+                if state.0.to_bits() == 2.0_f64.to_bits() {
+                    f64::INFINITY
+                } else {
+                    Normal.log_prob(state)
+                }
+            }
+        }
+
+        let mut chain = Chain::new(Scalar(1.0), &InfiniteAtTwo).unwrap();
+        let log_prob = chain.log_prob();
+        let mut proposal = CheckedCommitProposal {
+            scored: 0.0,
+            committed: 2.0,
+        };
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed_checked(&InfiniteAtTwo, &mut proposal, &mut rng);
+
+        assert_matches!(
+            result,
+            Err(DelayedStepError::Mcmc(McmcError::InfiniteCommittedLogProb))
+        );
+        assert_eq!(chain.state, Scalar(1.0));
+        assert_relative_eq!(chain.log_prob(), log_prob);
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 0);
+    }
+
+    #[test]
+    fn delayed_checked_restores_after_mutating_commit_error() {
+        struct MutatingCommitError;
+        impl DelayedProposal<Scalar> for MutatingCommitError {
+            type Plan = f64;
+            type Info = f64;
+            type Error = DelayedFixtureError;
+
+            fn propose_plan<R: Rng + ?Sized>(
+                &mut self,
+                _state: &Scalar,
+                _rng: &mut R,
+            ) -> Result<Option<f64>, Self::Error> {
+                Ok(Some(0.0))
+            }
+
+            fn proposed_log_prob<T: Target<Scalar>>(
+                &self,
+                _state: &Scalar,
+                plan: &f64,
+                target: &T,
+            ) -> Result<f64, Self::Error> {
+                Ok(target.log_prob(&Scalar(*plan)))
+            }
+
+            fn info(&self, plan: &f64) -> f64 {
+                *plan
+            }
+
+            fn commit<R: Rng + ?Sized>(
+                &mut self,
+                state: &mut Scalar,
+                plan: f64,
+                _rng: &mut R,
+            ) -> Result<(), Self::Error> {
+                state.0 = plan;
+                Err(DelayedFixtureError::Commit)
+            }
+        }
+
+        let mut chain = Chain::new(Scalar(1.0), &Normal).unwrap();
+        let log_prob = chain.log_prob();
+        let mut proposal = MutatingCommitError;
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = chain.step_delayed_checked(&Normal, &mut proposal, &mut rng);
+
+        assert_matches!(
+            result,
+            Err(DelayedStepError::Commit(DelayedFixtureError::Commit))
+        );
+        assert_eq!(chain.state, Scalar(1.0));
         assert_relative_eq!(chain.log_prob(), log_prob);
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 0);

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,20 @@ pub enum McmcError {
     NanCheckpointLogProb,
     /// Target returned NaN log-probability for the current chain state.
     NanCurrentLogProb,
+    /// Target returned NaN log-probability after a checked delayed commit.
+    ///
+    /// This is reported by [`crate::Chain::step_delayed_checked`] or
+    /// [`crate::Sampler::step_delayed_checked`] after an accepted delayed
+    /// proposal has been committed and re-scored.
+    NanCommittedLogProb,
+    /// A checked delayed proposal committed a state whose target log-probability
+    /// differs from the log-probability used for the acceptance decision.
+    ///
+    /// This is reported by [`crate::Chain::step_delayed_checked`] or
+    /// [`crate::Sampler::step_delayed_checked`] when the delayed plan scores
+    /// one transition but [`crate::DelayedProposal::commit`] applies a
+    /// different one.
+    InconsistentDelayedCommitLogProb,
     /// Target returned +∞ log-probability for the initial state.
     ///
     /// This indicates infinite probability, which is invalid for any
@@ -51,6 +65,15 @@ pub enum McmcError {
     /// This indicates infinite probability, which is invalid for any
     /// proper (normalizable) distribution.
     InfiniteCurrentLogProb,
+    /// Target returned +∞ log-probability after a checked delayed commit.
+    ///
+    /// This is reported by [`crate::Chain::step_delayed_checked`] or
+    /// [`crate::Sampler::step_delayed_checked`] after an accepted delayed
+    /// proposal has been committed and re-scored.
+    ///
+    /// This indicates infinite probability, which is invalid for any
+    /// proper (normalizable) distribution.
+    InfiniteCommittedLogProb,
 }
 
 impl fmt::Display for McmcError {
@@ -87,6 +110,18 @@ impl fmt::Display for McmcError {
                     "target returned NaN log-probability for the current chain state"
                 )
             }
+            Self::NanCommittedLogProb => {
+                write!(
+                    f,
+                    "target returned NaN log-probability after a checked delayed commit"
+                )
+            }
+            Self::InconsistentDelayedCommitLogProb => {
+                write!(
+                    f,
+                    "checked delayed commit produced a state with a different log-probability than the accepted plan"
+                )
+            }
             Self::InfiniteInitialLogProb => {
                 write!(
                     f,
@@ -116,6 +151,12 @@ impl fmt::Display for McmcError {
                 write!(
                     f,
                     "target returned +inf log-probability for the current chain state"
+                )
+            }
+            Self::InfiniteCommittedLogProb => {
+                write!(
+                    f,
+                    "target returned +inf log-probability after a checked delayed commit"
                 )
             }
         }
@@ -180,6 +221,24 @@ mod tests {
     }
 
     #[test]
+    fn display_nan_committed_log_prob() {
+        let msg = McmcError::NanCommittedLogProb.to_string();
+        assert_eq!(
+            msg,
+            "target returned NaN log-probability after a checked delayed commit"
+        );
+    }
+
+    #[test]
+    fn display_inconsistent_delayed_commit_log_prob() {
+        let msg = McmcError::InconsistentDelayedCommitLogProb.to_string();
+        assert_eq!(
+            msg,
+            "checked delayed commit produced a state with a different log-probability than the accepted plan"
+        );
+    }
+
+    #[test]
     fn display_infinite_initial_log_prob() {
         let msg = McmcError::InfiniteInitialLogProb.to_string();
         assert_eq!(
@@ -227,6 +286,15 @@ mod tests {
         assert_eq!(
             msg,
             "target returned +inf log-probability for the current chain state"
+        );
+    }
+
+    #[test]
+    fn display_infinite_committed_log_prob() {
+        let msg = McmcError::InfiniteCommittedLogProb.to_string();
+        assert_eq!(
+            msg,
+            "target returned +inf log-probability after a checked delayed commit"
         );
     }
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1920,6 +1920,90 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
             .step_delayed(self.target, &mut self.proposal, self.rng)
     }
 
+    /// Perform one delayed-commit step and verify the committed state afterward.
+    ///
+    /// Delegates to [`Chain::step_delayed_checked`].  Use this while developing
+    /// delayed proposals to catch mismatches between the scored plan and the
+    /// state actually committed by the proposal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct TargetLine;
+    /// impl Target<i32> for TargetLine {
+    ///     fn log_prob(&self, state: &i32) -> f64 {
+    ///         -f64::from(state.abs())
+    ///     }
+    /// }
+    ///
+    /// struct MoveRight;
+    /// impl DelayedProposal<i32> for MoveRight {
+    ///     type Plan = i32;
+    ///     type Info = i32;
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _state: &i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<Option<i32>, Self::Error> {
+    ///         Ok(Some(1))
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<i32>>(
+    ///         &self,
+    ///         state: &i32,
+    ///         plan: &i32,
+    ///         target: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         Ok(target.log_prob(&(*state + *plan)))
+    ///     }
+    ///
+    ///     fn info(&self, plan: &i32) -> i32 {
+    ///         *plan
+    ///     }
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         state: &mut i32,
+    ///         plan: i32,
+    ///         _rng: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         *state += plan;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let target = TargetLine;
+    /// let mut proposal = MoveRight;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(-1, &target)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    ///
+    /// let step = sampler.step_delayed_checked()?;
+    /// assert!(step.accepted);
+    /// assert_eq!(*sampler.chain_ref().state(), 0);
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DelayedStepError`] when planning, numerical validation,
+    /// accepted-move commit, or post-commit validation fails.
+    pub fn step_delayed_checked(
+        &mut self,
+    ) -> Result<DelayedStep<P::Info>, DelayedStepError<P::Error>>
+    where
+        S: Clone,
+    {
+        self.chain
+            .step_delayed_checked(self.target, &mut self.proposal, self.rng)
+    }
+
     /// Run `steps` delayed-commit Metropolis-Hastings steps.
     ///
     /// Stops and returns the first error encountered.

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -178,11 +178,11 @@ impl OnlineStats {
         Ok(stats)
     }
 
-    /// Add one sample to the accumulator.
+    /// Add one sample to the accumulator without validating it.
     ///
-    /// This method does not validate the sample.  Use [`try_push`](Self::try_push)
-    /// when non-finite measurements should be reported as errors instead of
-    /// becoming part of the accumulator state.
+    /// This is a compatibility alias for [`push_unchecked`](Self::push_unchecked).
+    /// Use [`try_push`](Self::try_push) when non-finite measurements should be
+    /// reported as errors instead of becoming part of the accumulator state.
     ///
     /// ```
     /// use markov_chain_monte_carlo::OnlineStats;
@@ -197,11 +197,22 @@ impl OnlineStats {
         self.push_unchecked(sample);
     }
 
-    /// Apply one Welford update without validation.
+    /// Add one sample to the accumulator without validating it.
     ///
-    /// This is shared by infallible `push` and fallible `try_push`, where
-    /// `try_push` first updates a copy so it can remain atomic on error.
-    fn push_unchecked(&mut self, sample: f64) {
+    /// Non-finite samples can permanently contaminate the running mean and
+    /// variance accumulator.  Use [`try_push`](Self::try_push) for production
+    /// measurement streams where `NaN` or infinity should be rejected atomically.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::OnlineStats;
+    ///
+    /// let mut stats = OnlineStats::new();
+    /// stats.push_unchecked(1.0);
+    /// stats.push_unchecked(3.0);
+    ///
+    /// assert_eq!(stats.mean(), Some(2.0));
+    /// ```
+    pub fn push_unchecked(&mut self, sample: f64) {
         self.count += 1;
         let delta = sample - self.mean;
         self.mean += delta / count_as_f64(self.count);
@@ -657,11 +668,11 @@ impl BinningAnalysis {
         Ok(analysis)
     }
 
-    /// Add one measurement.
+    /// Add one measurement without validating it.
     ///
-    /// This method does not validate the sample.  Use [`try_push`](Self::try_push)
-    /// when non-finite measurements should be reported as errors instead of
-    /// becoming part of the binning state.
+    /// This is a compatibility alias for [`push_unchecked`](Self::push_unchecked).
+    /// Use [`try_push`](Self::try_push) when non-finite measurements should be
+    /// reported as errors instead of becoming part of the binning state.
     ///
     /// ```
     /// use markov_chain_monte_carlo::BinningAnalysis;
@@ -677,7 +688,21 @@ impl BinningAnalysis {
     }
 
     /// Add one measurement without validating it.
-    fn push_unchecked(&mut self, sample: f64) {
+    ///
+    /// Non-finite samples can permanently contaminate every affected binning
+    /// level.  Use [`try_push`](Self::try_push) for production measurement
+    /// streams where `NaN` or infinity should be rejected atomically.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::BinningAnalysis;
+    ///
+    /// let mut bins = BinningAnalysis::new();
+    /// bins.push_unchecked(1.0);
+    /// bins.push_unchecked(2.0);
+    ///
+    /// assert_eq!(bins.count(), 2);
+    /// ```
+    pub fn push_unchecked(&mut self, sample: f64) {
         self.count += 1;
         self.push_block(0, sample);
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -255,13 +255,6 @@ pub enum DetailedBalanceError<E = Infallible> {
         /// Observed log q-ratio.
         log_q_ratio: f64,
     },
-    /// Metropolis-Hastings log acceptance ratio was `NaN`.
-    InvalidLogAcceptanceRatio {
-        /// Direction whose log acceptance ratio was invalid.
-        direction: DetailedBalanceDirection,
-        /// Observed log acceptance ratio.
-        log_acceptance_ratio: f64,
-    },
     /// Delayed proposal planning failed.
     Plan {
         /// Direction whose planning failed.
@@ -328,13 +321,6 @@ impl<E: fmt::Display> fmt::Display for DetailedBalanceError<E> {
                 f,
                 "{direction} proposal log q-ratio is {log_q_ratio}: expected finite or -infinity"
             ),
-            Self::InvalidLogAcceptanceRatio {
-                direction,
-                log_acceptance_ratio,
-            } => write!(
-                f,
-                "{direction} log acceptance ratio is {log_acceptance_ratio}: expected a non-NaN value"
-            ),
             Self::Plan { direction, source } => {
                 write!(f, "{direction} delayed proposal planning failed: {source}")
             }
@@ -382,7 +368,6 @@ where
             | Self::InvalidMinHits { .. }
             | Self::InvalidTargetLogProb { .. }
             | Self::InvalidLogQRatio { .. }
-            | Self::InvalidLogAcceptanceRatio { .. }
             | Self::InsufficientHits { .. }
             | Self::Violation { .. } => None,
         }
@@ -1063,13 +1048,11 @@ where
     check_log_q_ratio(DetailedBalanceDirection::Reverse, reverse_log_q_ratio)?;
 
     let forward_acceptance = acceptance_probability(
-        DetailedBalanceDirection::Forward,
         endpoint_log_probs.proposed - endpoint_log_probs.current + forward_log_q_ratio,
-    )?;
+    );
     let reverse_acceptance = acceptance_probability(
-        DetailedBalanceDirection::Reverse,
         endpoint_log_probs.current - endpoint_log_probs.proposed + reverse_log_q_ratio,
-    )?;
+    );
 
     let forward = estimate_by_value_transition(
         current,
@@ -1391,9 +1374,8 @@ where
             let log_q_ratio = proposal.log_q_ratio(&candidate, &token);
             check_log_q_ratio(request.direction, log_q_ratio)?;
             estimate.push(acceptance_probability(
-                request.direction,
                 proposed_log_prob - request.from_log_prob + log_q_ratio,
-            )?);
+            ));
         }
     }
     Ok(estimate)
@@ -1444,9 +1426,8 @@ where
             })?;
             check_log_q_ratio(request.direction, log_q_ratio)?;
             estimate.push(acceptance_probability(
-                request.direction,
                 proposed_log_prob - request.from_log_prob + log_q_ratio,
-            )?);
+            ));
         }
     }
     Ok(estimate)
@@ -1513,20 +1494,17 @@ fn log_residual(forward_log_flow: f64, reverse_log_flow: f64) -> f64 {
     }
 }
 
-/// Convert a log Metropolis-Hastings ratio into an acceptance probability,
-/// rejecting undefined ratios before they contaminate empirical estimates.
-fn acceptance_probability<E>(
-    direction: DetailedBalanceDirection,
-    log_acceptance_ratio: f64,
-) -> Result<f64, DetailedBalanceError<E>> {
+/// Convert a log Metropolis-Hastings ratio into an acceptance probability.
+///
+/// This mirrors the sampler's edge-case policy: ratios such as
+/// `-inf - (-inf)` become `NaN` and are treated as zero acceptance
+/// probability, while nonnegative ratios accept with probability one.
+fn acceptance_probability(log_acceptance_ratio: f64) -> f64 {
     if log_acceptance_ratio.is_nan() {
         cold_path();
-        Err(DetailedBalanceError::InvalidLogAcceptanceRatio {
-            direction,
-            log_acceptance_ratio,
-        })
+        0.0
     } else {
-        Ok(log_acceptance_ratio.min(0.0).exp())
+        log_acceptance_ratio.min(0.0).exp()
     }
 }
 
@@ -2036,14 +2014,6 @@ mod tests {
             "forward proposal log q-ratio is inf: expected finite or -infinity"
         );
         assert_eq!(
-            DetailedBalanceError::<DelayedFailure>::InvalidLogAcceptanceRatio {
-                direction: DetailedBalanceDirection::Reverse,
-                log_acceptance_ratio: f64::NAN,
-            }
-            .to_string(),
-            "reverse log acceptance ratio is NaN: expected a non-NaN value"
-        );
-        assert_eq!(
             DetailedBalanceError::InsufficientHits::<DelayedFailure> {
                 direction: DetailedBalanceDirection::Forward,
                 hits: 0,
@@ -2528,9 +2498,9 @@ mod tests {
     }
 
     #[test]
-    fn reports_invalid_log_acceptance_ratio() {
+    fn treats_two_impossible_endpoints_as_zero_flow() {
         let mut rng = StdRng::seed_from_u64(42);
-        let err = verify_detailed_balance(
+        let report = verify_detailed_balance(
             &false,
             &true,
             &ImpossibleTarget,
@@ -2538,15 +2508,16 @@ mod tests {
             &mut rng,
             small_config(),
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert_matches!(
-            err,
-            DetailedBalanceError::InvalidLogAcceptanceRatio {
-                direction: DetailedBalanceDirection::Forward,
-                log_acceptance_ratio,
-            } if log_acceptance_ratio.is_nan()
-        );
+        assert_eq!(report.forward_hits, 128);
+        assert_eq!(report.reverse_hits, 128);
+        assert!(report.forward_log_transition.is_infinite());
+        assert!(report.forward_log_transition.is_sign_negative());
+        assert!(report.reverse_log_transition.is_infinite());
+        assert!(report.reverse_log_transition.is_sign_negative());
+        assert_relative_eq!(report.log_balance_residual, 0.0);
+        assert!(report.log_balance_standard_error.is_infinite());
     }
 
     #[test]


### PR DESCRIPTION
- Add checked delayed-commit stepping for Chain and Sampler so proposal authors can verify that committed states match the scored plan.
- Report committed-state NaN, positive-infinity, and score-mismatch failures with dedicated McmcError variants while restoring the previous chain state.
- Treat undefined detailed-balance acceptance ratios as zero acceptance so impossible bidirectional transitions produce balanced zero-flow reports.
- Expose unchecked streaming-statistics push methods for callers that already validate measurement streams.
- Add benchmark coverage for streaming observations into OnlineStats and BinningAnalysis.

BREAKING CHANGE: Removed DetailedBalanceError::InvalidLogAcceptanceRatio and changed impossible-endpoint detailed-balance checks from an invalid-acceptance error into a zero-flow report.