### PR TITLE
feat!: add delayed proposal ratio helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ changing numerical semantics, or changing acceptance/error behavior.
 
 - Prefer borrowed APIs by default: take references (`&T`, `&mut T`, `&[T]`) as arguments and return borrowed views (`&T`, `&[T]`) when possible. Only take
   ownership or return `Vec`/allocated data when required.
+- Put property-based Rust tests in integration files named `tests/proptest_*.rs`. Keep `src` unit tests focused on deterministic local behavior unless a
+  private helper cannot be exercised through a public or crate-visible path.
 - Rust/tooling details live in [`docs/dev/rust.md`](docs/dev/rust.md).
 
 ## Common Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,9 @@ in `src/`/examples/benches/doctests, requiring `expect()` reasons, and forbiddin
 
 ### Property-Based Tests
 
-For numerical/statistical invariants, use [proptest](https://docs.rs/proptest/) (already a dev-dependency). Seed RNGs explicitly so failing cases reproduce.
+For numerical/statistical invariants, use [proptest](https://docs.rs/proptest/) (already a dev-dependency). Put property-based Rust tests in integration
+files named `tests/proptest_*.rs`; keep `src` unit tests focused on deterministic local behavior unless a private helper cannot be reached otherwise. Seed
+RNGs explicitly so failing cases reproduce.
 
 ### Test Conventions
 

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -88,6 +88,7 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 │   └── traits.rs
 ├── tests/
 │   ├── proptest_chain.rs
+│   ├── proptest_validators.rs
 │   └── semgrep/
 │       ├── benches/
 │       │   ├── erased_error.rs
@@ -118,7 +119,7 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 
 - `src/` — core library modules and crate-level documentation. The detailed source file map is below.
 - `examples/` — complete runnable workflows that demonstrate public APIs.
-- `tests/` — integration tests and project-rule tests, including Semgrep fixtures under `tests/semgrep/`.
+- `tests/` — integration tests, property-based tests named `tests/proptest_*.rs`, and project-rule tests including Semgrep fixtures under `tests/semgrep/`.
 - `benches/` — Criterion benchmarks for stepping, sampler loops, and observing overhead.
 - `docs/` — topic guides that support the public API documentation without duplicating README or crate-level contract material.
 - `scripts/` — Python helpers for changelog post-processing and release tagging.

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -90,6 +90,8 @@ remains on the narrower `rustfmt` `max_width = 100` setting because wide Rust si
 - Python tooling tests: `just test-python`
 - Single runnable test by name filter: `cargo nextest run chain_samples_near_mode`
 - Examples: `just examples` builds all examples once, then runs the compiled binaries.
+- Property-based Rust tests live in integration files named `tests/proptest_*.rs`; keep `src` unit tests deterministic unless a private helper requires a
+  local test.
 
 ## Benchmarks
 

--- a/docs/proposal_validation.md
+++ b/docs/proposal_validation.md
@@ -60,6 +60,22 @@ Useful checks:
 Delayed detailed-balance checks use plan predicates because plans are the transition descriptors. The helper does not assume endpoint equality is enough to
 identify a move.
 
+For local combinatorial kernels, include valid-site multiplicities in `DelayedProposal::log_q_ratio` whenever they affect concrete transition probabilities.
+For a move that chooses a move kind and then chooses uniformly among valid concrete sites, the ratio for a successful transition is:
+
+```text
+log_q_ratio = log q(current | proposed) - log q(proposed | current)
+            = log reverse_move_weight - log forward_move_weight
+            + log valid_forward_sites - log valid_reverse_sites
+```
+
+Add any non-uniform concrete-site selection terms as well. A bounded search that returns `Ok(None)` after failing to find a valid site is an ordinary
+self-loop/rejection, but it does not repair an omitted Hastings correction for successful moves.
+
+Use `DiscreteProposalRatio::from_counts(forward_sites, reverse_sites)?` for the common equal-move-weight case, or `DiscreteProposalRatio::new(...)` when inverse
+move families have different selection weights. Construction rejects invalid successful-forward inputs immediately. A zero reverse-site count is valid and
+computes to `-inf`, while a successful plan with zero forward sites is reported as an invalid proposal-ratio input.
+
 ## Continuous Proposals
 
 The current detailed-balance helpers are designed for discrete, quantized, or exactly comparable transitions. Continuous proposals almost never resample the

--- a/examples/detailed_balance.rs
+++ b/examples/detailed_balance.rs
@@ -78,7 +78,7 @@ impl DelayedProposal<bool> for DelayedFlip {
 
 fn main() -> Result<(), DetailedBalanceError> {
     let target = TwoStateTarget;
-    let config = DetailedBalanceConfig::new(256, 1e-10, 1);
+    let config = DetailedBalanceConfig::new(256, 1e-10, 1)?;
 
     let mut rng = StdRng::seed_from_u64(42);
     let by_value = verify_detailed_balance(&false, &true, &target, &Flip, &mut rng, config)?;
@@ -94,7 +94,7 @@ fn main() -> Result<(), DetailedBalanceError> {
         &Flip,
         &mut rng,
         config,
-    )?;
+    );
 
     let forward = |plan: &bool| *plan;
     let reverse = |plan: &bool| !*plan;
@@ -109,7 +109,7 @@ fn main() -> Result<(), DetailedBalanceError> {
         &mut delayed_proposal,
         &mut rng,
         config,
-    )?;
+    );
 
     assert!(batch.is_success());
     assert!(delayed.is_success());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,10 @@
 //! rejection, while [`DelayedProposal::commit`] errors are reserved for
 //! exceptional failures applying an already accepted concrete move.
 //!
+//! Use [`DiscreteProposalRatio`] when a delayed combinatorial proposal chooses
+//! a move family and then samples uniformly among that family's valid concrete
+//! sites.
+//!
 //! ```
 //! use core::convert::Infallible;
 //! use markov_chain_monte_carlo::prelude::delayed::*;
@@ -429,7 +433,10 @@ pub use testing::{
     verify_detailed_balance_delayed_many, verify_detailed_balance_many,
     verify_detailed_balance_mut, verify_detailed_balance_mut_many,
 };
-pub use traits::{DelayedProposal, Proposal, ProposalMut, Target};
+pub use traits::{
+    DelayedProposal, DiscreteProposalRatio, DiscreteProposalRatioError, Proposal, ProposalMut,
+    Target,
+};
 
 /// Convenience re-exports for common usage.
 ///
@@ -484,11 +491,12 @@ pub mod prelude {
     /// importing the in-place or delayed proposal traits.
     pub mod by_value {
         pub use crate::{
-            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, McmcError, Observable,
-            ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats, Proposal,
-            SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult,
-            ThinnedRunResult, ThinningError, TryAccumulator, TryObservable,
-            TryObservedIntoRunResult, TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
+            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DiscreteProposalRatio,
+            DiscreteProposalRatioError, McmcError, Observable, ObservedIntoRunResult,
+            ObservedStepError, ObservedStreamError, OnlineStats, Proposal, SampleBuffer, Sampler,
+            StatisticsError, Target, ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningError,
+            TryAccumulator, TryObservable, TryObservedIntoRunResult,
+            TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
         };
     }
 
@@ -498,12 +506,12 @@ pub mod prelude {
     /// importing the by-value or delayed proposal traits.
     pub mod in_place {
         pub use crate::{
-            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, McmcError, Observable,
-            ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats,
-            ProposalMut, SampleBuffer, Sampler, StatisticsError, Target,
-            ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningError, TryAccumulator,
-            TryObservable, TryObservedIntoRunResult, TryThinnedObservedIntoRunResult,
-            TryThinnedObservedRunResult,
+            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DiscreteProposalRatio,
+            DiscreteProposalRatioError, McmcError, Observable, ObservedIntoRunResult,
+            ObservedStepError, ObservedStreamError, OnlineStats, ProposalMut, SampleBuffer,
+            Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult, ThinnedRunResult,
+            ThinningError, TryAccumulator, TryObservable, TryObservedIntoRunResult,
+            TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
         };
     }
 
@@ -514,11 +522,12 @@ pub mod prelude {
     pub mod delayed {
         pub use crate::{
             BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DelayedProposal, DelayedStep,
-            DelayedStepError, McmcError, Observable, ObservedDelayedIntoRunResult,
-            ObservedDelayedStep, ObservedDelayedStepResult, ObservedStepError, ObservedStreamError,
-            OnlineStats, SampleBuffer, Sampler, StatisticsError, Target,
-            ThinnedObservedDelayedIntoRunResult, ThinnedRunResult, ThinningError, TryAccumulator,
-            TryObservable, TryObservedDelayedIntoRunResult, TryThinnedObservedDelayedIntoRunResult,
+            DelayedStepError, DiscreteProposalRatio, DiscreteProposalRatioError, McmcError,
+            Observable, ObservedDelayedIntoRunResult, ObservedDelayedStep,
+            ObservedDelayedStepResult, ObservedStepError, ObservedStreamError, OnlineStats,
+            SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedDelayedIntoRunResult,
+            ThinnedRunResult, ThinningError, TryAccumulator, TryObservable,
+            TryObservedDelayedIntoRunResult, TryThinnedObservedDelayedIntoRunResult,
             TryThinnedObservedRunResult,
         };
     }
@@ -534,8 +543,9 @@ pub mod prelude {
         pub use crate::{
             DelayedProposal, DetailedBalanceBatchReport, DetailedBalanceConfig,
             DetailedBalanceDelayedTransition, DetailedBalanceDirection, DetailedBalanceError,
-            DetailedBalanceFailure, DetailedBalanceReport, DetailedBalanceState, Proposal,
-            ProposalMut, Target, verify_detailed_balance, verify_detailed_balance_delayed,
+            DetailedBalanceFailure, DetailedBalanceReport, DetailedBalanceState,
+            DiscreteProposalRatio, DiscreteProposalRatioError, Proposal, ProposalMut, Target,
+            verify_detailed_balance, verify_detailed_balance_delayed,
             verify_detailed_balance_delayed_many, verify_detailed_balance_many,
             verify_detailed_balance_mut, verify_detailed_balance_mut_many,
         };
@@ -662,15 +672,23 @@ mod public_api_smoke_tests {
         let _: Option<DetailedBalanceState> = None;
         let _: Option<prelude::ThinnedRunResult<(), McmcError>> = None;
         let _: Option<prelude::TryThinnedObservedRunResult<f64, McmcError, Infallible>> = None;
+        let _: Option<by_value::DiscreteProposalRatio> = None;
+        let _: Option<by_value::DiscreteProposalRatioError> = None;
         let _: Option<by_value::ThinnedObservedIntoRunResult<McmcError, Infallible>> = None;
+        let _: Option<in_place::DiscreteProposalRatio> = None;
+        let _: Option<in_place::DiscreteProposalRatioError> = None;
         let _: Option<
             in_place::TryThinnedObservedIntoRunResult<McmcError, Infallible, Infallible>,
         > = None;
+        let _: Option<delayed::DiscreteProposalRatio> = None;
+        let _: Option<delayed::DiscreteProposalRatioError> = None;
         let _: Option<delayed::ThinnedObservedDelayedIntoRunResult<Infallible, Infallible>> = None;
         let _: Option<delayed::McmcError> = None;
         let _: Option<testing::DetailedBalanceConfig> = None;
         let _: Option<testing::DetailedBalanceError> = None;
         let _: Option<testing::DetailedBalanceReport> = None;
+        let _: Option<testing::DiscreteProposalRatio> = None;
+        let _: Option<testing::DiscreteProposalRatioError> = None;
         let _: Option<
             delayed::TryObservedDelayedIntoRunResult<Infallible, Infallible, Infallible>,
         > = None;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -2326,6 +2326,18 @@ mod tests {
             epsilon = 1e-12
         );
 
+        let mut committed = current;
+        let plan = OccupancyPlan {
+            kind: OccupancyMoveKind::Add,
+            site: 0,
+        };
+        assert_eq!(proposal.info(&plan), plan);
+        let mut commit_rng = StdRng::seed_from_u64(7);
+        proposal
+            .commit(&mut committed, plan, &mut commit_rng)
+            .unwrap();
+        assert_eq!(committed, proposed);
+
         let mut rng = StdRng::seed_from_u64(42);
         let report = verify_detailed_balance_delayed(
             &current,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -28,41 +28,119 @@ use crate::{DelayedProposal, Proposal, ProposalMut, Target};
 #[must_use]
 pub struct DetailedBalanceConfig {
     /// Number of proposal samples drawn in each direction.
-    pub samples: usize,
+    samples: usize,
     /// Absolute tolerance for the log detailed-balance residual.
-    pub tolerance: f64,
+    tolerance: f64,
     /// Minimum hit count required in each direction.
-    pub min_hits: usize,
+    min_hits: usize,
 }
 
 impl DetailedBalanceConfig {
     /// Create detailed-balance verification configuration.
     ///
-    /// The verification functions validate these values before sampling.
+    /// # Errors
+    ///
+    /// Returns [`DetailedBalanceError::InvalidSamples`] when `samples` is zero.
+    ///
+    /// Returns [`DetailedBalanceError::InvalidTolerance`] when `tolerance` is
+    /// negative, `NaN`, or infinite.
+    ///
+    /// Returns [`DetailedBalanceError::InvalidMinHits`] when `min_hits` is zero
+    /// or larger than `samples`.
     ///
     /// # Examples
     ///
     /// ```
     /// use markov_chain_monte_carlo::DetailedBalanceConfig;
     ///
-    /// let config = DetailedBalanceConfig::new(128, 1e-12, 1);
+    /// let config = DetailedBalanceConfig::new(128, 1e-12, 1)?;
     ///
-    /// assert_eq!(config.samples, 128);
-    /// assert_eq!(config.tolerance, 1e-12);
-    /// assert_eq!(config.min_hits, 1);
+    /// assert_eq!(config.samples(), 128);
+    /// assert_eq!(config.tolerance(), 1e-12);
+    /// assert_eq!(config.min_hits(), 1);
+    /// # Ok::<(), markov_chain_monte_carlo::DetailedBalanceError>(())
     /// ```
-    pub const fn new(samples: usize, tolerance: f64, min_hits: usize) -> Self {
-        Self {
+    pub fn new(
+        samples: usize,
+        tolerance: f64,
+        min_hits: usize,
+    ) -> Result<Self, DetailedBalanceError> {
+        if samples == 0 {
+            return Err(DetailedBalanceError::InvalidSamples { samples });
+        }
+        if !tolerance.is_finite() || tolerance < 0.0 {
+            return Err(DetailedBalanceError::InvalidTolerance { tolerance });
+        }
+        if min_hits == 0 || min_hits > samples {
+            return Err(DetailedBalanceError::InvalidMinHits { min_hits, samples });
+        }
+
+        Ok(Self {
             samples,
             tolerance,
             min_hits,
-        }
+        })
+    }
+
+    /// Number of proposal samples drawn in each direction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DetailedBalanceConfig;
+    ///
+    /// let config = DetailedBalanceConfig::new(128, 1e-12, 1)?;
+    ///
+    /// assert_eq!(config.samples(), 128);
+    /// # Ok::<(), markov_chain_monte_carlo::DetailedBalanceError>(())
+    /// ```
+    #[must_use]
+    pub const fn samples(self) -> usize {
+        self.samples
+    }
+
+    /// Absolute tolerance for the log detailed-balance residual.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DetailedBalanceConfig;
+    ///
+    /// let config = DetailedBalanceConfig::new(128, 1e-12, 1)?;
+    ///
+    /// assert_eq!(config.tolerance(), 1e-12);
+    /// # Ok::<(), markov_chain_monte_carlo::DetailedBalanceError>(())
+    /// ```
+    #[must_use]
+    pub const fn tolerance(self) -> f64 {
+        self.tolerance
+    }
+
+    /// Minimum hit count required in each direction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DetailedBalanceConfig;
+    ///
+    /// let config = DetailedBalanceConfig::new(128, 1e-12, 1)?;
+    ///
+    /// assert_eq!(config.min_hits(), 1);
+    /// # Ok::<(), markov_chain_monte_carlo::DetailedBalanceError>(())
+    /// ```
+    #[must_use]
+    pub const fn min_hits(self) -> usize {
+        self.min_hits
     }
 }
 
 impl Default for DetailedBalanceConfig {
     fn default() -> Self {
-        Self::new(10_000, 0.1, 30)
+        Self {
+            samples: 10_000,
+            tolerance: 0.1,
+            min_hits: 30,
+        }
     }
 }
 
@@ -220,7 +298,7 @@ impl DetailedBalanceReport {
     }
 }
 
-/// Error returned by empirical detailed-balance verification.
+/// Error returned by detailed-balance configuration and verification.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub enum DetailedBalanceError<E = Infallible> {
@@ -513,7 +591,7 @@ impl<'a, S, Plan> DetailedBalanceDelayedTransition<'a, S, Plan> {
 ///
 /// This helper samples `proposal` from `current` and `proposed`, estimates the
 /// off-diagonal Metropolis-Hastings transition probabilities in both directions,
-/// and checks that the log transition flows agree within `config.tolerance`.
+/// and checks that the log transition flows agree within the configured tolerance.
 ///
 /// Because it compares states with [`PartialEq`], this is intended for
 /// discrete, quantized, or otherwise exactly comparable state spaces.  For
@@ -545,7 +623,7 @@ impl<'a, S, Plan> DetailedBalanceDelayedTransition<'a, S, Plan> {
 ///     &Flat,
 ///     &Flip,
 ///     &mut rng,
-///     DetailedBalanceConfig::new(128, 1e-12, 1),
+///     DetailedBalanceConfig::new(128, 1e-12, 1)?,
 /// )?;
 ///
 /// assert_eq!(report.forward_hits, 128);
@@ -555,10 +633,10 @@ impl<'a, S, Plan> DetailedBalanceDelayedTransition<'a, S, Plan> {
 ///
 /// # Errors
 ///
-/// Returns [`DetailedBalanceError`] if the configuration is invalid, target
-/// log-probabilities or proposal ratios are `NaN`/`+infinity`, too few exact
-/// hits are observed in either direction, or the estimated detailed-balance
-/// residual exceeds the configured tolerance.
+/// Returns [`DetailedBalanceError`] if target log-probabilities or proposal
+/// ratios are `NaN`/`+infinity`, too few exact hits are observed in either
+/// direction, or the estimated detailed-balance residual exceeds the configured
+/// tolerance.
 pub fn verify_detailed_balance<S, T, P, R>(
     current: &S,
     proposed: &S,
@@ -573,7 +651,6 @@ where
     P: Proposal<S> + ?Sized,
     R: Rng + ?Sized,
 {
-    validate_config(config)?;
     verify_detailed_balance_unchecked(current, proposed, target, proposal, rng, config)
 }
 
@@ -607,25 +684,22 @@ where
 ///     &Flat,
 ///     &Flip,
 ///     &mut rng,
-///     DetailedBalanceConfig::new(128, 1e-12, 1),
-/// )?;
+///     DetailedBalanceConfig::new(128, 1e-12, 1)?,
+/// );
 ///
 /// assert!(batch.is_success());
 /// assert_eq!(batch.reports.len(), 2);
 /// # Ok::<(), DetailedBalanceError>(())
 /// ```
 ///
-/// # Errors
-///
-/// Returns [`DetailedBalanceError`] if the configuration is invalid.  Per-transition
-/// failures are collected in [`DetailedBalanceBatchReport::failures`].
+/// Per-transition failures are collected in [`DetailedBalanceBatchReport::failures`].
 pub fn verify_detailed_balance_many<'a, S, T, P, R, I>(
     pairs: I,
     target: &T,
     proposal: &P,
     rng: &mut R,
     config: DetailedBalanceConfig,
-) -> Result<DetailedBalanceBatchReport, DetailedBalanceError>
+) -> DetailedBalanceBatchReport
 where
     S: PartialEq + 'a,
     T: Target<S>,
@@ -634,8 +708,6 @@ where
     I: IntoIterator<Item = (&'a S, &'a S)>,
 {
     let mut batch = DetailedBalanceBatchReport::new(Vec::new(), Vec::new());
-
-    validate_config(config)?;
 
     for (index, (current, proposed)) in pairs.into_iter().enumerate() {
         match verify_detailed_balance_unchecked(current, proposed, target, proposal, rng, config) {
@@ -646,7 +718,7 @@ where
         }
     }
 
-    Ok(batch)
+    batch
 }
 
 /// Empirically verify detailed balance for one in-place transition.
@@ -690,7 +762,7 @@ where
 ///     &Flat,
 ///     &Flip,
 ///     &mut rng,
-///     DetailedBalanceConfig::new(128, 1e-12, 1),
+///     DetailedBalanceConfig::new(128, 1e-12, 1)?,
 /// )?;
 ///
 /// assert!(report.is_within_tolerance(1e-12));
@@ -699,10 +771,10 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`DetailedBalanceError`] if the configuration is invalid, target
-/// log-probabilities or proposal ratios are `NaN`/`+infinity`, too few exact
-/// hits are observed in either direction, or the estimated detailed-balance
-/// residual exceeds the configured tolerance.
+/// Returns [`DetailedBalanceError`] if target log-probabilities or proposal
+/// ratios are `NaN`/`+infinity`, too few exact hits are observed in either
+/// direction, or the estimated detailed-balance residual exceeds the configured
+/// tolerance.
 pub fn verify_detailed_balance_mut<S, T, P, R>(
     current: &S,
     proposed: &S,
@@ -717,7 +789,6 @@ where
     P: ProposalMut<S> + ?Sized,
     R: Rng + ?Sized,
 {
-    validate_config(config)?;
     verify_detailed_balance_mut_unchecked(current, proposed, target, proposal, rng, config)
 }
 
@@ -756,25 +827,22 @@ where
 ///     &Flat,
 ///     &Flip,
 ///     &mut rng,
-///     DetailedBalanceConfig::new(128, 1e-12, 1),
-/// )?;
+///     DetailedBalanceConfig::new(128, 1e-12, 1)?,
+/// );
 ///
 /// assert!(batch.is_success());
 /// assert_eq!(batch.reports.len(), 2);
 /// # Ok::<(), DetailedBalanceError>(())
 /// ```
 ///
-/// # Errors
-///
-/// Returns [`DetailedBalanceError`] if the configuration is invalid.  Per-transition
-/// failures are collected in [`DetailedBalanceBatchReport::failures`].
+/// Per-transition failures are collected in [`DetailedBalanceBatchReport::failures`].
 pub fn verify_detailed_balance_mut_many<'a, S, T, P, R, I>(
     pairs: I,
     target: &T,
     proposal: &P,
     rng: &mut R,
     config: DetailedBalanceConfig,
-) -> Result<DetailedBalanceBatchReport, DetailedBalanceError>
+) -> DetailedBalanceBatchReport
 where
     S: Clone + PartialEq + 'a,
     T: Target<S>,
@@ -783,8 +851,6 @@ where
     I: IntoIterator<Item = (&'a S, &'a S)>,
 {
     let mut batch = DetailedBalanceBatchReport::new(Vec::new(), Vec::new());
-
-    validate_config(config)?;
 
     for (index, (current, proposed)) in pairs.into_iter().enumerate() {
         match verify_detailed_balance_mut_unchecked(
@@ -797,7 +863,7 @@ where
         }
     }
 
-    Ok(batch)
+    batch
 }
 
 /// Empirically verify detailed balance for one delayed-commit transition.
@@ -810,11 +876,10 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`DetailedBalanceError`] if the configuration is invalid, delayed
-/// proposal planning/scoring fails, target log-probabilities or proposal ratios
-/// are `NaN`/`+infinity`, too few matching plans are observed in either
-/// direction, or the estimated detailed-balance residual exceeds the configured
-/// tolerance.
+/// Returns [`DetailedBalanceError`] if delayed proposal planning/scoring fails,
+/// target log-probabilities or proposal ratios are `NaN`/`+infinity`, too few
+/// matching plans are observed in either direction, or the estimated
+/// detailed-balance residual exceeds the configured tolerance.
 ///
 /// # Examples
 ///
@@ -872,7 +937,7 @@ where
 ///     &Flat,
 ///     &mut proposal,
 ///     &mut rng,
-///     DetailedBalanceConfig::new(128, 1e-12, 1),
+///     DetailedBalanceConfig::new(128, 1e-12, 1)?,
 ///     (|plan| *plan, |plan| !*plan),
 /// )?;
 ///
@@ -893,7 +958,6 @@ where
     P: DelayedProposal<S> + ?Sized,
     R: Rng + ?Sized,
 {
-    validate_config(config)?;
     let (forward_matches, reverse_matches) = plan_matches;
     verify_detailed_balance_delayed_unchecked(
         current,
@@ -971,25 +1035,22 @@ where
 ///     &Flat,
 ///     &mut proposal,
 ///     &mut rng,
-///     DetailedBalanceConfig::new(128, 1e-12, 1),
-/// )?;
+///     DetailedBalanceConfig::new(128, 1e-12, 1)?,
+/// );
 ///
 /// assert!(batch.is_success());
 /// assert_eq!(batch.reports.len(), 1);
 /// # Ok::<(), DetailedBalanceError<Infallible>>(())
 /// ```
 ///
-/// # Errors
-///
-/// Returns [`DetailedBalanceError`] if the configuration is invalid.  Per-transition
-/// failures are collected in [`DetailedBalanceBatchReport::failures`].
+/// Per-transition failures are collected in [`DetailedBalanceBatchReport::failures`].
 pub fn verify_detailed_balance_delayed_many<'a, S, T, P, R, I>(
     transitions: I,
     target: &T,
     proposal: &mut P,
     rng: &mut R,
     config: DetailedBalanceConfig,
-) -> Result<DetailedBalanceBatchReport<P::Error>, DetailedBalanceError<P::Error>>
+) -> DetailedBalanceBatchReport<P::Error>
 where
     S: 'a,
     T: Target<S>,
@@ -999,8 +1060,6 @@ where
     I: IntoIterator<Item = DetailedBalanceDelayedTransition<'a, S, P::Plan>>,
 {
     let mut batch = DetailedBalanceBatchReport::new(Vec::new(), Vec::new());
-
-    validate_config(config)?;
 
     for (index, transition) in transitions.into_iter().enumerate() {
         match verify_detailed_balance_delayed_unchecked(
@@ -1022,11 +1081,10 @@ where
         }
     }
 
-    Ok(batch)
+    batch
 }
 
-/// Run a by-value detailed-balance check after the public caller has already
-/// validated the sampling configuration.
+/// Run a by-value detailed-balance check with an already validated config.
 fn verify_detailed_balance_unchecked<S, T, P, R>(
     current: &S,
     proposed: &S,
@@ -1074,7 +1132,7 @@ where
     finish_report(endpoint_log_probs, forward, reverse, config)
 }
 
-/// Run an in-place detailed-balance check after configuration validation,
+/// Run an in-place detailed-balance check with an already validated config,
 /// estimating each direction from cloned endpoint states.
 fn verify_detailed_balance_mut_unchecked<S, T, P, R>(
     current: &S,
@@ -1119,8 +1177,8 @@ where
     finish_report(endpoint_log_probs, forward, reverse, config)
 }
 
-/// Run a delayed-proposal detailed-balance check after configuration validation,
-/// using caller-supplied predicates to identify matching concrete plans.
+/// Run a delayed-proposal detailed-balance check with an already validated
+/// config, using caller-supplied predicates to identify matching concrete plans.
 fn verify_detailed_balance_delayed_unchecked<S, T, P, R, F, G>(
     current: &S,
     proposed: &S,
@@ -1164,27 +1222,6 @@ where
     )?;
 
     finish_report(endpoint_log_probs, forward, reverse, config)
-}
-
-/// Validate detailed-balance configuration before sampling.
-fn validate_config<E>(config: DetailedBalanceConfig) -> Result<(), DetailedBalanceError<E>> {
-    if config.samples == 0 {
-        return Err(DetailedBalanceError::InvalidSamples {
-            samples: config.samples,
-        });
-    }
-    if !config.tolerance.is_finite() || config.tolerance < 0.0 {
-        return Err(DetailedBalanceError::InvalidTolerance {
-            tolerance: config.tolerance,
-        });
-    }
-    if config.min_hits == 0 || config.min_hits > config.samples {
-        return Err(DetailedBalanceError::InvalidMinHits {
-            min_hits: config.min_hits,
-            samples: config.samples,
-        });
-    }
-    Ok(())
 }
 
 /// Cached endpoint target log-probabilities for the two states in a check.
@@ -1539,7 +1576,9 @@ mod tests {
     use std::{assert_matches, error::Error as _};
 
     use approx::{assert_relative_eq, relative_eq};
-    use rand::{Rng, SeedableRng, rngs::StdRng};
+    use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
+
+    use crate::{DiscreteProposalRatio, DiscreteProposalRatioError};
 
     use super::*;
 
@@ -1707,6 +1746,131 @@ mod tests {
             _: &mut R,
         ) -> Result<(), Infallible> {
             *state = plan;
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum OccupancyMoveKind {
+        Add,
+        Remove,
+    }
+
+    impl OccupancyMoveKind {
+        const fn reverse(self) -> Self {
+            match self {
+                Self::Add => Self::Remove,
+                Self::Remove => Self::Add,
+            }
+        }
+
+        const fn target_occupied(self) -> bool {
+            match self {
+                Self::Add => true,
+                Self::Remove => false,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct OccupancyPlan {
+        kind: OccupancyMoveKind,
+        site: usize,
+    }
+
+    struct FlatOccupancyTarget;
+    impl Target<[bool; 3]> for FlatOccupancyTarget {
+        fn log_prob(&self, _: &[bool; 3]) -> f64 {
+            0.0
+        }
+    }
+
+    struct OccupancyToggle;
+    impl OccupancyToggle {
+        fn valid_sites(state: [bool; 3], kind: OccupancyMoveKind) -> impl Iterator<Item = usize> {
+            let target_occupied = kind.target_occupied();
+            state
+                .into_iter()
+                .enumerate()
+                .filter_map(move |(site, occupied)| (target_occupied != occupied).then_some(site))
+        }
+
+        fn valid_site_count(state: [bool; 3], kind: OccupancyMoveKind) -> usize {
+            Self::valid_sites(state, kind).count()
+        }
+
+        fn nth_valid_site(state: [bool; 3], kind: OccupancyMoveKind, index: usize) -> usize {
+            Self::valid_sites(state, kind)
+                .nth(index)
+                .expect("valid site index is drawn below the valid-site count")
+        }
+
+        fn proposed_state(state: [bool; 3], plan: OccupancyPlan) -> [bool; 3] {
+            let mut proposed = state;
+            proposed[plan.site] = plan.kind.target_occupied();
+            proposed
+        }
+    }
+
+    impl DelayedProposal<[bool; 3]> for OccupancyToggle {
+        type Plan = OccupancyPlan;
+        type Info = OccupancyPlan;
+        type Error = DiscreteProposalRatioError;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            state: &[bool; 3],
+            rng: &mut R,
+        ) -> Result<Option<OccupancyPlan>, DiscreteProposalRatioError> {
+            let kind = if rng.random_range(0..2) == 0 {
+                OccupancyMoveKind::Add
+            } else {
+                OccupancyMoveKind::Remove
+            };
+            let valid_sites = Self::valid_site_count(*state, kind);
+            if valid_sites == 0 {
+                return Ok(None);
+            }
+
+            let site_index = rng.random_range(0..valid_sites);
+            Ok(Some(OccupancyPlan {
+                kind,
+                site: Self::nth_valid_site(*state, kind, site_index),
+            }))
+        }
+
+        fn proposed_log_prob<T: Target<[bool; 3]>>(
+            &self,
+            state: &[bool; 3],
+            plan: &OccupancyPlan,
+            target: &T,
+        ) -> Result<f64, DiscreteProposalRatioError> {
+            Ok(target.log_prob(&Self::proposed_state(*state, *plan)))
+        }
+
+        fn log_q_ratio(
+            &self,
+            state: &[bool; 3],
+            plan: &OccupancyPlan,
+        ) -> Result<f64, DiscreteProposalRatioError> {
+            let proposed = Self::proposed_state(*state, *plan);
+            let forward_sites = Self::valid_site_count(*state, plan.kind);
+            let reverse_sites = Self::valid_site_count(proposed, plan.kind.reverse());
+
+            Ok(DiscreteProposalRatio::from_counts(forward_sites, reverse_sites)?.log_q_ratio())
+        }
+
+        fn info(&self, plan: &OccupancyPlan) -> OccupancyPlan {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut [bool; 3],
+            plan: OccupancyPlan,
+            _: &mut R,
+        ) -> Result<(), DiscreteProposalRatioError> {
+            *state = Self::proposed_state(*state, plan);
             Ok(())
         }
     }
@@ -1926,7 +2090,7 @@ mod tests {
 
     /// Return a fast deterministic configuration for exact two-state tests.
     fn small_config() -> DetailedBalanceConfig {
-        DetailedBalanceConfig::new(128, 1e-12, 1)
+        DetailedBalanceConfig::new(128, 1e-12, 1).unwrap()
     }
 
     /// Build a minimal report with a configurable standard error for helper API tests.
@@ -1947,9 +2111,9 @@ mod tests {
     #[test]
     fn default_config_and_report_helpers_cover_public_contract() {
         let config = DetailedBalanceConfig::default();
-        assert_eq!(config.samples, 10_000);
-        assert_eq!(config.tolerance.to_bits(), 0.1_f64.to_bits());
-        assert_eq!(config.min_hits, 30);
+        assert_eq!(config.samples(), 10_000);
+        assert_eq!(config.tolerance().to_bits(), 0.1_f64.to_bits());
+        assert_eq!(config.min_hits(), 30);
 
         let report = report_with_standard_error(0.0);
         assert!(report.is_within_tolerance(0.0));
@@ -2125,6 +2289,56 @@ mod tests {
         assert_eq!(report.forward_hits, 128);
         assert_eq!(report.reverse_hits, 128);
         assert!(report.is_within_tolerance(1e-12));
+    }
+
+    #[test]
+    fn delayed_valid_site_counts_supply_hastings_correction() {
+        let current = [false, false, false];
+        let proposed = [true, false, false];
+        let forward = |plan: &OccupancyPlan| plan.kind == OccupancyMoveKind::Add && plan.site == 0;
+        let reverse =
+            |plan: &OccupancyPlan| plan.kind == OccupancyMoveKind::Remove && plan.site == 0;
+
+        let mut proposal = OccupancyToggle;
+        let forward_log_q_ratio = proposal
+            .log_q_ratio(
+                &current,
+                &OccupancyPlan {
+                    kind: OccupancyMoveKind::Add,
+                    site: 0,
+                },
+            )
+            .unwrap();
+        let reverse_log_q_ratio = proposal
+            .log_q_ratio(
+                &proposed,
+                &OccupancyPlan {
+                    kind: OccupancyMoveKind::Remove,
+                    site: 0,
+                },
+            )
+            .unwrap();
+
+        assert_relative_eq!(forward_log_q_ratio, 3.0_f64.ln(), epsilon = 1e-12);
+        assert_relative_eq!(
+            reverse_log_q_ratio,
+            (1.0_f64 / 3.0_f64).ln(),
+            epsilon = 1e-12
+        );
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let report = verify_detailed_balance_delayed(
+            &current,
+            &proposed,
+            &FlatOccupancyTarget,
+            &mut proposal,
+            &mut rng,
+            DetailedBalanceConfig::new(16_384, 0.08, 64).unwrap(),
+            (forward, reverse),
+        )
+        .unwrap();
+
+        assert!(report.is_within_tolerance(0.08), "{report:?}");
     }
 
     #[test]
@@ -2530,8 +2744,7 @@ mod tests {
             &BadLogQ,
             &mut rng,
             small_config(),
-        )
-        .unwrap();
+        );
 
         assert!(!batch.is_success());
         assert_eq!(batch.failures.len(), 2);
@@ -2549,8 +2762,7 @@ mod tests {
             &BadLogQMut,
             &mut rng,
             small_config(),
-        )
-        .unwrap();
+        );
 
         assert!(!batch.is_success());
         assert_eq!(batch.reports.len(), 0);
@@ -2575,8 +2787,7 @@ mod tests {
             &mut proposal,
             &mut rng,
             small_config(),
-        )
-        .unwrap();
+        );
 
         assert!(batch.is_success());
         assert_eq!(batch.reports.len(), 1);
@@ -2599,8 +2810,7 @@ mod tests {
             &mut proposal,
             &mut rng,
             small_config(),
-        )
-        .unwrap();
+        );
 
         assert!(!batch.is_success());
         assert_eq!(batch.reports.len(), 0);
@@ -2616,29 +2826,14 @@ mod tests {
     }
 
     #[test]
-    fn batch_rejects_invalid_config_without_fake_transition_index() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let err = verify_detailed_balance_many(
-            core::iter::empty::<(&bool, &bool)>(),
-            &TwoStateTarget,
-            &Flip,
-            &mut rng,
-            DetailedBalanceConfig::new(0, 1e-12, 1),
-        )
-        .unwrap_err();
-
+    fn detailed_balance_config_rejects_zero_samples_at_construction() {
+        let err = DetailedBalanceConfig::new(0, 1e-12, 1).unwrap_err();
         assert_matches!(err, DetailedBalanceError::InvalidSamples { samples: 0 });
     }
 
     #[test]
-    fn rejects_invalid_config() {
-        let err: DetailedBalanceError =
-            validate_config(DetailedBalanceConfig::new(0, 0.0, 1)).unwrap_err();
-
-        assert_matches!(err, DetailedBalanceError::InvalidSamples { samples: 0 });
-
-        let err =
-            validate_config::<Infallible>(DetailedBalanceConfig::new(1, -1.0, 1)).unwrap_err();
+    fn detailed_balance_config_rejects_invalid_tolerances_at_construction() {
+        let err = DetailedBalanceConfig::new(1, -1.0, 1).unwrap_err();
 
         assert_matches!(
             err,
@@ -2646,24 +2841,25 @@ mod tests {
                 if tolerance.to_bits() == (-1.0_f64).to_bits()
         );
 
-        let err =
-            validate_config::<Infallible>(DetailedBalanceConfig::new(1, f64::NAN, 1)).unwrap_err();
+        let err = DetailedBalanceConfig::new(1, f64::NAN, 1).unwrap_err();
 
         assert_matches!(
             err,
             DetailedBalanceError::InvalidTolerance { tolerance } if tolerance.is_nan()
         );
 
-        let err = validate_config::<Infallible>(DetailedBalanceConfig::new(1, f64::INFINITY, 1))
-            .unwrap_err();
+        let err = DetailedBalanceConfig::new(1, f64::INFINITY, 1).unwrap_err();
 
         assert_matches!(
             err,
             DetailedBalanceError::InvalidTolerance { tolerance }
                 if tolerance.is_infinite() && tolerance.is_sign_positive()
         );
+    }
 
-        let err = validate_config::<Infallible>(DetailedBalanceConfig::new(1, 0.0, 0)).unwrap_err();
+    #[test]
+    fn detailed_balance_config_rejects_invalid_min_hits_at_construction() {
+        let err = DetailedBalanceConfig::new(1, 0.0, 0).unwrap_err();
 
         assert_matches!(
             err,
@@ -2673,7 +2869,7 @@ mod tests {
             }
         );
 
-        let err = validate_config::<Infallible>(DetailedBalanceConfig::new(1, 0.0, 2)).unwrap_err();
+        let err = DetailedBalanceConfig::new(1, 0.0, 2).unwrap_err();
 
         assert_matches!(
             err,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -732,12 +732,15 @@ mod tests {
 
     #[test]
     fn discrete_proposal_ratio_accounts_for_move_weights() {
-        let ratio = DiscreteProposalRatio::new(0.25, 6, 0.75, 2)
-            .unwrap()
-            .log_q_ratio();
+        let ratio = DiscreteProposalRatio::new(0.25, 6, 0.75, 2).unwrap();
+
+        assert_eq!(ratio.forward_weight().to_bits(), 0.25_f64.to_bits());
+        assert_eq!(ratio.reverse_weight().to_bits(), 0.75_f64.to_bits());
+        assert_eq!(ratio.forward_site_count(), 6);
+        assert_eq!(ratio.reverse_site_count(), 2);
 
         assert_relative_eq!(
-            ratio,
+            ratio.log_q_ratio(),
             0.75_f64.ln() - 0.25_f64.ln() + 6.0_f64.ln() - 2.0_f64.ln(),
             epsilon = 1e-12
         );
@@ -778,6 +781,12 @@ mod tests {
     fn discrete_proposal_ratio_rejects_invalid_forward_weights() {
         for weight in [0.0, -1.0, f64::NEG_INFINITY, f64::NAN, f64::INFINITY] {
             let err = DiscreteProposalRatio::new(weight, 1, 1.0, 1).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "invalid forward move-family weight {weight}: expected a positive finite value"
+                )
+            );
 
             match err {
                 DiscreteProposalRatioError::InvalidForwardWeight { weight: observed } => {
@@ -796,6 +805,12 @@ mod tests {
     fn discrete_proposal_ratio_rejects_invalid_reverse_weights() {
         for weight in [-1.0, f64::NEG_INFINITY, f64::NAN, f64::INFINITY] {
             let err = DiscreteProposalRatio::new(1.0, 1, weight, 1).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "invalid reverse move-family weight {weight}: expected a nonnegative finite value"
+                )
+            );
 
             match err {
                 DiscreteProposalRatioError::InvalidReverseWeight { weight: observed } => {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,6 +2,288 @@
 
 use rand::Rng;
 
+/// Hastings correction for a discrete proposal with weighted move families and
+/// uniformly sampled concrete sites.
+///
+/// This helper covers proposal kernels that first choose a move family, then
+/// choose uniformly from that family's concrete valid-site set.  It computes:
+///
+/// ```text
+/// log(q(current | proposed) / q(proposed | current))
+/// = log(reverse_weight) - log(forward_weight)
+/// + log(forward_site_count) - log(reverse_site_count)
+/// ```
+///
+/// Use [`from_counts`](Self::from_counts) when forward and reverse move-family
+/// weights are equal and cancel.
+///
+/// # Examples
+///
+/// ```
+/// use markov_chain_monte_carlo::DiscreteProposalRatio;
+///
+/// let log_q_ratio = DiscreteProposalRatio::from_counts(3, 1)?.log_q_ratio();
+///
+/// assert!((log_q_ratio - 3.0_f64.ln()).abs() < 1e-12);
+/// # Ok::<(), markov_chain_monte_carlo::DiscreteProposalRatioError>(())
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[must_use]
+pub struct DiscreteProposalRatio {
+    forward_weight: f64,
+    reverse_weight: f64,
+    forward_site_count: usize,
+    reverse_site_count: usize,
+}
+
+impl DiscreteProposalRatio {
+    /// Create a ratio from move-family weights and valid concrete-site counts.
+    ///
+    /// `forward_weight` is the probability or relative weight of selecting the
+    /// move family that proposed the current plan.  `reverse_weight` is the
+    /// probability or relative weight of selecting that plan's inverse move
+    /// family from the proposed state.
+    ///
+    /// The forward count and weight must be positive for a successful plan.  A
+    /// zero reverse count or weight is allowed and yields `f64::NEG_INFINITY`
+    /// from [`log_q_ratio`](Self::log_q_ratio), meaning the forward transition
+    /// should never be accepted under the Metropolis-Hastings correction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscreteProposalRatioError::InvalidForwardWeight`] when the
+    /// forward move-family weight is not positive and finite.
+    ///
+    /// Returns [`DiscreteProposalRatioError::InvalidReverseWeight`] when the
+    /// reverse move-family weight is negative, `NaN`, or infinite.  A zero
+    /// reverse weight is valid.
+    ///
+    /// Returns [`DiscreteProposalRatioError::ZeroForwardSiteCount`] when a
+    /// successful proposal reports no valid forward sites.  A zero reverse-site
+    /// count is valid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DiscreteProposalRatio;
+    ///
+    /// let ratio = DiscreteProposalRatio::new(0.25, 6, 0.75, 2)?;
+    ///
+    /// assert_eq!(ratio.forward_weight(), 0.25);
+    /// assert_eq!(ratio.forward_site_count(), 6);
+    /// assert_eq!(ratio.reverse_weight(), 0.75);
+    /// assert_eq!(ratio.reverse_site_count(), 2);
+    /// # Ok::<(), markov_chain_monte_carlo::DiscreteProposalRatioError>(())
+    /// ```
+    pub fn new(
+        forward_weight: f64,
+        forward_site_count: usize,
+        reverse_weight: f64,
+        reverse_site_count: usize,
+    ) -> Result<Self, DiscreteProposalRatioError> {
+        if !forward_weight.is_finite() || forward_weight <= 0.0 {
+            return Err(DiscreteProposalRatioError::InvalidForwardWeight {
+                weight: forward_weight,
+            });
+        }
+        if !reverse_weight.is_finite() || reverse_weight < 0.0 {
+            return Err(DiscreteProposalRatioError::InvalidReverseWeight {
+                weight: reverse_weight,
+            });
+        }
+        if forward_site_count == 0 {
+            return Err(DiscreteProposalRatioError::ZeroForwardSiteCount);
+        }
+
+        Ok(Self {
+            forward_weight,
+            reverse_weight,
+            forward_site_count,
+            reverse_site_count,
+        })
+    }
+
+    /// Create a ratio for equal move-family weights.
+    ///
+    /// This is the common CDT-style site-count correction:
+    ///
+    /// ```text
+    /// log_q_ratio = log(forward_site_count) - log(reverse_site_count)
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscreteProposalRatioError::ZeroForwardSiteCount`] when a
+    /// successful proposal reports no valid forward sites.  A zero reverse-site
+    /// count is valid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DiscreteProposalRatio;
+    ///
+    /// let ratio = DiscreteProposalRatio::from_counts(4, 2)?;
+    /// let log_q_ratio = ratio.log_q_ratio();
+    ///
+    /// assert!((log_q_ratio - 2.0_f64.ln()).abs() < 1e-12);
+    /// # Ok::<(), markov_chain_monte_carlo::DiscreteProposalRatioError>(())
+    /// ```
+    pub fn from_counts(
+        forward_site_count: usize,
+        reverse_site_count: usize,
+    ) -> Result<Self, DiscreteProposalRatioError> {
+        Self::new(1.0, forward_site_count, 1.0, reverse_site_count)
+    }
+
+    /// Forward move-family weight.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DiscreteProposalRatio;
+    ///
+    /// let ratio = DiscreteProposalRatio::new(0.25, 6, 0.75, 2)?;
+    ///
+    /// assert_eq!(ratio.forward_weight(), 0.25);
+    /// # Ok::<(), markov_chain_monte_carlo::DiscreteProposalRatioError>(())
+    /// ```
+    #[must_use]
+    pub const fn forward_weight(self) -> f64 {
+        self.forward_weight
+    }
+
+    /// Reverse move-family weight.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DiscreteProposalRatio;
+    ///
+    /// let ratio = DiscreteProposalRatio::new(0.25, 6, 0.75, 2)?;
+    ///
+    /// assert_eq!(ratio.reverse_weight(), 0.75);
+    /// # Ok::<(), markov_chain_monte_carlo::DiscreteProposalRatioError>(())
+    /// ```
+    #[must_use]
+    pub const fn reverse_weight(self) -> f64 {
+        self.reverse_weight
+    }
+
+    /// Number of concrete sites sampled by the forward proposal family.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DiscreteProposalRatio;
+    ///
+    /// let ratio = DiscreteProposalRatio::from_counts(4, 2)?;
+    ///
+    /// assert_eq!(ratio.forward_site_count(), 4);
+    /// # Ok::<(), markov_chain_monte_carlo::DiscreteProposalRatioError>(())
+    /// ```
+    #[must_use]
+    pub const fn forward_site_count(self) -> usize {
+        self.forward_site_count
+    }
+
+    /// Number of concrete sites sampled by the reverse proposal family.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DiscreteProposalRatio;
+    ///
+    /// let ratio = DiscreteProposalRatio::from_counts(4, 2)?;
+    ///
+    /// assert_eq!(ratio.reverse_site_count(), 2);
+    /// # Ok::<(), markov_chain_monte_carlo::DiscreteProposalRatioError>(())
+    /// ```
+    #[must_use]
+    pub const fn reverse_site_count(self) -> usize {
+        self.reverse_site_count
+    }
+
+    /// Compute `log(q(current | proposed) / q(proposed | current))`.
+    ///
+    /// Construction validates the forward proposal probability and move-family
+    /// weights, so this method only performs the log-space arithmetic.  A zero
+    /// reverse-site count or zero reverse move-family weight produces
+    /// `f64::NEG_INFINITY`.
+    ///
+    /// # Examples
+    ///
+    /// Zero reverse-site counts produce `-inf`, representing a transition that
+    /// cannot be accepted because no reverse proposal exists.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::DiscreteProposalRatio;
+    ///
+    /// let log_q_ratio = DiscreteProposalRatio::from_counts(3, 0)?.log_q_ratio();
+    ///
+    /// assert!(log_q_ratio.is_infinite());
+    /// assert!(log_q_ratio.is_sign_negative());
+    /// # Ok::<(), markov_chain_monte_carlo::DiscreteProposalRatioError>(())
+    /// ```
+    #[must_use]
+    pub fn log_q_ratio(self) -> f64 {
+        if self.reverse_weight == 0.0 || self.reverse_site_count == 0 {
+            return f64::NEG_INFINITY;
+        }
+
+        self.reverse_weight.ln() - self.forward_weight.ln() + count_ln(self.forward_site_count)
+            - count_ln(self.reverse_site_count)
+    }
+}
+
+/// Errors from constructing a [`DiscreteProposalRatio`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub enum DiscreteProposalRatioError {
+    /// The forward move-family weight is not positive and finite.
+    #[non_exhaustive]
+    InvalidForwardWeight {
+        /// Invalid forward move-family weight.
+        weight: f64,
+    },
+    /// The reverse move-family weight is negative, `NaN`, or infinite.
+    #[non_exhaustive]
+    InvalidReverseWeight {
+        /// Invalid reverse move-family weight.
+        weight: f64,
+    },
+    /// A successful forward proposal reported zero valid forward sites.
+    ZeroForwardSiteCount,
+}
+
+impl core::fmt::Display for DiscreteProposalRatioError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidForwardWeight { weight } => write!(
+                f,
+                "invalid forward move-family weight {weight}: expected a positive finite value"
+            ),
+            Self::InvalidReverseWeight { weight } => write!(
+                f,
+                "invalid reverse move-family weight {weight}: expected a nonnegative finite value"
+            ),
+            Self::ZeroForwardSiteCount => {
+                f.write_str("invalid forward site count 0 for a successful proposal")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DiscreteProposalRatioError {}
+
+/// Convert a valid-site count into a logarithm for proposal-ratio arithmetic.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "valid-site counts intentionally cross into log-space f64 proposal arithmetic"
+)]
+fn count_ln(count: usize) -> f64 {
+    (count as f64).ln()
+}
+
 /// Target distribution.
 ///
 /// `log_prob` returns a value proportional to the natural logarithm of the
@@ -151,6 +433,16 @@ impl<S, P: ProposalMut<S> + ?Sized> ProposalMut<S> for &mut P {
 /// instead of accepting first and discovering that absence during
 /// [`commit`](Self::commit).
 ///
+/// When different move kinds or concrete sites have different proposal
+/// probabilities, the plan and [`log_q_ratio`](Self::log_q_ratio) must encode
+/// the full Hastings correction for the successful transition.  This is common
+/// in local combinatorial kernels: a proposal might choose an add/delete move
+/// kind, then choose uniformly among valid sites for that kind, while the
+/// reverse state has a different number of valid sites.  Failed planning,
+/// including bounded searches that find no valid site and return `Ok(None)`,
+/// contributes self-loop probability but does not correct asymmetry among
+/// successful forward and reverse moves.
+///
 /// This is useful for combinatorial state spaces where the log-probability
 /// delta is cheap to compute from a concrete move descriptor.  If `commit`
 /// returns an error, it must be failure-atomic: either the accepted move is
@@ -203,6 +495,10 @@ pub trait DelayedProposal<S> {
     /// by [`Plan`](DelayedProposal::Plan).  Include proposal asymmetries such
     /// as move-kind weights, site multiplicities, or reverse-move counts when
     /// they affect the forward/reverse transition probabilities.
+    /// For example, a uniformly chosen local site usually contributes
+    /// `ln(valid_forward_sites / valid_reverse_sites)` after equal move-kind
+    /// weights cancel. [`DiscreteProposalRatio`] computes this common
+    /// correction for weighted move families with uniformly sampled sites.
     ///
     /// Defaults to 0 for symmetric proposals.
     ///
@@ -423,6 +719,95 @@ mod tests {
         let p = SymmetricDelayedProposal;
         let ratio = p.log_q_ratio(&Scalar(0.0), &1.0).unwrap();
         assert_relative_eq!(ratio, 0.0);
+    }
+
+    #[test]
+    fn discrete_proposal_ratio_accounts_for_site_counts() {
+        let ratio = DiscreteProposalRatio::from_counts(3, 1)
+            .unwrap()
+            .log_q_ratio();
+
+        assert_relative_eq!(ratio, 3.0_f64.ln(), epsilon = 1e-12);
+    }
+
+    #[test]
+    fn discrete_proposal_ratio_accounts_for_move_weights() {
+        let ratio = DiscreteProposalRatio::new(0.25, 6, 0.75, 2)
+            .unwrap()
+            .log_q_ratio();
+
+        assert_relative_eq!(
+            ratio,
+            0.75_f64.ln() - 0.25_f64.ln() + 6.0_f64.ln() - 2.0_f64.ln(),
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn discrete_proposal_ratio_allows_missing_reverse_sites() {
+        let ratio = DiscreteProposalRatio::from_counts(3, 0)
+            .unwrap()
+            .log_q_ratio();
+
+        assert!(ratio.is_infinite());
+        assert!(ratio.is_sign_negative());
+    }
+
+    #[test]
+    fn discrete_proposal_ratio_allows_zero_reverse_weight() {
+        let ratio = DiscreteProposalRatio::new(1.0, 3, 0.0, 1)
+            .unwrap()
+            .log_q_ratio();
+
+        assert!(ratio.is_infinite());
+        assert!(ratio.is_sign_negative());
+    }
+
+    #[test]
+    fn discrete_proposal_ratio_rejects_impossible_successful_forward_plan_at_construction() {
+        let err = DiscreteProposalRatio::from_counts(0, 1).unwrap_err();
+
+        assert_eq!(err, DiscreteProposalRatioError::ZeroForwardSiteCount);
+        assert_eq!(
+            err.to_string(),
+            "invalid forward site count 0 for a successful proposal"
+        );
+    }
+
+    #[test]
+    fn discrete_proposal_ratio_rejects_invalid_forward_weights() {
+        for weight in [0.0, -1.0, f64::NEG_INFINITY, f64::NAN, f64::INFINITY] {
+            let err = DiscreteProposalRatio::new(weight, 1, 1.0, 1).unwrap_err();
+
+            match err {
+                DiscreteProposalRatioError::InvalidForwardWeight { weight: observed } => {
+                    if weight.is_nan() {
+                        assert!(observed.is_nan());
+                    } else {
+                        assert_eq!(observed.to_bits(), weight.to_bits());
+                    }
+                }
+                other => panic!("unexpected error variant: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn discrete_proposal_ratio_rejects_invalid_reverse_weights() {
+        for weight in [-1.0, f64::NEG_INFINITY, f64::NAN, f64::INFINITY] {
+            let err = DiscreteProposalRatio::new(1.0, 1, weight, 1).unwrap_err();
+
+            match err {
+                DiscreteProposalRatioError::InvalidReverseWeight { weight: observed } => {
+                    if weight.is_nan() {
+                        assert!(observed.is_nan());
+                    } else {
+                        assert_eq!(observed.to_bits(), weight.to_bits());
+                    }
+                }
+                other => panic!("unexpected error variant: {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/tests/proptest_validators.rs
+++ b/tests/proptest_validators.rs
@@ -1,0 +1,81 @@
+//! Property tests for public validator constructors.
+
+use markov_chain_monte_carlo::{
+    DetailedBalanceConfig, DetailedBalanceError, DiscreteProposalRatio, DiscreteProposalRatioError,
+};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn discrete_proposal_ratio_accepts_only_valid_constructor_inputs(
+        forward_weight in any::<f64>(),
+        forward_site_count in any::<usize>(),
+        reverse_weight in any::<f64>(),
+        reverse_site_count in any::<usize>(),
+    ) {
+        let ratio = DiscreteProposalRatio::new(
+            forward_weight,
+            forward_site_count,
+            reverse_weight,
+            reverse_site_count,
+        );
+        let should_accept = forward_weight.is_finite()
+            && forward_weight > 0.0
+            && reverse_weight.is_finite()
+            && reverse_weight >= 0.0
+            && forward_site_count > 0;
+
+        prop_assert_eq!(ratio.is_ok(), should_accept);
+
+        if let Ok(ratio) = ratio {
+            let log_q_ratio = ratio.log_q_ratio();
+            if reverse_weight == 0.0 || reverse_site_count == 0 {
+                prop_assert!(log_q_ratio.is_infinite());
+                prop_assert!(log_q_ratio.is_sign_negative());
+            } else {
+                prop_assert!(log_q_ratio.is_finite());
+            }
+        }
+    }
+
+    #[test]
+    fn detailed_balance_config_accepts_only_valid_constructor_inputs(
+        samples in any::<usize>(),
+        tolerance in any::<f64>(),
+        min_hits in any::<usize>(),
+    ) {
+        let config = DetailedBalanceConfig::new(samples, tolerance, min_hits);
+        let should_accept = samples > 0
+            && tolerance.is_finite()
+            && tolerance >= 0.0
+            && min_hits > 0
+            && min_hits <= samples;
+
+        prop_assert_eq!(config.is_ok(), should_accept);
+
+        if let Ok(config) = config {
+            prop_assert_eq!(config.samples(), samples);
+            prop_assert_eq!(config.tolerance().to_bits(), tolerance.to_bits());
+            prop_assert_eq!(config.min_hits(), min_hits);
+        }
+    }
+}
+
+#[test]
+fn validators_reject_antagonistic_float_values() {
+    for value in [f64::NEG_INFINITY, -0.0, f64::NAN, f64::INFINITY] {
+        let ratio = DiscreteProposalRatio::new(value, 1, 1.0, 1);
+        assert!(matches!(
+            ratio,
+            Err(DiscreteProposalRatioError::InvalidForwardWeight { .. })
+        ));
+    }
+
+    for value in [f64::NEG_INFINITY, -1.0, f64::NAN, f64::INFINITY] {
+        let config = DetailedBalanceConfig::new(1, value, 1);
+        assert!(matches!(
+            config,
+            Err(DetailedBalanceError::InvalidTolerance { .. })
+        ));
+    }
+}


### PR DESCRIPTION
- Add DiscreteProposalRatio for weighted move-family and valid-site Hastings corrections in delayed proposals.
- Document delayed valid-site multiplicities and expose the ratio helper through the public API and scoped preludes.
- Validate DetailedBalanceConfig at construction so detailed-balance checks operate on accepted configuration values.
- Add validator property tests and document the repository convention for proptest integration files.

BREAKING CHANGE: DetailedBalanceConfig fields are now private and DetailedBalanceConfig::new returns Result. Detailed-balance batch helpers now return DetailedBalanceBatchReport directly instead of Result.

Closes #48