### PR TITLE
feat(sampler): expose resumable chunked runs (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ responsibilities.
 - Generic `Chain<S>` over user-defined state spaces with explicit accepted/rejected counters.
 - Log-space Metropolis-Hastings acceptance with typed errors for NaN and positive-infinite target or proposal values.
 - Three proposal workflows: by-value `Proposal`, rollback-safe in-place `ProposalMut`, and delayed-commit `DelayedProposal`.
-- `Sampler` helpers for repeated runs, iterator-style sampling, thinning, observations, and counter resets after burn-in.
+- `Sampler` helpers for repeated and chunked runs, iterator-style sampling, thinning, observations, and counter resets after burn-in.
 - Streaming `OnlineStats` and `BinningAnalysis` for long correlated runs without retaining every sample.
 - `ChainCheckpoint` restore APIs that recompute cached log-probabilities against the resumed target.
 - Optional `serde` support for serializing chains, samplers, and portable checkpoints.
@@ -124,7 +124,7 @@ fn main() -> Result<(), McmcError> {
 - Start with `Proposal` and `Chain::step` when state cloning is cheap.
 - Use `ProposalMut` and `Chain::step_mut` when cloning state is expensive and rollback is simple.
 - Use `DelayedProposal` and `Chain::step_delayed` when you need to plan and score a concrete move before mutating state.
-- Use `Sampler` when you want ergonomic repeated runs, iterator-based sampling, or observing helpers.
+- Use `Sampler` when you want ergonomic repeated runs, resumable chunks, iterator-based sampling, or observing helpers.
 - Use `verify_detailed_balance*` helpers in proposal tests for representative discrete transitions.
 - Use `OnlineStats` and `BinningAnalysis` when long runs should stream statistics instead of retaining every sample.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ The next feature release should focus on downstream sampler integration rather t
 MSRV/toolchain refresh.
 
 - [#65](https://github.com/acgetchell/markov-chain-monte-carlo/issues/65) - Update Rust toolchain and MSRV to 1.96.0
-- [#60](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60) - Expose resumable sampler state for chunked runs
+- [x] [#60](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60) - Expose resumable sampler state for chunked runs
 - [#61](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61) - Expose delayed-step hooks or telemetry for domain-specific sampler integration
 - [#59](https://github.com/acgetchell/markov-chain-monte-carlo/issues/59) - Support additive target bias terms in Metropolis-Hastings acceptance
 - [#48](https://github.com/acgetchell/markov-chain-monte-carlo/issues/48) - Investigate detailed balance for delayed proposals with variable valid-site counts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,11 @@
 //! for those streaming measurement loops.  Samplers also provide
 //! `*_with_thinning` variants to collect cloned states or measurements only
 //! every k-th completed step while still advancing the chain on every step.
+//! For workflows that choose the next step budget from the updated state, use
+//! [`Sampler::run_chunk`], [`Sampler::run_mut_chunk`], or
+//! [`Sampler::run_delayed_chunk`].  They run the next chunk on the same RNG
+//! stream and return a checkpoint-compatible view containing the current state
+//! and counters.
 //!
 //! # Proposal validation
 //!

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -6,7 +6,7 @@ use std::{error::Error, fmt};
 use rand::Rng;
 
 use crate::{
-    Chain, DelayedProposal, DelayedStep, DelayedStepError, McmcError, Observable,
+    Chain, ChainCheckpoint, DelayedProposal, DelayedStep, DelayedStepError, McmcError, Observable,
     ObservedStepError, ObservedStreamError, Proposal, ProposalMut, SampleBuffer, Target,
     TryAccumulator, TryObservable,
 };
@@ -306,6 +306,68 @@ impl<S, T, P, R: ?Sized> Sampler<'_, S, T, P, R> {
         self.chain
     }
 
+    /// Borrow checkpoint-compatible continuation state from the inner chain.
+    ///
+    /// The returned checkpoint includes the current state and accepted/rejected
+    /// counters. It deliberately borrows the state and does not include the
+    /// RNG stream; keep using the same sampler to preserve RNG state across
+    /// chunks, or persist the caller-owned RNG separately for durable resumes.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<i32> for T { fn log_prob(&self, _: &i32) -> f64 { 0.0 } }
+    /// # struct P;
+    /// # impl Proposal<i32> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &i32, _: &mut R) -> i32 {
+    /// #         current + 1
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &T)?;
+    /// let sampler = Sampler::new(chain, &T, &P, &mut rng)?;
+    ///
+    /// let checkpoint = sampler.checkpoint();
+    /// assert_eq!(checkpoint.state(), &&0);
+    /// assert_eq!(checkpoint.total_steps(), 0);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub const fn checkpoint(&self) -> ChainCheckpoint<&S> {
+        self.chain.checkpoint()
+    }
+
+    /// Consume the sampler and return an owned checkpoint for its chain.
+    ///
+    /// Restore the returned checkpoint with [`Chain::from_checkpoint`] and
+    /// reconstruct the target, proposal, and RNG stream that will be used for
+    /// resumed sampling.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<String> for T { fn log_prob(&self, _: &String) -> f64 { 0.0 } }
+    /// # struct P;
+    /// # impl Proposal<String> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &String, _: &mut R) -> String {
+    /// #         current.clone()
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(String::from("state"), &T)?;
+    /// let sampler = Sampler::new(chain, &T, &P, &mut rng)?;
+    ///
+    /// let checkpoint = sampler.into_checkpoint();
+    /// assert_eq!(checkpoint.into_parts(), (String::from("state"), 0, 0));
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    pub fn into_checkpoint(self) -> ChainCheckpoint<S> {
+        self.chain.into_checkpoint()
+    }
+
     /// Reset acceptance and rejection counters on the inner chain.
     ///
     /// Useful after burn-in to measure the acceptance rate of the production
@@ -589,6 +651,45 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
             self.step()?;
         }
         Ok(())
+    }
+
+    /// Run a resumable by-value chunk and return continuation state.
+    ///
+    /// This is equivalent to [`run`](Self::run) followed by
+    /// [`checkpoint`](Self::checkpoint). Repeated chunks on the same sampler
+    /// preserve the chain counters and RNG stream exactly as a one-shot run
+    /// with the same total number of steps.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::by_value::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # struct T;
+    /// # impl Target<i32> for T { fn log_prob(&self, _: &i32) -> f64 { 0.0 } }
+    /// # struct P;
+    /// # impl Proposal<i32> for P {
+    /// #     fn propose<R: Rng + ?Sized>(&self, current: &i32, _: &mut R) -> i32 {
+    /// #         current + 1
+    /// #     }
+    /// # }
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &T)?;
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
+    ///
+    /// let continuation = sampler.run_chunk(3)?;
+    /// assert_eq!(continuation.state(), &&3);
+    /// assert_eq!(continuation.total_steps(), 3);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`run`](Self::run): [`McmcError`] on the
+    /// first step with invalid target log-probability or proposal ratio
+    /// numerics.
+    pub fn run_chunk(&mut self, steps: usize) -> Result<ChainCheckpoint<&S>, McmcError> {
+        self.run(steps)?;
+        Ok(self.checkpoint())
     }
 
     /// Run by-value steps and collect cloned states every `thin_interval` steps.
@@ -1234,6 +1335,57 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
             self.step_mut()?;
         }
         Ok(())
+    }
+
+    /// Run a resumable in-place chunk and return continuation state.
+    ///
+    /// This is equivalent to [`run_mut`](Self::run_mut) followed by
+    /// [`checkpoint`](Self::checkpoint). Repeated chunks on the same sampler
+    /// preserve the chain counters and RNG stream exactly as a one-shot run
+    /// with the same total number of steps.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::prelude::in_place::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct S(i32);
+    /// struct Flat;
+    /// impl Target<S> for Flat {
+    ///     fn log_prob(&self, _: &S) -> f64 { 0.0 }
+    /// }
+    /// struct Increment;
+    /// impl ProposalMut<S> for Increment {
+    ///     type Undo = i32;
+    ///
+    ///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, _: &mut R) -> Option<i32> {
+    ///         let old = state.0;
+    ///         state.0 += 1;
+    ///         Some(old)
+    ///     }
+    ///
+    ///     fn undo(&self, state: &mut S, old: i32) {
+    ///         state.0 = old;
+    ///     }
+    /// }
+    ///
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)?;
+    ///
+    /// let continuation = sampler.run_mut_chunk(3)?;
+    /// assert_eq!(continuation.state().0, 3);
+    /// assert_eq!(continuation.total_steps(), 3);
+    /// # Ok::<(), McmcError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`run_mut`](Self::run_mut): [`McmcError`] on
+    /// the first step with invalid target log-probability or proposal ratio
+    /// numerics after rolling back the in-place proposal when needed.
+    pub fn run_mut_chunk(&mut self, steps: usize) -> Result<ChainCheckpoint<&S>, McmcError> {
+        self.run_mut(steps)?;
+        Ok(self.checkpoint())
     }
 
     /// Run in-place steps and collect cloned states every `thin_interval` steps.
