### PR TITLE
refactor!: enforce parse-don't-validate invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [**breaking**] Add constructors for fallible stats and public reports [#66](https://github.com/acgetchell/markov-chain-monte-carlo/pull/66) [`fee14b4`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/fee14b4ac75e2a0f8ede899541c10109d6ebd990)
+
+  - Add checked bulk constructors for streaming statistics so callers can reject non-finite samples without retaining partial accumulator state.
+  - Add constructors for detailed-balance config, reports, failures, batches, and delayed transitions before making those public structs non-exhaustive.
+  - Reuse compiled example binaries during local validation to avoid rebuilding examples twice.
+  - Refresh the pre-1.0 roadmap around v0.4.0, adaptive diagnostics, learned proposals, and portability.
+- [**breaking**] Validate delayed commits after acceptance [#70](https://github.com/acgetchell/markov-chain-monte-carlo/pull/70) [`1c4654b`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/1c4654bf9cc94a9bc37131858183854620e46692)
+
+  - Add checked delayed-commit stepping for Chain and Sampler so proposal authors can verify that committed states match the scored plan.
+  - Report committed-state NaN, positive-infinity, and score-mismatch failures with dedicated McmcError variants while restoring the previous chain state.
+  - Treat undefined detailed-balance acceptance ratios as zero acceptance so impossible bidirectional transitions produce balanced zero-flow reports.
+  - Expose unchecked streaming-statistics push methods for callers that already validate measurement streams.
+  - Add benchmark coverage for streaming observations into OnlineStats and BinningAnalysis.
+- [**breaking**] Add delayed proposal ratio helpers [#71](https://github.com/acgetchell/markov-chain-monte-carlo/pull/71) [`ed876f6`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/ed876f67fcd1f3ed0fa79242ba5a10c8ccd7a489)
+
+  * feat!: add delayed proposal ratio helpers
+
+  - Add DiscreteProposalRatio for weighted move-family and valid-site Hastings corrections in delayed proposals.
+  - Document delayed valid-site multiplicities and expose the ratio helper through the public API and scoped preludes.
+  - Validate DetailedBalanceConfig at construction so detailed-balance checks operate on accepted configuration values.
+  - Add validator property tests and document the repository convention for proptest integration files.
+
 ### Fixed
 
 - Escape changelog angle brackets for GitHub rendering [`82014b4`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/82014b424d0b5be37c93770e2cdd925ba351ca25)
@@ -20,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This fix escapes those characters during changelog generation,
   ensuring correct display. The changelog was regenerated,
   also incorporating repository security enhancements from #63.
+- Clean regenerated changelog entries [`4147806`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/414780606cc68da0f8a5b99de821af89a94e0671)
+
+  - Repair the historical changelog body for escaped Rust generic examples.
+  - Filter changelog-only body noise from generated release notes.
+  - Regenerate CHANGELOG.md with the corrected commit preprocessing.
 
 ### Maintenance
 
@@ -49,6 +78,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replace taiki-e/install-action with cached Cargo installs for audit and coverage workflow tools.
   - Update uv-managed development tools, including Semgrep, Ruff, Ty, and the workflow uv version.
   - Refresh the serde_json dev dependency and remove taiki-e from the repository-owned Actions allowlist.
+- Clear code scanning workflow findings [`cf946db`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/cf946dbd2e2f4b44bc41343692d98459954ced4d)
+
+  - Align the Clippy SARIF job with the local Clippy policy so dependency-version noise is not uploaded as code scanning alerts.
+  - Refresh CodeQL action SHA pins and version comments across CodeQL, Clippy, and Semgrep SARIF workflows.
+- Use rumdl and dprint for checks [#53](https://github.com/acgetchell/markov-chain-monte-carlo/pull/53) [#67](https://github.com/acgetchell/markov-chain-monte-carlo/pull/67) [`d23029c`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/d23029c9763067a1ad5510cd80dcb19c9c7fdc1e)
+
+  - Replace dprint Markdown formatting and yamllint validation with rumdl Markdown checks and dprint Pretty YAML checks.
+  - Install and verify rumdl through Cargo-managed local setup and CI tooling.
+  - Keep non-Rust formatter widths at 160 columns across Markdown, TOML, YAML, and Python.
+  - Add a Semgrep fixture that keeps contributor docs ordering non-mutating checks before mutating fixes.
+- Cache cargo-installed CI tools [#68](https://github.com/acgetchell/markov-chain-monte-carlo/pull/68) [`ebd98de`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/ebd98de9fb8725f2f261a52ab6c4c6e77ee7a9d7)
+
+  * ci: cache cargo-installed CI tools
+
+  - Install Cargo-managed CI tools through taiki-e/cache-cargo-install-action instead of rebuilding them in each matrix job.
+  - Keep full just ci coverage on Linux, macOS, and Windows while exposing smaller CI subsets for timing and local diagnosis.
+  - Compile benchmark harnesses with all crate features enabled and allow the pinned cache action in the repository workflow policy.
+- Bump Rust MSRV to 1.96.0 [#65](https://github.com/acgetchell/markov-chain-monte-carlo/pull/65) [#69](https://github.com/acgetchell/markov-chain-monte-carlo/pull/69) [`ba7beb2`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/ba7beb2a65b4d506374569d19a77b336ad74e53d)
+
+  * build: bump Rust MSRV to 1.96.0 [#65](https://github.com/acgetchell/markov-chain-monte-carlo/pull/65)
+
+  - Pin Cargo, rustup, Clippy, and contributor docs to Rust 1.96.0.
+  - Adopt 1.96-compatible numeric updates with fused multiply-add in statistics, examples, and benchmarks.
+  - Refresh typed error assertions and doctests to use `std::assert_matches!`.
+  - Clarify that LLVM coverage tools are installed by setup and Codecov rather than the default pinned toolchain.
+
+  * ci: add Windows taplo install fallback [#65](https://github.com/acgetchell/markov-chain-monte-carlo/pull/65)
+
+  - Preserve the cached cargo install action as the primary tool installation path across operating systems.
+  - Fall back to direct taplo installation on Windows only when the cached install step fails.
 
 ## [0.3.0] - 2026-05-05
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ rust-version = "1.96.0"
 
 description = "A composable Markov Chain Monte Carlo (MCMC) framework for arbitrary state spaces in Rust"
 homepage = "https://github.com/acgetchell/markov-chain-monte-carlo"
+documentation = "https://docs.rs/markov-chain-monte-carlo"
 license = "BSD-3-Clause"
 repository = "https://github.com/acgetchell/markov-chain-monte-carlo"
 readme = "README.md"

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -89,6 +89,112 @@ rules:
               ...
           }
 
+  - id: mcmc.rust.no-public-unchecked-apis
+    languages:
+      - rust
+    severity: WARNING
+    message: "Keep *_unchecked APIs private so invalid-state escape hatches do not become public contracts."
+    metadata:
+      category: correctness
+      rationale: "Unchecked helpers should stay behind validated constructors, parsers, or setters."
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    patterns:
+      - pattern-regex: '^\s*pub(?:\([^)]*\))?\s+(?:const\s+|async\s+|unsafe\s+)?fn\s+[A-Za-z_][A-Za-z0-9_]*_unchecked\s*\('
+      - pattern-not-inside: |
+          mod tests {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          mod $MOD {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          fn $FUNC(...) {
+              ...
+          }
+
+  - id: mcmc.rust.no-infallible-statistics-f64-ingestion
+    languages:
+      - rust
+    severity: WARNING
+    message: "OnlineStats and BinningAnalysis must ingest raw f64 samples through fallible APIs."
+    metadata:
+      category: correctness
+      rationale: "Raw f64 measurements can be NaN, infinite, or overflow accumulator state; accepted samples should carry validation evidence."
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    pattern-either:
+      - pattern-regex: '^\s*pub\s+fn\s+push\s*\(\s*&mut\s+self\s*,\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*f64\s*\)'
+      - pattern-regex: '^\s*impl\s+(?:(?:std::)?iter::)?(?:Extend|FromIterator|Sum)\s*<\s*f64\s*>\s+for\s+(?:OnlineStats|BinningAnalysis)\b'
+
+  - id: mcmc.rust.invariant-fields-use-refined-types
+    languages:
+      - rust
+    severity: WARNING
+    message: "Keep established invariant-bearing fields stored as refined types, not raw primitives."
+    metadata:
+      category: correctness
+      rationale: "Positive counts and validated sample thresholds should remain unrepresentable as zero once parsed."
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    pattern-either:
+      - patterns:
+          - pattern-inside: |
+              pub struct DetailedBalanceConfig {
+                  ...
+              }
+          - pattern-regex: '^\s*samples\s*:\s*usize\b'
+      - patterns:
+          - pattern-inside: |
+              pub struct DetailedBalanceConfig {
+                  ...
+              }
+          - pattern-regex: '^\s*min_hits\s*:\s*usize\b'
+      - patterns:
+          - pattern-inside: |
+              pub struct DiscreteProposalRatio {
+                  ...
+              }
+          - pattern-regex: '^\s*forward_site_count\s*:\s*usize\b'
+
+  - id: mcmc.rust.no-public-unit-validators
+    languages:
+      - rust
+    severity: WARNING
+    message: "Prefer returning a refined value from constructors/parsers over public validate_* -> Result<(), _> APIs."
+    metadata:
+      category: correctness
+      rationale: "A unit-returning validator discards validation evidence that a refined type could carry."
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    patterns:
+      - pattern-regex: '^\s*pub(?:\([^)]*\))?\s+(?:const\s+|async\s+|unsafe\s+)?fn\s+validate_[A-Za-z_][A-Za-z0-9_]*\s*\([^)]*\)\s*->\s*Result\s*<\s*\(\s*\)\s*,'
+      - pattern-not-inside: |
+          mod tests {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          mod $MOD {
+              ...
+          }
+      - pattern-not-inside: |
+          #[cfg(test)]
+          fn $FUNC(...) {
+              ...
+          }
+
   - id: mcmc.rust.no-box-dyn-error-in-src
     languages:
       - rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,13 +368,14 @@
 //! use markov_chain_monte_carlo::prelude::*;
 //!
 //! let mut energy = OnlineStats::new();
-//! energy.extend([1.0, 2.0, 3.0, 4.0]);
+//! energy.try_extend([1.0, 2.0, 3.0, 4.0])?;
 //!
 //! assert_eq!(energy.mean(), Some(2.5));
 //!
 //! let mut bins = BinningAnalysis::new();
-//! bins.extend([1.0, 2.0, 3.0, 4.0]);
+//! bins.try_extend([1.0, 2.0, 3.0, 4.0])?;
 //! assert!(bins.standard_error().is_some());
+//! # Ok::<(), StatisticsError>(())
 //! ```
 //!
 //! `Sampler` can also stream observations directly into these accumulators:

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -2,9 +2,7 @@
 
 use core::hint::cold_path;
 
-use std::error::Error;
-use std::fmt;
-use std::iter;
+use std::{error::Error, fmt};
 
 use crate::TryAccumulator;
 
@@ -66,20 +64,32 @@ impl fmt::Display for StatisticsError {
 
 impl Error for StatisticsError {}
 
-/// Validate one input sample before fallible accumulation mutates state.
+/// Finite measurement accepted by the public fallible statistics APIs.
 ///
-/// This exists so all statistical sinks report NaN and infinity with the same
-/// orthogonal error variants.
-const fn check_sample(sample: f64) -> Result<(), StatisticsError> {
-    if sample.is_nan() {
-        cold_path();
-        return Err(StatisticsError::NanSample);
+/// Keeping this proof type private makes raw `f64` parsing a boundary concern:
+/// once a sample reaches the online formulas or binning hierarchy, downstream
+/// helpers can rely on it not being `NaN` or infinite.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct FiniteSample(f64);
+
+impl FiniteSample {
+    /// Parse a raw measurement into a finite sample.
+    const fn new(sample: f64) -> Result<Self, StatisticsError> {
+        if sample.is_nan() {
+            cold_path();
+            return Err(StatisticsError::NanSample);
+        }
+        if sample.is_infinite() {
+            cold_path();
+            return Err(StatisticsError::InfiniteSample);
+        }
+        Ok(Self(sample))
     }
-    if sample.is_infinite() {
-        cold_path();
-        return Err(StatisticsError::InfiniteSample);
+
+    /// Return the validated raw measurement for floating-point arithmetic.
+    const fn into_inner(self) -> f64 {
+        self.0
     }
-    Ok(())
 }
 
 /// Validate the floating-point state produced by one Welford update.
@@ -110,20 +120,22 @@ const fn check_stats(stats: &OnlineStats) -> Result<(), StatisticsError> {
 ///
 /// `OnlineStats` updates in constant memory and is suitable for long
 /// production runs where retaining every measurement would be expensive.
-/// Use [`try_push`](Self::try_push), [`try_extend`](Self::try_extend), or
-/// [`try_from_iter`](Self::try_from_iter) when non-finite measurements should be
-/// rejected instead of becoming part of the accumulator state.
+/// Measurements enter through [`try_push`](Self::try_push),
+/// [`try_extend`](Self::try_extend), or [`try_from_iter`](Self::try_from_iter)
+/// so invalid floating-point values are rejected before they can become part of
+/// the accumulator state.
 ///
 /// ```
 /// use approx::assert_relative_eq;
-/// use markov_chain_monte_carlo::OnlineStats;
+/// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
 ///
 /// let mut stats = OnlineStats::new();
-/// stats.extend([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]);
+/// stats.try_extend([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0])?;
 ///
 /// assert_eq!(stats.count(), 8);
 /// assert_relative_eq!(stats.mean().unwrap(), 5.0, epsilon = 1e-12);
 /// assert_relative_eq!(stats.population_variance().unwrap(), 4.0, epsilon = 1e-12);
+/// # Ok::<(), StatisticsError>(())
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[must_use]
@@ -152,8 +164,8 @@ impl OnlineStats {
 
     /// Build an accumulator from finite samples.
     ///
-    /// Unlike [`FromIterator`], this validates every sample and leaves no
-    /// partially constructed accumulator behind on error.
+    /// This validates every sample and leaves no partially constructed
+    /// accumulator behind on error.
     ///
     /// ```
     /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
@@ -170,50 +182,28 @@ impl OnlineStats {
     ///
     /// # Errors
     ///
-    /// Returns [`StatisticsError`] on the first invalid sample or non-finite
-    /// accumulator update.
-    pub fn try_from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Result<Self, StatisticsError> {
+    /// Returns [`StatisticsError::NanSample`] or
+    /// [`StatisticsError::InfiniteSample`] for the first non-finite input
+    /// sample.
+    ///
+    /// Returns [`StatisticsError::NanMean`], [`StatisticsError::InfiniteMean`],
+    /// [`StatisticsError::NanVarianceAccumulator`], or
+    /// [`StatisticsError::InfiniteVarianceAccumulator`] if Welford's update
+    /// produces non-finite accumulator state.  No partially constructed
+    /// accumulator is returned on error.
+    pub fn try_from_iter(iter: impl IntoIterator<Item = f64>) -> Result<Self, StatisticsError> {
         let mut stats = Self::new();
         stats.try_extend(iter)?;
         Ok(stats)
     }
 
-    /// Add one sample to the accumulator without validating it.
+    /// Apply one already validated sample to Welford state.
     ///
-    /// This is a compatibility alias for [`push_unchecked`](Self::push_unchecked).
-    /// Use [`try_push`](Self::try_push) when non-finite measurements should be
-    /// reported as errors instead of becoming part of the accumulator state.
-    ///
-    /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
-    ///
-    /// let mut stats = OnlineStats::new();
-    /// stats.push(1.0);
-    /// stats.push(3.0);
-    ///
-    /// assert_eq!(stats.mean(), Some(2.0));
-    /// ```
-    pub fn push(&mut self, sample: f64) {
-        self.push_unchecked(sample);
-    }
-
-    /// Add one sample to the accumulator without validating it.
-    ///
-    /// Non-finite samples can permanently contaminate the running mean and
-    /// variance accumulator.  Use [`try_push`](Self::try_push) for production
-    /// measurement streams where `NaN` or infinity should be rejected atomically.
-    ///
-    /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
-    ///
-    /// let mut stats = OnlineStats::new();
-    /// stats.push_unchecked(1.0);
-    /// stats.push_unchecked(3.0);
-    ///
-    /// assert_eq!(stats.mean(), Some(2.0));
-    /// ```
-    pub fn push_unchecked(&mut self, sample: f64) {
+    /// Public callers reach this only through [`Self::try_push`], which stages
+    /// the mutation and rejects non-finite arithmetic before committing it.
+    fn push_sample(&mut self, sample: FiniteSample) {
         self.count += 1;
+        let sample = sample.into_inner();
         let delta = sample - self.mean;
         self.mean += delta / count_as_f64(self.count);
         let delta_after = sample - self.mean;
@@ -234,12 +224,17 @@ impl OnlineStats {
     ///
     /// # Errors
     ///
-    /// Returns [`StatisticsError`] if `sample` is NaN or infinite, or if the
-    /// online mean or variance accumulator becomes non-finite while updating.
+    /// Returns [`StatisticsError::NanSample`] or
+    /// [`StatisticsError::InfiniteSample`] if `sample` is non-finite.
+    ///
+    /// Returns [`StatisticsError::NanMean`], [`StatisticsError::InfiniteMean`],
+    /// [`StatisticsError::NanVarianceAccumulator`], or
+    /// [`StatisticsError::InfiniteVarianceAccumulator`] if Welford's update
+    /// produces non-finite accumulator state.
     pub fn try_push(&mut self, sample: f64) -> Result<(), StatisticsError> {
-        check_sample(sample)?;
+        let sample = FiniteSample::new(sample)?;
         let mut next = *self;
-        next.push_unchecked(sample);
+        next.push_sample(sample);
         check_stats(&next)?;
         *self = next;
         Ok(())
@@ -262,11 +257,18 @@ impl OnlineStats {
     ///
     /// # Errors
     ///
-    /// Returns [`StatisticsError`] on the first invalid sample or non-finite
-    /// accumulator update.
-    pub fn try_extend<I: IntoIterator<Item = f64>>(
+    /// Returns [`StatisticsError::NanSample`] or
+    /// [`StatisticsError::InfiniteSample`] for the first non-finite input
+    /// sample.
+    ///
+    /// Returns [`StatisticsError::NanMean`], [`StatisticsError::InfiniteMean`],
+    /// [`StatisticsError::NanVarianceAccumulator`], or
+    /// [`StatisticsError::InfiniteVarianceAccumulator`] if Welford's update
+    /// produces non-finite accumulator state.  Samples accepted before the error
+    /// remain in the accumulator.
+    pub fn try_extend(
         &mut self,
-        iter: I,
+        iter: impl IntoIterator<Item = f64>,
     ) -> Result<(), StatisticsError> {
         for sample in iter {
             self.try_push(sample)?;
@@ -277,11 +279,12 @@ impl OnlineStats {
     /// Remove all accumulated samples.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
     ///
-    /// let mut stats: OnlineStats = [1.0, 2.0].into_iter().collect();
+    /// let mut stats = OnlineStats::try_from_iter([1.0, 2.0])?;
     /// stats.clear();
     /// assert_eq!(stats.count(), 0);
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     pub const fn clear(&mut self) {
         *self = Self::new();
@@ -290,10 +293,11 @@ impl OnlineStats {
     /// Number of accumulated samples.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
     ///
-    /// let stats: OnlineStats = [1.0, 2.0, 3.0].into_iter().collect();
+    /// let stats = OnlineStats::try_from_iter([1.0, 2.0, 3.0])?;
     /// assert_eq!(stats.count(), 3);
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub const fn count(&self) -> usize {
@@ -307,7 +311,7 @@ impl OnlineStats {
     ///
     /// let mut stats = OnlineStats::new();
     /// assert!(stats.is_empty());
-    /// stats.push(1.0);
+    /// stats.try_push(1.0).unwrap();
     /// assert!(!stats.is_empty());
     /// ```
     #[must_use]
@@ -320,10 +324,11 @@ impl OnlineStats {
     /// Returns `None` until at least one sample has been added.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
     ///
-    /// let stats: OnlineStats = [2.0, 4.0].into_iter().collect();
+    /// let stats = OnlineStats::try_from_iter([2.0, 4.0])?;
     /// assert_eq!(stats.mean(), Some(3.0));
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn mean(&self) -> Option<f64> {
@@ -335,10 +340,11 @@ impl OnlineStats {
     /// Returns `None` until at least one sample has been added.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
     ///
-    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// let stats = OnlineStats::try_from_iter([1.0, 3.0])?;
     /// assert_eq!(stats.population_variance(), Some(1.0));
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn population_variance(&self) -> Option<f64> {
@@ -350,10 +356,11 @@ impl OnlineStats {
     /// Returns `None` until at least two samples have been added.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
     ///
-    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// let stats = OnlineStats::try_from_iter([1.0, 3.0])?;
     /// assert_eq!(stats.sample_variance(), Some(2.0));
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn sample_variance(&self) -> Option<f64> {
@@ -365,10 +372,11 @@ impl OnlineStats {
     /// Returns `None` until at least one sample has been added.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
     ///
-    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// let stats = OnlineStats::try_from_iter([1.0, 3.0])?;
     /// assert_eq!(stats.population_std_dev(), Some(1.0));
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn population_std_dev(&self) -> Option<f64> {
@@ -380,10 +388,11 @@ impl OnlineStats {
     /// Returns `None` until at least two samples have been added.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
     ///
-    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// let stats = OnlineStats::try_from_iter([1.0, 3.0])?;
     /// assert_eq!(stats.sample_std_dev(), Some(2.0_f64.sqrt()));
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn sample_std_dev(&self) -> Option<f64> {
@@ -396,10 +405,11 @@ impl OnlineStats {
     /// inspect the blocked standard-error estimates.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::OnlineStats;
+    /// use markov_chain_monte_carlo::{OnlineStats, StatisticsError};
     ///
-    /// let stats: OnlineStats = [1.0, 3.0].into_iter().collect();
+    /// let stats = OnlineStats::try_from_iter([1.0, 3.0])?;
     /// assert_eq!(stats.standard_error(), Some(1.0));
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn standard_error(&self) -> Option<f64> {
@@ -414,27 +424,11 @@ impl Default for OnlineStats {
     }
 }
 
-impl Extend<f64> for OnlineStats {
-    fn extend<I: IntoIterator<Item = f64>>(&mut self, iter: I) {
-        for sample in iter {
-            self.push(sample);
-        }
-    }
-}
-
 impl TryAccumulator<f64> for OnlineStats {
     type Error = StatisticsError;
 
     fn try_push(&mut self, sample: f64) -> Result<(), Self::Error> {
         Self::try_push(self, sample)
-    }
-}
-
-impl FromIterator<f64> for OnlineStats {
-    fn from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Self {
-        let mut stats = Self::new();
-        stats.extend(iter);
-        stats
     }
 }
 
@@ -457,10 +451,11 @@ impl BinningEstimate {
     /// Number of original samples per block at this level.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
     /// assert_eq!(bins.estimates().nth(1).unwrap().block_size(), 2);
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub const fn block_size(&self) -> usize {
@@ -470,10 +465,11 @@ impl BinningEstimate {
     /// Number of completed block means included in this estimate.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
     /// assert_eq!(bins.estimates().next().unwrap().block_count(), 4);
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub const fn block_count(&self) -> usize {
@@ -483,10 +479,11 @@ impl BinningEstimate {
     /// Mean of the completed block means.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
     /// assert_eq!(bins.estimates().next().unwrap().mean(), 2.5);
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub const fn mean(&self) -> f64 {
@@ -498,10 +495,11 @@ impl BinningEstimate {
     /// Returns `None` until at least two completed blocks exist at this level.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
     /// assert_eq!(bins.estimates().nth(2).unwrap().sample_variance(), None);
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub const fn sample_variance(&self) -> Option<f64> {
@@ -513,10 +511,11 @@ impl BinningEstimate {
     /// Returns `None` until at least two completed blocks exist at this level.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
     /// assert!(bins.estimates().next().unwrap().standard_error().is_some());
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub const fn standard_error(&self) -> Option<f64> {
@@ -528,7 +527,7 @@ impl BinningEstimate {
 struct BinningLevel {
     block_size: usize,
     stats: OnlineStats,
-    pending: Option<f64>,
+    pending: Option<FiniteSample>,
 }
 
 impl BinningLevel {
@@ -564,30 +563,23 @@ impl BinningLevel {
         })
     }
 
-    /// Apply the per-level update shared by infallible and staged pushes.
+    /// Apply one validated per-level update during staged accumulation.
     ///
     /// Returns a coarser block mean only when this level pairs the incoming block
     /// with an existing pending block.
-    fn push_block_mean(&mut self, block_mean: f64) -> Option<f64> {
-        self.stats.push(block_mean);
+    fn push_block_mean(
+        &mut self,
+        block_mean: FiniteSample,
+    ) -> Result<Option<FiniteSample>, StatisticsError> {
+        self.stats.push_sample(block_mean);
+        check_stats(&self.stats)?;
         if let Some(previous) = self.pending.take() {
-            Some(0.5_f64.mul_add(block_mean, 0.5 * previous))
+            FiniteSample::new(0.5_f64.mul_add(block_mean.into_inner(), 0.5 * previous.into_inner()))
+                .map(Some)
         } else {
             self.pending = Some(block_mean);
-            None
+            Ok(None)
         }
-    }
-
-    /// Validate a staged level before it is committed to the visible analysis.
-    ///
-    /// This preserves `try_push` failure atomicity while reusing the same sample
-    /// and accumulator checks as the public fallible statistics APIs.
-    fn check(&self) -> Result<(), StatisticsError> {
-        check_stats(&self.stats)?;
-        if let Some(pending) = self.pending {
-            check_sample(pending)?;
-        }
-        Ok(())
     }
 }
 
@@ -599,21 +591,23 @@ impl BinningLevel {
 /// once the estimates plateau, that value is the usual binning estimate for the
 /// standard error of an MCMC mean.
 ///
-/// Use [`try_push`](Self::try_push), [`try_extend`](Self::try_extend), or
-/// [`try_from_iter`](Self::try_from_iter) when non-finite measurements should be
-/// rejected instead of becoming part of the binning hierarchy.
+/// Measurements enter through [`try_push`](Self::try_push),
+/// [`try_extend`](Self::try_extend), or [`try_from_iter`](Self::try_from_iter)
+/// so invalid floating-point values are rejected before they can become part of
+/// the binning hierarchy.
 ///
 /// ```
-/// use markov_chain_monte_carlo::BinningAnalysis;
+/// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
 ///
 /// let mut bins = BinningAnalysis::new();
-/// bins.extend((1..=8).map(f64::from));
+/// bins.try_extend((1..=8).map(f64::from))?;
 ///
 /// let estimates: Vec<_> = bins.estimates().collect();
 /// assert_eq!(estimates[0].block_size(), 1);
 /// assert_eq!(estimates[1].block_size(), 2);
 /// assert_eq!(estimates[2].block_size(), 4);
 /// assert_eq!(bins.mean(), Some(4.5));
+/// # Ok::<(), StatisticsError>(())
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 #[must_use]
@@ -642,8 +636,8 @@ impl BinningAnalysis {
 
     /// Build a binning analysis from finite samples.
     ///
-    /// Unlike [`FromIterator`], this validates every sample and leaves no
-    /// partially constructed analysis behind on error.
+    /// This validates every sample and leaves no partially constructed analysis
+    /// behind on error.
     ///
     /// ```
     /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
@@ -660,51 +654,19 @@ impl BinningAnalysis {
     ///
     /// # Errors
     ///
-    /// Returns [`StatisticsError`] on the first invalid sample or non-finite
-    /// accumulator update.
-    pub fn try_from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Result<Self, StatisticsError> {
+    /// Returns [`StatisticsError::NanSample`] or
+    /// [`StatisticsError::InfiniteSample`] for the first non-finite input
+    /// sample.
+    ///
+    /// Returns [`StatisticsError::NanMean`], [`StatisticsError::InfiniteMean`],
+    /// [`StatisticsError::NanVarianceAccumulator`], or
+    /// [`StatisticsError::InfiniteVarianceAccumulator`] if any binning-level
+    /// accumulator update produces non-finite state.  No partially constructed
+    /// analysis is returned on error.
+    pub fn try_from_iter(iter: impl IntoIterator<Item = f64>) -> Result<Self, StatisticsError> {
         let mut analysis = Self::new();
         analysis.try_extend(iter)?;
         Ok(analysis)
-    }
-
-    /// Add one measurement without validating it.
-    ///
-    /// This is a compatibility alias for [`push_unchecked`](Self::push_unchecked).
-    /// Use [`try_push`](Self::try_push) when non-finite measurements should be
-    /// reported as errors instead of becoming part of the binning state.
-    ///
-    /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
-    ///
-    /// let mut bins = BinningAnalysis::new();
-    /// bins.push(1.0);
-    /// bins.push(2.0);
-    ///
-    /// assert_eq!(bins.count(), 2);
-    /// ```
-    pub fn push(&mut self, sample: f64) {
-        self.push_unchecked(sample);
-    }
-
-    /// Add one measurement without validating it.
-    ///
-    /// Non-finite samples can permanently contaminate every affected binning
-    /// level.  Use [`try_push`](Self::try_push) for production measurement
-    /// streams where `NaN` or infinity should be rejected atomically.
-    ///
-    /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
-    ///
-    /// let mut bins = BinningAnalysis::new();
-    /// bins.push_unchecked(1.0);
-    /// bins.push_unchecked(2.0);
-    ///
-    /// assert_eq!(bins.count(), 2);
-    /// ```
-    pub fn push_unchecked(&mut self, sample: f64) {
-        self.count += 1;
-        self.push_block(0, sample);
     }
 
     /// Add one finite measurement.
@@ -721,10 +683,15 @@ impl BinningAnalysis {
     ///
     /// # Errors
     ///
-    /// Returns [`StatisticsError`] if `sample` is NaN or infinite, or if any
-    /// online binning accumulator becomes non-finite while updating.
+    /// Returns [`StatisticsError::NanSample`] or
+    /// [`StatisticsError::InfiniteSample`] if `sample` is non-finite.
+    ///
+    /// Returns [`StatisticsError::NanMean`], [`StatisticsError::InfiniteMean`],
+    /// [`StatisticsError::NanVarianceAccumulator`], or
+    /// [`StatisticsError::InfiniteVarianceAccumulator`] if any staged
+    /// binning-level accumulator update produces non-finite state.
     pub fn try_push(&mut self, sample: f64) -> Result<(), StatisticsError> {
-        check_sample(sample)?;
+        let sample = FiniteSample::new(sample)?;
         self.stage_push(sample)?;
 
         self.count += 1;
@@ -755,11 +722,18 @@ impl BinningAnalysis {
     ///
     /// # Errors
     ///
-    /// Returns [`StatisticsError`] on the first invalid sample or non-finite
-    /// accumulator update.
-    pub fn try_extend<I: IntoIterator<Item = f64>>(
+    /// Returns [`StatisticsError::NanSample`] or
+    /// [`StatisticsError::InfiniteSample`] for the first non-finite input
+    /// sample.
+    ///
+    /// Returns [`StatisticsError::NanMean`], [`StatisticsError::InfiniteMean`],
+    /// [`StatisticsError::NanVarianceAccumulator`], or
+    /// [`StatisticsError::InfiniteVarianceAccumulator`] if any binning-level
+    /// accumulator update produces non-finite state.  Samples accepted before the
+    /// error remain in the analysis.
+    pub fn try_extend(
         &mut self,
-        iter: I,
+        iter: impl IntoIterator<Item = f64>,
     ) -> Result<(), StatisticsError> {
         for sample in iter {
             self.try_push(sample)?;
@@ -770,11 +744,12 @@ impl BinningAnalysis {
     /// Remove all accumulated samples and bins.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let mut bins: BinningAnalysis = [1.0, 2.0].into_iter().collect();
+    /// let mut bins = BinningAnalysis::try_from_iter([1.0, 2.0])?;
     /// bins.clear();
     /// assert!(bins.is_empty());
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     pub fn clear(&mut self) {
         self.count = 0;
@@ -785,10 +760,11 @@ impl BinningAnalysis {
     /// Number of original measurements pushed into the analysis.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = [1.0, 2.0, 3.0].into_iter().collect();
+    /// let bins = BinningAnalysis::try_from_iter([1.0, 2.0, 3.0])?;
     /// assert_eq!(bins.count(), 3);
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub const fn count(&self) -> usize {
@@ -802,7 +778,7 @@ impl BinningAnalysis {
     ///
     /// let mut bins = BinningAnalysis::new();
     /// assert!(bins.is_empty());
-    /// bins.push(1.0);
+    /// bins.try_push(1.0).unwrap();
     /// assert!(!bins.is_empty());
     /// ```
     #[must_use]
@@ -815,10 +791,11 @@ impl BinningAnalysis {
     /// Returns `None` until at least one sample has been added.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = [1.0, 2.0, 3.0].into_iter().collect();
+    /// let bins = BinningAnalysis::try_from_iter([1.0, 2.0, 3.0])?;
     /// assert_eq!(bins.mean(), Some(2.0));
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn mean(&self) -> Option<f64> {
@@ -831,10 +808,11 @@ impl BinningAnalysis {
     /// [`OnlineStats::standard_error`] over the original measurements.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = [1.0, 3.0].into_iter().collect();
+    /// let bins = BinningAnalysis::try_from_iter([1.0, 3.0])?;
     /// assert_eq!(bins.unblocked_standard_error(), Some(1.0));
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn unblocked_standard_error(&self) -> Option<f64> {
@@ -850,10 +828,11 @@ impl BinningAnalysis {
     /// standard error has stabilized across block sizes.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = (1..=8).map(f64::from).collect();
+    /// let bins = BinningAnalysis::try_from_iter((1..=8).map(f64::from))?;
     /// assert_eq!(bins.coarsest_estimate().unwrap().block_size(), 4);
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn coarsest_estimate(&self) -> Option<BinningEstimate> {
@@ -867,10 +846,11 @@ impl BinningAnalysis {
     /// Returns `None` until at least two completed blocks exist at some level.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
     /// assert!(bins.standard_error().is_some());
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub fn standard_error(&self) -> Option<f64> {
@@ -885,33 +865,16 @@ impl BinningAnalysis {
     /// completed blocks are available at that block size.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::BinningAnalysis;
+    /// use markov_chain_monte_carlo::{BinningAnalysis, StatisticsError};
     ///
-    /// let bins: BinningAnalysis = (1..=4).map(f64::from).collect();
+    /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
     /// let block_sizes: Vec<_> = bins.estimates().map(|estimate| estimate.block_size()).collect();
     ///
     /// assert_eq!(block_sizes, vec![1, 2, 4]);
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     pub fn estimates(&self) -> impl Iterator<Item = BinningEstimate> + '_ {
         self.levels.iter().filter_map(BinningLevel::estimate)
-    }
-
-    /// Propagate one completed block mean through the power-of-two hierarchy.
-    ///
-    /// Each level stores one pending block mean; when a second block arrives,
-    /// their average becomes one completed block at the next coarser level.
-    fn push_block(&mut self, mut level_index: usize, mut block_mean: f64) {
-        loop {
-            self.ensure_level(level_index);
-            let next_block_mean = self.levels[level_index].push_block_mean(block_mean);
-
-            if let Some(mean) = next_block_mean {
-                block_mean = mean;
-                level_index += 1;
-            } else {
-                break;
-            }
-        }
     }
 
     /// Stage the exact levels changed by a fallible push.
@@ -919,7 +882,7 @@ impl BinningAnalysis {
     /// A single sample only touches a prefix of the binning hierarchy.  Staging
     /// that prefix keeps `try_push` failure-atomic without cloning untouched
     /// coarser levels.
-    fn stage_push(&mut self, sample: f64) -> Result<(), StatisticsError> {
+    fn stage_push(&mut self, sample: FiniteSample) -> Result<(), StatisticsError> {
         self.staged_levels.clear();
         let mut level_index = 0;
         let mut block_mean = sample;
@@ -930,11 +893,13 @@ impl BinningAnalysis {
                 .get(level_index)
                 .cloned()
                 .unwrap_or_else(|| self.new_staged_level(level_index));
-            let next_block_mean = level.push_block_mean(block_mean);
-            if let Err(err) = level.check() {
-                self.staged_levels.clear();
-                return Err(err);
-            }
+            let next_block_mean = match level.push_block_mean(block_mean) {
+                Ok(next_block_mean) => next_block_mean,
+                Err(err) => {
+                    self.staged_levels.clear();
+                    return Err(err);
+                }
+            };
             self.staged_levels.push((level_index, level));
 
             if let Some(mean) = next_block_mean {
@@ -963,20 +928,6 @@ impl BinningAnalysis {
 
         BinningLevel::new(block_size)
     }
-
-    /// Ensure the hierarchy contains `level_index`.
-    ///
-    /// Levels are created lazily so short runs do not allocate unused coarse
-    /// block levels.
-    fn ensure_level(&mut self, level_index: usize) {
-        while self.levels.len() <= level_index {
-            let block_size = self
-                .levels
-                .last()
-                .map_or(1, |level| level.block_size.saturating_mul(2));
-            self.levels.push(BinningLevel::new(block_size));
-        }
-    }
 }
 
 impl Default for BinningAnalysis {
@@ -985,39 +936,11 @@ impl Default for BinningAnalysis {
     }
 }
 
-impl Extend<f64> for BinningAnalysis {
-    fn extend<I: IntoIterator<Item = f64>>(&mut self, iter: I) {
-        for sample in iter {
-            self.push(sample);
-        }
-    }
-}
-
 impl TryAccumulator<f64> for BinningAnalysis {
     type Error = StatisticsError;
 
     fn try_push(&mut self, sample: f64) -> Result<(), Self::Error> {
         Self::try_push(self, sample)
-    }
-}
-
-impl FromIterator<f64> for BinningAnalysis {
-    fn from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Self {
-        let mut analysis = Self::new();
-        analysis.extend(iter);
-        analysis
-    }
-}
-
-impl iter::Sum<f64> for OnlineStats {
-    fn sum<I: Iterator<Item = f64>>(iter: I) -> Self {
-        iter.collect()
-    }
-}
-
-impl iter::Sum<f64> for BinningAnalysis {
-    fn sum<I: Iterator<Item = f64>>(iter: I) -> Self {
-        iter.collect()
     }
 }
 
@@ -1073,9 +996,7 @@ mod tests {
 
     #[test]
     fn online_stats_matches_known_values() {
-        let stats: OnlineStats = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
-            .into_iter()
-            .collect();
+        let stats = OnlineStats::try_from_iter([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]).unwrap();
 
         assert_eq!(stats.count(), 8);
         assert_close(stats.mean().unwrap(), 5.0);
@@ -1087,9 +1008,7 @@ mod tests {
 
     #[test]
     fn online_stats_pins_fused_variance_update() {
-        let stats: OnlineStats = [1.0, 1.0e12, -1.0e12, 3.5, -2.25, 8.125]
-            .into_iter()
-            .collect();
+        let stats = OnlineStats::try_from_iter([1.0, 1.0e12, -1.0e12, 3.5, -2.25, 8.125]).unwrap();
 
         assert_eq!(stats.count(), 6);
         assert_eq!(stats.mean.to_bits(), 0x3ffb_aaa0_0000_0000);
@@ -1107,9 +1026,9 @@ mod tests {
     #[test]
     fn online_stats_can_clear_and_reuse() {
         let mut stats = OnlineStats::default();
-        stats.extend([1.0, 3.0]);
+        stats.try_extend([1.0, 3.0]).unwrap();
         stats.clear();
-        stats.push(10.0);
+        stats.try_push(10.0).unwrap();
 
         assert_eq!(stats.count(), 1);
         assert_eq!(stats.mean(), Some(10.0));
@@ -1214,7 +1133,7 @@ mod tests {
 
     #[test]
     fn binning_analysis_builds_power_of_two_levels() {
-        let bins: BinningAnalysis = (1..=8).map(f64::from).collect();
+        let bins = BinningAnalysis::try_from_iter((1..=8).map(f64::from)).unwrap();
         let estimates: Vec<_> = bins.estimates().collect();
 
         assert_eq!(bins.count(), 8);
@@ -1232,7 +1151,7 @@ mod tests {
 
     #[test]
     fn binning_analysis_reports_blocked_errors() {
-        let bins: BinningAnalysis = (1..=8).map(f64::from).collect();
+        let bins = BinningAnalysis::try_from_iter((1..=8).map(f64::from)).unwrap();
         let estimates: Vec<_> = bins.estimates().collect();
 
         assert_close(estimates[0].sample_variance().unwrap(), 6.0);
@@ -1257,7 +1176,7 @@ mod tests {
 
     #[test]
     fn binning_analysis_handles_partial_tail_blocks() {
-        let bins: BinningAnalysis = (1..=5).map(f64::from).collect();
+        let bins = BinningAnalysis::try_from_iter((1..=5).map(f64::from)).unwrap();
         let estimates: Vec<_> = bins.estimates().collect();
 
         assert_eq!(bins.count(), 5);
@@ -1274,9 +1193,9 @@ mod tests {
     #[test]
     fn binning_analysis_can_clear_and_reuse() {
         let mut bins = BinningAnalysis::default();
-        bins.extend([1.0, 2.0, 3.0, 4.0]);
+        bins.try_extend([1.0, 2.0, 3.0, 4.0]).unwrap();
         bins.clear();
-        bins.extend([10.0, 14.0]);
+        bins.try_extend([10.0, 14.0]).unwrap();
 
         assert_eq!(bins.count(), 2);
         assert_eq!(bins.mean(), Some(12.0));
@@ -1310,17 +1229,16 @@ mod tests {
     }
 
     #[test]
-    fn binning_analysis_try_push_matches_infallible_hierarchy() {
+    fn binning_analysis_try_push_matches_try_from_iter_hierarchy() {
         let samples = (1..=9).map(f64::from);
         let mut fallible = BinningAnalysis::new();
-        let mut infallible = BinningAnalysis::new();
 
-        for sample in samples {
+        for sample in samples.clone() {
             fallible.try_push(sample).unwrap();
-            infallible.push(sample);
         }
+        let from_iter = BinningAnalysis::try_from_iter(samples).unwrap();
 
-        assert_eq!(fallible, infallible);
+        assert_eq!(fallible, from_iter);
 
         let estimates: Vec<_> = fallible.estimates().collect();
         assert_eq!(

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -14,9 +14,8 @@
 //! [`DetailedBalanceBatchReport`] so callers can inspect every failed
 //! transition instead of stopping at the first violation.
 
-use core::{convert::Infallible, hint::cold_path};
-use std::error::Error;
-use std::fmt;
+use core::{convert::Infallible, hint::cold_path, num::NonZeroUsize};
+use std::{error::Error, fmt};
 
 use rand::Rng;
 
@@ -28,11 +27,11 @@ use crate::{DelayedProposal, Proposal, ProposalMut, Target};
 #[must_use]
 pub struct DetailedBalanceConfig {
     /// Number of proposal samples drawn in each direction.
-    samples: usize,
+    samples: NonZeroUsize,
     /// Absolute tolerance for the log detailed-balance residual.
     tolerance: f64,
     /// Minimum hit count required in each direction.
-    min_hits: usize,
+    min_hits: NonZeroUsize,
 }
 
 impl DetailedBalanceConfig {
@@ -65,14 +64,23 @@ impl DetailedBalanceConfig {
         tolerance: f64,
         min_hits: usize,
     ) -> Result<Self, DetailedBalanceError> {
-        if samples == 0 {
+        let Some(samples) = NonZeroUsize::new(samples) else {
             return Err(DetailedBalanceError::InvalidSamples { samples });
-        }
+        };
         if !tolerance.is_finite() || tolerance < 0.0 {
             return Err(DetailedBalanceError::InvalidTolerance { tolerance });
         }
-        if min_hits == 0 || min_hits > samples {
-            return Err(DetailedBalanceError::InvalidMinHits { min_hits, samples });
+        let Some(min_hits) = NonZeroUsize::new(min_hits) else {
+            return Err(DetailedBalanceError::InvalidMinHits {
+                min_hits,
+                samples: samples.get(),
+            });
+        };
+        if min_hits > samples {
+            return Err(DetailedBalanceError::InvalidMinHits {
+                min_hits: min_hits.get(),
+                samples: samples.get(),
+            });
         }
 
         Ok(Self {
@@ -96,7 +104,7 @@ impl DetailedBalanceConfig {
     /// ```
     #[must_use]
     pub const fn samples(self) -> usize {
-        self.samples
+        self.samples.get()
     }
 
     /// Absolute tolerance for the log detailed-balance residual.
@@ -130,16 +138,16 @@ impl DetailedBalanceConfig {
     /// ```
     #[must_use]
     pub const fn min_hits(self) -> usize {
-        self.min_hits
+        self.min_hits.get()
     }
 }
 
 impl Default for DetailedBalanceConfig {
     fn default() -> Self {
         Self {
-            samples: 10_000,
+            samples: NonZeroUsize::MIN.saturating_add(9_999),
             tolerance: 0.1,
-            min_hits: 30,
+            min_hits: NonZeroUsize::MIN.saturating_add(29),
         }
     }
 }
@@ -303,16 +311,19 @@ impl DetailedBalanceReport {
 #[non_exhaustive]
 pub enum DetailedBalanceError<E = Infallible> {
     /// `samples` must be greater than zero.
+    #[non_exhaustive]
     InvalidSamples {
         /// Invalid sample count.
         samples: usize,
     },
     /// `tolerance` must be finite and nonnegative.
+    #[non_exhaustive]
     InvalidTolerance {
         /// Invalid tolerance.
         tolerance: f64,
     },
     /// `min_hits` must be greater than zero and no larger than `samples`.
+    #[non_exhaustive]
     InvalidMinHits {
         /// Invalid minimum hit count.
         min_hits: usize,
@@ -320,6 +331,7 @@ pub enum DetailedBalanceError<E = Infallible> {
         samples: usize,
     },
     /// Target log-probability was `NaN` or positive infinity for one endpoint.
+    #[non_exhaustive]
     InvalidTargetLogProb {
         /// Endpoint whose log-probability was invalid.
         state: DetailedBalanceState,
@@ -327,6 +339,7 @@ pub enum DetailedBalanceError<E = Infallible> {
         log_prob: f64,
     },
     /// Proposal log q-ratio was `NaN` or positive infinity for one direction.
+    #[non_exhaustive]
     InvalidLogQRatio {
         /// Direction whose log q-ratio was invalid.
         direction: DetailedBalanceDirection,
@@ -334,6 +347,7 @@ pub enum DetailedBalanceError<E = Infallible> {
         log_q_ratio: f64,
     },
     /// Delayed proposal planning failed.
+    #[non_exhaustive]
     Plan {
         /// Direction whose planning failed.
         direction: DetailedBalanceDirection,
@@ -341,6 +355,7 @@ pub enum DetailedBalanceError<E = Infallible> {
         source: E,
     },
     /// Delayed proposal log-probability evaluation failed.
+    #[non_exhaustive]
     ProposedLogProb {
         /// Direction whose proposed log-probability evaluation failed.
         direction: DetailedBalanceDirection,
@@ -348,6 +363,7 @@ pub enum DetailedBalanceError<E = Infallible> {
         source: E,
     },
     /// Delayed proposal log q-ratio evaluation failed.
+    #[non_exhaustive]
     LogQRatio {
         /// Direction whose proposal ratio evaluation failed.
         direction: DetailedBalanceDirection,
@@ -355,6 +371,7 @@ pub enum DetailedBalanceError<E = Infallible> {
         source: E,
     },
     /// Too few exact proposal hits were observed in one direction.
+    #[non_exhaustive]
     InsufficientHits {
         /// Direction with too few hits.
         direction: DetailedBalanceDirection,
@@ -364,6 +381,7 @@ pub enum DetailedBalanceError<E = Infallible> {
         min_hits: usize,
     },
     /// Estimated detailed-balance residual exceeded the configured tolerance.
+    #[non_exhaustive]
     Violation {
         /// Estimated `log(forward flow) - log(reverse flow)`.
         residual: f64,
@@ -469,11 +487,12 @@ impl<E> DetailedBalanceFailure<E> {
     /// # Examples
     ///
     /// ```
-    /// use markov_chain_monte_carlo::{DetailedBalanceError, DetailedBalanceFailure};
+    /// use markov_chain_monte_carlo::{DetailedBalanceConfig, DetailedBalanceFailure};
     ///
+    /// let error = DetailedBalanceConfig::new(0, 1e-12, 1).unwrap_err();
     /// let failure = DetailedBalanceFailure::new(
     ///     2,
-    ///     DetailedBalanceError::<()>::InvalidSamples { samples: 0 },
+    ///     error,
     /// );
     ///
     /// assert_eq!(failure.index, 2);
@@ -1117,7 +1136,7 @@ where
         proposed,
         proposal,
         rng,
-        config.samples,
+        config.samples(),
         forward_acceptance,
     );
     let reverse = estimate_by_value_transition(
@@ -1125,7 +1144,7 @@ where
         current,
         proposal,
         rng,
-        config.samples,
+        config.samples(),
         reverse_acceptance,
     );
 
@@ -1156,7 +1175,7 @@ where
         proposal,
         rng,
         TransitionRequest {
-            samples: config.samples,
+            samples: config.samples(),
             from_log_prob: endpoint_log_probs.current,
             direction: DetailedBalanceDirection::Forward,
         },
@@ -1168,7 +1187,7 @@ where
         proposal,
         rng,
         TransitionRequest {
-            samples: config.samples,
+            samples: config.samples(),
             from_log_prob: endpoint_log_probs.proposed,
             direction: DetailedBalanceDirection::Reverse,
         },
@@ -1202,7 +1221,7 @@ where
         proposal,
         rng,
         TransitionRequest {
-            samples: config.samples,
+            samples: config.samples(),
             from_log_prob: endpoint_log_probs.current,
             direction: DetailedBalanceDirection::Forward,
         },
@@ -1214,7 +1233,7 @@ where
         proposal,
         rng,
         TransitionRequest {
-            samples: config.samples,
+            samples: config.samples(),
             from_log_prob: endpoint_log_probs.proposed,
             direction: DetailedBalanceDirection::Reverse,
         },
@@ -1481,39 +1500,39 @@ fn finish_report<E>(
     check_hits(
         DetailedBalanceDirection::Forward,
         forward.hits,
-        config.min_hits,
+        config.min_hits(),
     )?;
     check_hits(
         DetailedBalanceDirection::Reverse,
         reverse.hits,
-        config.min_hits,
+        config.min_hits(),
     )?;
 
-    let forward_log_transition = forward.log_transition_probability(config.samples);
-    let reverse_log_transition = reverse.log_transition_probability(config.samples);
+    let forward_log_transition = forward.log_transition_probability(config.samples());
+    let reverse_log_transition = reverse.log_transition_probability(config.samples());
     let forward_log_flow = endpoint_log_probs.current + forward_log_transition;
     let reverse_log_flow = endpoint_log_probs.proposed + reverse_log_transition;
     let log_balance_residual = log_residual(forward_log_flow, reverse_log_flow);
     let log_balance_standard_error = forward
-        .log_standard_error(config.samples)
-        .hypot(reverse.log_standard_error(config.samples));
+        .log_standard_error(config.samples())
+        .hypot(reverse.log_standard_error(config.samples()));
 
     let report = DetailedBalanceReport {
-        samples: config.samples,
+        samples: config.samples(),
         forward_hits: forward.hits,
         reverse_hits: reverse.hits,
-        forward_log_proposal: forward.log_proposal_probability(config.samples),
-        reverse_log_proposal: reverse.log_proposal_probability(config.samples),
+        forward_log_proposal: forward.log_proposal_probability(config.samples()),
+        reverse_log_proposal: reverse.log_proposal_probability(config.samples()),
         forward_log_transition,
         reverse_log_transition,
         log_balance_residual,
         log_balance_standard_error,
     };
 
-    if !report.is_within_tolerance(config.tolerance) {
+    if !report.is_within_tolerance(config.tolerance()) {
         return Err(DetailedBalanceError::Violation {
             residual: log_balance_residual,
-            tolerance: config.tolerance,
+            tolerance: config.tolerance(),
             report,
         });
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,8 @@
 //! Core traits for target distributions and proposal distributions.
 
+use core::{fmt, num::NonZeroUsize};
+use std::error::Error;
+
 use rand::Rng;
 
 /// Hastings correction for a discrete proposal with weighted move families and
@@ -32,7 +35,7 @@ use rand::Rng;
 pub struct DiscreteProposalRatio {
     forward_weight: f64,
     reverse_weight: f64,
-    forward_site_count: usize,
+    forward_site_count: NonZeroUsize,
     reverse_site_count: usize,
 }
 
@@ -91,9 +94,9 @@ impl DiscreteProposalRatio {
                 weight: reverse_weight,
             });
         }
-        if forward_site_count == 0 {
+        let Some(forward_site_count) = NonZeroUsize::new(forward_site_count) else {
             return Err(DiscreteProposalRatioError::ZeroForwardSiteCount);
-        }
+        };
 
         Ok(Self {
             forward_weight,
@@ -183,7 +186,7 @@ impl DiscreteProposalRatio {
     /// ```
     #[must_use]
     pub const fn forward_site_count(self) -> usize {
-        self.forward_site_count
+        self.forward_site_count.get()
     }
 
     /// Number of concrete sites sampled by the reverse proposal family.
@@ -226,12 +229,15 @@ impl DiscreteProposalRatio {
     /// ```
     #[must_use]
     pub fn log_q_ratio(self) -> f64 {
-        if self.reverse_weight == 0.0 || self.reverse_site_count == 0 {
+        let Some(reverse_site_count) = NonZeroUsize::new(self.reverse_site_count) else {
+            return f64::NEG_INFINITY;
+        };
+        if self.reverse_weight == 0.0 {
             return f64::NEG_INFINITY;
         }
 
         self.reverse_weight.ln() - self.forward_weight.ln() + count_ln(self.forward_site_count)
-            - count_ln(self.reverse_site_count)
+            - count_ln(reverse_site_count)
     }
 }
 
@@ -255,8 +261,8 @@ pub enum DiscreteProposalRatioError {
     ZeroForwardSiteCount,
 }
 
-impl core::fmt::Display for DiscreteProposalRatioError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl fmt::Display for DiscreteProposalRatioError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidForwardWeight { weight } => write!(
                 f,
@@ -273,15 +279,18 @@ impl core::fmt::Display for DiscreteProposalRatioError {
     }
 }
 
-impl std::error::Error for DiscreteProposalRatioError {}
+impl Error for DiscreteProposalRatioError {}
 
 /// Convert a valid-site count into a logarithm for proposal-ratio arithmetic.
+///
+/// The [`NonZeroUsize`] argument records the constructor invariant for counts
+/// that must be positive before they enter log-space arithmetic.
 #[expect(
     clippy::cast_precision_loss,
     reason = "valid-site counts intentionally cross into log-space f64 proposal arithmetic"
 )]
-fn count_ln(count: usize) -> f64 {
-    (count as f64).ln()
+fn count_ln(count: NonZeroUsize) -> f64 {
+    (count.get() as f64).ln()
 }
 
 /// Target distribution.

--- a/tests/proptest_validators.rs
+++ b/tests/proptest_validators.rs
@@ -1,8 +1,9 @@
 //! Property tests for public validator constructors.
 
-use markov_chain_monte_carlo::{
+use markov_chain_monte_carlo::prelude::testing::{
     DetailedBalanceConfig, DetailedBalanceError, DiscreteProposalRatio, DiscreteProposalRatioError,
 };
+use markov_chain_monte_carlo::prelude::{BinningAnalysis, OnlineStats, StatisticsError};
 use proptest::prelude::*;
 
 proptest! {
@@ -57,6 +58,47 @@ proptest! {
             prop_assert_eq!(config.samples(), samples);
             prop_assert_eq!(config.tolerance().to_bits(), tolerance.to_bits());
             prop_assert_eq!(config.min_hits(), min_hits);
+        }
+    }
+
+    #[test]
+    fn online_stats_accepts_only_finite_single_samples(sample in any::<f64>()) {
+        let mut stats = OnlineStats::new();
+        let result = stats.try_push(sample);
+
+        if sample.is_finite() {
+            prop_assert_eq!(result, Ok(()));
+            prop_assert_eq!(stats.count(), 1);
+            prop_assert_eq!(stats.mean(), Some(sample));
+        } else {
+            let expected = if sample.is_nan() {
+                StatisticsError::NanSample
+            } else {
+                StatisticsError::InfiniteSample
+            };
+            prop_assert_eq!(result, Err(expected));
+            prop_assert!(stats.is_empty());
+        }
+    }
+
+    #[test]
+    fn binning_analysis_accepts_only_finite_single_samples(sample in any::<f64>()) {
+        let mut bins = BinningAnalysis::new();
+        let result = bins.try_push(sample);
+
+        if sample.is_finite() {
+            prop_assert_eq!(result, Ok(()));
+            prop_assert_eq!(bins.count(), 1);
+            prop_assert_eq!(bins.mean(), Some(sample));
+            prop_assert_eq!(bins.estimates().count(), 1);
+        } else {
+            let expected = if sample.is_nan() {
+                StatisticsError::NanSample
+            } else {
+                StatisticsError::InfiniteSample
+            };
+            prop_assert_eq!(result, Err(expected));
+            prop_assert!(bins.is_empty());
         }
     }
 }

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -27,6 +27,61 @@ fn raw_panic() {
     panic!("boom");
 }
 
+pub struct InvariantType;
+
+impl InvariantType {
+    // ruleid: mcmc.rust.no-public-unchecked-apis
+    pub fn new_unchecked() -> Self {
+        Self
+    }
+
+    // ruleid: mcmc.rust.no-public-unit-validators
+    pub fn validate_positive(value: usize) -> Result<(), ()> {
+        if value == 0 { Err(()) } else { Ok(()) }
+    }
+}
+
+pub struct OnlineStats;
+pub struct BinningAnalysis;
+
+impl OnlineStats {
+    // ruleid: mcmc.rust.no-infallible-statistics-f64-ingestion
+    pub fn push(&mut self, sample: f64) {
+        let _ = sample;
+    }
+}
+
+// ruleid: mcmc.rust.no-infallible-statistics-f64-ingestion
+impl Extend<f64> for BinningAnalysis {
+    fn extend<T: IntoIterator<Item = f64>>(&mut self, iter: T) {
+        for sample in iter {
+            let _ = sample;
+        }
+    }
+}
+
+// ruleid: mcmc.rust.no-infallible-statistics-f64-ingestion
+impl FromIterator<f64> for OnlineStats {
+    fn from_iter<T: IntoIterator<Item = f64>>(iter: T) -> Self {
+        for sample in iter {
+            let _ = sample;
+        }
+        Self
+    }
+}
+
+pub struct DetailedBalanceConfig {
+    // ruleid: mcmc.rust.invariant-fields-use-refined-types
+    samples: usize,
+    // ruleid: mcmc.rust.invariant-fields-use-refined-types
+    min_hits: usize,
+}
+
+pub struct DiscreteProposalRatio {
+    // ruleid: mcmc.rust.invariant-fields-use-refined-types
+    forward_site_count: usize,
+}
+
 // ruleid: mcmc.rust.no-box-dyn-error-in-src
 fn erased_error() -> Result<(), Box<dyn Error>> {
     Ok(())


### PR DESCRIPTION
- Require OnlineStats and BinningAnalysis to ingest raw f64 samples through fallible APIs, with private finite-sample evidence carried through accumulator internals.
- Store nonzero detailed-balance and proposal-ratio counts as refined types so zero is rejected at construction instead of rechecked downstream.
- Add Semgrep guardrails for unchecked APIs, infallible statistics ingestion, raw invariant fields, and public unit validators.
- Refresh docs, property tests, and crate metadata for the stricter public API surface.

BREAKING CHANGE: Removed infallible statistics ingestion APIs, including push, push_unchecked, Extend<f64>, FromIterator<f64>, and Sum<f64> implementations for OnlineStats and BinningAnalysis. Callers must use try_push, try_extend, or try_from_iter and handle StatisticsError.