@@ -2073,6 +2225,87 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
             let _ = self.step_delayed()?;
         }
         Ok(())
+    }
+
+    /// Run a resumable delayed-commit chunk and return continuation state.
+    ///
+    /// This is equivalent to [`run_delayed`](Self::run_delayed) followed by
+    /// [`checkpoint`](Self::checkpoint). Repeated chunks on the same sampler
+    /// preserve the chain counters and RNG stream exactly as a one-shot run
+    /// with the same total number of steps.
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct Flat;
+    /// impl Target<i32> for Flat {
+    ///     fn log_prob(&self, _: &i32) -> f64 { 0.0 }
+    /// }
+    ///
+    /// struct Increment;
+    /// impl DelayedProposal<i32> for Increment {
+    ///     type Plan = i32;
+    ///     type Info = i32;
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _: &i32,
+    ///         _: &mut R,
+    ///     ) -> Result<Option<i32>, Self::Error> {
+    ///         Ok(Some(1))
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<i32>>(
+    ///         &self,
+    ///         state: &i32,
+    ///         plan: &i32,
+    ///         target: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         Ok(target.log_prob(&(*state + *plan)))
+    ///     }
+    ///
+    ///     fn info(&self, plan: &i32) -> i32 {
+    ///         *plan
+    ///     }
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         state: &mut i32,
+    ///         plan: i32,
+    ///         _: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         *state += plan;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let target = Flat;
+    /// let mut proposal = Increment;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    ///
+    /// let continuation = sampler.run_delayed_chunk(3)?;
+    /// assert_eq!(**continuation.state(), 3);
+    /// assert_eq!(continuation.total_steps(), 3);
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`run_delayed`](Self::run_delayed):
+    /// [`DelayedStepError`] when delayed proposal planning, proposed-state
+    /// scoring, proposal-ratio evaluation, Metropolis-Hastings numeric
+    /// validation, or accepted-move commit fails.
+    pub fn run_delayed_chunk(
+        &mut self,
+        steps: usize,
+    ) -> Result<ChainCheckpoint<&S>, DelayedStepError<P::Error>> {
+        self.run_delayed(steps)?;
+        Ok(self.checkpoint())
     }
 
     /// Run delayed-commit steps and collect cloned states every `thin_interval` steps.

--- a/tests/proptest_chain.rs
+++ b/tests/proptest_chain.rs
@@ -305,6 +305,55 @@ proptest! {
         prop_assert_eq!(chain.rejected(), sampler.chain_ref().rejected());
     }
 
+    /// Chunked by-value sampler runs must preserve RNG state, counters, and
+    /// checkpoint-compatible continuation state exactly like one-shot runs.
+    #[test]
+    fn sampler_run_chunk_matches_one_shot(
+        initial in -10.0f64..10.0,
+        width in 0.1f64..5.0,
+        steps in 1u32..500,
+        split in 0u32..500,
+        seed in any::<u64>(),
+    ) {
+        let proposal = CloneWalk { width };
+        let steps = steps as usize;
+        let first = split as usize % (steps + 1);
+        let second = steps - first;
+
+        let one_shot_chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut one_shot_rng = StdRng::seed_from_u64(seed);
+        let mut one_shot =
+            Sampler::new(one_shot_chain, &Normal, &proposal, &mut one_shot_rng).unwrap();
+        one_shot.run(steps).unwrap();
+
+        let chunked_chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut chunked_rng = StdRng::seed_from_u64(seed);
+        let mut chunked =
+            Sampler::new(chunked_chain, &Normal, &proposal, &mut chunked_rng).unwrap();
+
+        let first_total_steps = {
+            let continuation = chunked.run_chunk(first).unwrap();
+            continuation.total_steps()
+        };
+        prop_assert_eq!(first_total_steps, first);
+
+        let continuation = chunked.run_chunk(second).unwrap();
+        prop_assert_eq!(one_shot.chain_ref().state(), *continuation.state());
+        prop_assert_eq!(one_shot.chain_ref().accepted(), continuation.accepted());
+        prop_assert_eq!(one_shot.chain_ref().rejected(), continuation.rejected());
+        prop_assert_eq!(one_shot.chain_ref().total_steps(), continuation.total_steps());
+        prop_assert!(
+            relative_eq!(
+                one_shot.chain_ref().log_prob(),
+                chunked.chain_ref().log_prob(),
+                epsilon = 1e-12,
+            ),
+            "cached log_prob diverged: one-shot={:.15}, chunked={:.15}",
+            one_shot.chain_ref().log_prob(),
+            chunked.chain_ref().log_prob(),
+        );
+    }
+
     /// `Sampler::run_mut` must produce identical results to a raw `Chain`
     /// loop with the same seed.
     #[test]
@@ -333,4 +382,161 @@ proptest! {
         prop_assert_eq!(chain.accepted(), sampler.chain_ref().accepted());
         prop_assert_eq!(chain.rejected(), sampler.chain_ref().rejected());
     }
+
+    /// Chunked in-place sampler runs must match one-shot runs with the same
+    /// seed and expose continuation counters after each chunk.
+    #[test]
+    fn sampler_run_mut_chunk_matches_one_shot(
+        initial in -10.0f64..10.0,
+        width in 0.1f64..5.0,
+        steps in 1u32..500,
+        split in 0u32..500,
+        seed in any::<u64>(),
+    ) {
+        let proposal = MutWalk { width };
+        let steps = steps as usize;
+        let first = split as usize % (steps + 1);
+        let second = steps - first;
+
+        let one_shot_chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut one_shot_rng = StdRng::seed_from_u64(seed);
+        let mut one_shot =
+            Sampler::new(one_shot_chain, &Normal, &proposal, &mut one_shot_rng).unwrap();
+        one_shot.run_mut(steps).unwrap();
+
+        let chunked_chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut chunked_rng = StdRng::seed_from_u64(seed);
+        let mut chunked =
+            Sampler::new(chunked_chain, &Normal, &proposal, &mut chunked_rng).unwrap();
+
+        let first_total_steps = {
+            let continuation = chunked.run_mut_chunk(first).unwrap();
+            continuation.total_steps()
+        };
+        prop_assert_eq!(first_total_steps, first);
+
+        let continuation = chunked.run_mut_chunk(second).unwrap();
+        prop_assert_eq!(one_shot.chain_ref().state(), *continuation.state());
+        prop_assert_eq!(one_shot.chain_ref().accepted(), continuation.accepted());
+        prop_assert_eq!(one_shot.chain_ref().rejected(), continuation.rejected());
+        prop_assert_eq!(one_shot.chain_ref().total_steps(), continuation.total_steps());
+        prop_assert!(
+            relative_eq!(
+                one_shot.chain_ref().log_prob(),
+                chunked.chain_ref().log_prob(),
+                epsilon = 1e-12,
+            ),
+            "cached log_prob diverged: one-shot={:.15}, chunked={:.15}",
+            one_shot.chain_ref().log_prob(),
+            chunked.chain_ref().log_prob(),
+        );
+    }
+
+    /// Chunked delayed sampler runs must match one-shot delayed runs with the
+    /// same seed and preserve delayed proposal telemetry counters.
+    #[test]
+    fn sampler_run_delayed_chunk_matches_one_shot(
+        initial in -10.0f64..10.0,
+        width in 0.1f64..5.0,
+        steps in 1u32..200,
+        split in 0u32..200,
+        seed in any::<u64>(),
+    ) {
+        let steps = steps as usize;
+        let first = split as usize % (steps + 1);
+        let second = steps - first;
+
+        let one_shot_chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut one_shot_rng = StdRng::seed_from_u64(seed);
+        let mut one_shot_proposal = DelayedWalk { width };
+        let mut one_shot = Sampler::new(
+            one_shot_chain,
+            &Normal,
+            &mut one_shot_proposal,
+            &mut one_shot_rng,
+        ).unwrap();
+        one_shot.run_delayed(steps).unwrap();
+
+        let chunked_chain = Chain::new(Scalar(initial), &Normal).unwrap();
+        let mut chunked_rng = StdRng::seed_from_u64(seed);
+        let mut chunked_proposal = DelayedWalk { width };
+        let mut chunked = Sampler::new(
+            chunked_chain,
+            &Normal,
+            &mut chunked_proposal,
+            &mut chunked_rng,
+        ).unwrap();
+
+        let first_total_steps = {
+            let continuation = chunked.run_delayed_chunk(first).unwrap();
+            continuation.total_steps()
+        };
+        prop_assert_eq!(first_total_steps, first);
+
+        let continuation = chunked.run_delayed_chunk(second).unwrap();
+        prop_assert_eq!(one_shot.chain_ref().state(), *continuation.state());
+        prop_assert_eq!(one_shot.chain_ref().accepted(), continuation.accepted());
+        prop_assert_eq!(one_shot.chain_ref().rejected(), continuation.rejected());
+        prop_assert_eq!(one_shot.chain_ref().total_steps(), continuation.total_steps());
+        prop_assert!(
+            relative_eq!(
+                one_shot.chain_ref().log_prob(),
+                chunked.chain_ref().log_prob(),
+                epsilon = 1e-12,
+            ),
+            "cached log_prob diverged: one-shot={:.15}, chunked={:.15}",
+            one_shot.chain_ref().log_prob(),
+            chunked.chain_ref().log_prob(),
+        );
+    }
+}
+
+#[test]
+fn run_chunk_allows_next_chunk_size_from_current_state() {
+    #[derive(Clone, Debug, PartialEq)]
+    struct Counter(i32);
+
+    struct Flat;
+    impl Target<Counter> for Flat {
+        fn log_prob(&self, _: &Counter) -> f64 {
+            0.0
+        }
+    }
+
+    struct Increment;
+    impl Proposal<Counter> for Increment {
+        fn propose<R: Rng + ?Sized>(&self, current: &Counter, _: &mut R) -> Counter {
+            Counter(current.0 + 1)
+        }
+    }
+
+    let mut one_shot_rng = StdRng::seed_from_u64(42);
+    let one_shot_chain = Chain::new(Counter(0), &Flat).unwrap();
+    let mut one_shot = Sampler::new(one_shot_chain, &Flat, &Increment, &mut one_shot_rng).unwrap();
+    one_shot.run(5).unwrap();
+
+    let mut chunked_rng = StdRng::seed_from_u64(42);
+    let chunked_chain = Chain::new(Counter(0), &Flat).unwrap();
+    let mut chunked = Sampler::new(chunked_chain, &Flat, &Increment, &mut chunked_rng).unwrap();
+
+    let next_chunk_size = {
+        let continuation = chunked.run_chunk(2).unwrap();
+        assert_eq!(continuation.state().0, 2);
+        usize::try_from(continuation.state().0 + 1).unwrap()
+    };
+
+    let continuation = chunked.run_chunk(next_chunk_size).unwrap();
+
+    assert_eq!(one_shot.chain_ref().state(), *continuation.state());
+    assert_eq!(one_shot.chain_ref().accepted(), continuation.accepted());
+    assert_eq!(one_shot.chain_ref().rejected(), continuation.rejected());
+    assert_eq!(
+        one_shot.chain_ref().total_steps(),
+        continuation.total_steps()
+    );
+    assert!(relative_eq!(
+        one_shot.chain_ref().log_prob(),
+        chunked.chain_ref().log_prob(),
+        epsilon = 1e-12,
+    ));
 }


### PR DESCRIPTION
- Add checkpoint accessors on Sampler so callers can inspect or persist continuation state without unwrapping the inner chain.
- Add chunked by-value, in-place, and delayed-commit run helpers that preserve sampler counters and RNG streams across repeated chunks.
- Document chunked sampling as the ergonomic path for workflows that choose each next step budget from the updated state.

Closes #60