### PR TITLE
feat!: expose delayed-step outcome telemetry (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Document delayed valid-site multiplicities and expose the ratio helper through the public API and scoped preludes.
   - Validate DetailedBalanceConfig at construction so detailed-balance checks operate on accepted configuration values.
   - Add validator property tests and document the repository convention for proptest integration files.
+- Expose resumable chunked runs [#60](https://github.com/acgetchell/markov-chain-monte-carlo/pull/60) [#76](https://github.com/acgetchell/markov-chain-monte-carlo/pull/76) [`bbcad08`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/bbcad08c22216c4738227f8ae802495e8024796a)
+
+  - Add checkpoint accessors on Sampler so callers can inspect or persist continuation state without unwrapping the inner chain.
+  - Add chunked by-value, in-place, and delayed-commit run helpers that preserve sampler counters and RNG streams across repeated chunks.
+  - Document chunked sampling as the ergonomic path for workflows that choose each next step budget from the updated state.
+
+### Changed
+
+- [**breaking**] Enforce parse-don't-validate invariants [#75](https://github.com/acgetchell/markov-chain-monte-carlo/pull/75) [`85ee3e0`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/85ee3e036197b6ced9f7559cc394909a7949b4d5)
+
+  - Require OnlineStats and BinningAnalysis to ingest raw f64 samples through fallible APIs, with private finite-sample evidence carried through accumulator internals.
+  - Store nonzero detailed-balance and proposal-ratio counts as refined types so zero is rejected at construction instead of rechecked downstream.
+  - Add Semgrep guardrails for unchecked APIs, infallible statistics ingestion, raw invariant fields, and public unit validators.
+  - Refresh docs, property tests, and crate metadata for the stricter public API surface.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ fn main() -> Result<(), McmcError> {
 - Use `DelayedProposal` and `Chain::step_delayed` when you need to plan and score a concrete move before mutating state.
 - Use `DelayedStep` telemetry, `StepOutcome`, and `DelayedProposal::no_plan_info` when delayed proposals need domain-specific per-step records.
 - Use `Sampler` when you want ergonomic repeated runs, resumable chunks, iterator-based sampling, or observing helpers.
+- Use `Sampler::run_delayed_chunk_observing` to record per-step delayed telemetry and post-step state while resuming chunked runs from a `ChainCheckpoint`.
 - Use `verify_detailed_balance*` helpers in proposal tests for representative discrete transitions.
 - Use `OnlineStats` and `BinningAnalysis` when long runs should stream statistics instead of retaining every sample.
 
@@ -144,6 +145,8 @@ Complete runnable examples live in [`examples/`](https://github.com/acgetchell/m
 - [`examples/iterator_sampling.rs`](https://github.com/acgetchell/markov-chain-monte-carlo/blob/main/examples/iterator_sampling.rs) — `Sampler` as an iterator
 - [`examples/detailed_balance.rs`](https://github.com/acgetchell/markov-chain-monte-carlo/blob/main/examples/detailed_balance.rs) — by-value, in-place, delayed,
   and batch detailed-balance checks
+- [`examples/delayed_chunked_telemetry.rs`](https://github.com/acgetchell/markov-chain-monte-carlo/blob/main/examples/delayed_chunked_telemetry.rs) — per-step
+  delayed telemetry and post-step state recorded across resumable chunks
 
 Run them with:
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ fn main() -> Result<(), McmcError> {
 - Start with `Proposal` and `Chain::step` when state cloning is cheap.
 - Use `ProposalMut` and `Chain::step_mut` when cloning state is expensive and rollback is simple.
 - Use `DelayedProposal` and `Chain::step_delayed` when you need to plan and score a concrete move before mutating state.
+- Use `DelayedStep` telemetry, `StepOutcome`, and `DelayedProposal::no_plan_info` when delayed proposals need domain-specific per-step records.
 - Use `Sampler` when you want ergonomic repeated runs, resumable chunks, iterator-based sampling, or observing helpers.
 - Use `verify_detailed_balance*` helpers in proposal tests for representative discrete transitions.
 - Use `OnlineStats` and `BinningAnalysis` when long runs should stream statistics instead of retaining every sample.

--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -226,7 +226,7 @@ fn bench_delayed_steps(c: &mut Criterion) {
 
         b.iter(|| {
             let step = chain.step_delayed(&flat, &mut proposal, &mut rng).unwrap();
-            black_box(step.accepted);
+            black_box(step.outcome.is_accepted());
             black_box(chain.state().0);
         });
     });
@@ -240,7 +240,7 @@ fn bench_delayed_steps(c: &mut Criterion) {
             let step = chain
                 .step_delayed(&normal, &mut proposal, &mut rng)
                 .unwrap();
-            black_box(step.accepted);
+            black_box(step.outcome.is_accepted());
             black_box(chain.state().0);
         });
     });
@@ -254,7 +254,7 @@ fn bench_delayed_steps(c: &mut Criterion) {
             let step = chain
                 .step_delayed(&normal, &mut proposal, &mut rng)
                 .unwrap();
-            black_box(step.proposed);
+            black_box(step.outcome.has_proposal());
             black_box(chain.rejected());
         });
     });

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -58,6 +58,7 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 │   └── scientific_basis.md
 ├── dprint.json
 ├── examples/
+│   ├── delayed_chunked_telemetry.rs
 │   ├── detailed_balance.rs
 │   ├── ising_1d.rs
 │   ├── iterator_sampling.rs
@@ -221,6 +222,7 @@ New examples go in `examples/`. Each is a complete, runnable workflow:
 - `examples/normal_1d.rs` — simple by-value random-walk sampler.
 - `examples/ising_1d.rs` — in-place mutation with rollback.
 - `examples/iterator_sampling.rs` — by-value `Sampler` iterator API.
+- `examples/delayed_chunked_telemetry.rs` — delayed-step telemetry and post-step state recorded across resumable chunks.
 
 Keep examples deterministic when possible. The `validate-examples` recipe checks for expected output markers, so example output should remain stable enough for
 CI validation.

--- a/examples/delayed_chunked_telemetry.rs
+++ b/examples/delayed_chunked_telemetry.rs
@@ -1,0 +1,182 @@
+//! Record delayed-step telemetry across resumable chunks.
+//!
+//! Demonstrates [`Sampler::run_delayed_chunk_observing`], which composes the
+//! resumable continuation of [`Sampler::run_delayed_chunk`] with per-step
+//! [`DelayedStep`] telemetry. For every step the observer receives the selected
+//! move family ([`DelayedStep::info`]), the rejection reason
+//! ([`DelayedStep::rejection_reason`]), and the post-step chain state, while the
+//! sampler keeps ownership of the Metropolis-Hastings accept/reject draw and the
+//! chain counters. Each chunk returns a [`ChainCheckpoint`] used to resume the
+//! next chunk.
+//!
+//! This mirrors how a downstream crate (for example, CDT physics) can keep
+//! domain-specific statistics outside the generic sampler.
+//!
+//! Run with: `cargo run --example delayed_chunked_telemetry`
+
+use core::convert::Infallible;
+
+use markov_chain_monte_carlo::prelude::delayed::*;
+use rand::rngs::StdRng;
+use rand::{Rng, RngExt, SeedableRng};
+
+// --- Move family recorded as per-step telemetry ---
+
+#[derive(Clone, Copy, Debug)]
+enum Move {
+    Up,
+    Down,
+}
+
+// --- Target: mild bell centered on zero over an integer lattice ---
+
+struct Centered;
+impl Target<i32> for Centered {
+    fn log_prob(&self, state: &i32) -> f64 {
+        let coordinate = f64::from(*state);
+        -0.5 * 0.1 * coordinate * coordinate
+    }
+}
+
+// --- Delayed proposal: a bounded +/-1 walk that reports its move family ---
+//
+// When the drawn direction would leave the bounded region there is no valid
+// site, so `propose_plan` returns `Ok(None)`. The chosen family is still
+// reported through `no_plan_info`, so no-site self-loops carry telemetry too.
+
+const LATTICE_BOUND: u32 = 5;
+
+struct BoundedWalk {
+    last_family: Option<Move>,
+}
+
+impl DelayedProposal<i32> for BoundedWalk {
+    type Plan = i32;
+    type Info = Move;
+    type Error = Infallible;
+
+    fn propose_plan<R: Rng + ?Sized>(
+        &mut self,
+        state: &i32,
+        rng: &mut R,
+    ) -> Result<Option<i32>, Infallible> {
+        let up = rng.random_range(0..2) == 0;
+        let (family, delta) = if up { (Move::Up, 1) } else { (Move::Down, -1) };
+        self.last_family = Some(family);
+
+        if (state + delta).unsigned_abs() > LATTICE_BOUND {
+            // No valid site in this direction; telemetry still records the family.
+            Ok(None)
+        } else {
+            Ok(Some(delta))
+        }
+    }
+
+    fn no_plan_info(&mut self) -> Option<Move> {
+        self.last_family.take()
+    }
+
+    fn proposed_log_prob<T: Target<i32>>(
+        &self,
+        state: &i32,
+        plan: &i32,
+        target: &T,
+    ) -> Result<f64, Infallible> {
+        Ok(target.log_prob(&(state + plan)))
+    }
+
+    fn info(&self, plan: &i32) -> Move {
+        if *plan > 0 { Move::Up } else { Move::Down }
+    }
+
+    fn commit<R: Rng + ?Sized>(
+        &mut self,
+        state: &mut i32,
+        plan: i32,
+        _: &mut R,
+    ) -> Result<(), Infallible> {
+        *state += plan;
+        Ok(())
+    }
+}
+
+fn main() -> Result<(), DelayedStepError<Infallible>> {
+    let seed = 42;
+    let chunk_len = 200;
+    let chunks = 3;
+
+    let mut rng = StdRng::seed_from_u64(seed);
+    let target = Centered;
+    let mut proposal = BoundedWalk { last_family: None };
+    let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
+    let mut sampler =
+        Sampler::new(chain, &target, &mut proposal, &mut rng).map_err(DelayedStepError::Mcmc)?;
+
+    println!("Delayed chunked telemetry (seed={seed})");
+
+    // Domain-specific statistics kept outside the generic sampler.
+    let mut up = 0_u64;
+    let mut down = 0_u64;
+    let mut accepted = 0_u64;
+    let mut rejected = 0_u64;
+    let mut rejected_mh = 0_u64;
+    let mut no_site = 0_u64;
+    let mut state_sum = 0.0_f64;
+    let mut observed = 0.0_f64;
+
+    for chunk in 1..=chunks {
+        let continuation = sampler.run_delayed_chunk_observing(chunk_len, |step, state| {
+            // Selected family is available for every step, including no-site loops.
+            if let Some(family) = step.info {
+                match family {
+                    Move::Up => up += 1,
+                    Move::Down => down += 1,
+                }
+            }
+
+            // The sampler owns the accept/reject draw; we only classify the
+            // recorded outcome. `rejection_reason` is non-exhaustive, so the
+            // breakdown keeps a wildcard arm for forward compatibility.
+            if step.outcome.is_accepted() {
+                accepted += 1;
+            } else {
+                rejected += 1;
+                match step.rejection_reason() {
+                    Some(StepRejectionReason::RejectedProposal) => rejected_mh += 1,
+                    Some(StepRejectionReason::NoProposal) => no_site += 1,
+                    _ => {}
+                }
+            }
+
+            // Post-step measurement read from the state the sampler still owns.
+            state_sum += f64::from(*state);
+            observed += 1.0;
+        })?;
+
+        println!(
+            "  chunk {chunk}: total steps {}, state {}",
+            continuation.total_steps(),
+            **continuation.state()
+        );
+    }
+
+    // Every step carries a family and is classified as accepted or rejected.
+    assert_eq!(up + down, accepted + rejected);
+
+    let mean_state = if observed > 0.0 {
+        state_sum / observed
+    } else {
+        0.0
+    };
+
+    println!("\nPer-step telemetry across {} steps:", accepted + rejected);
+    println!("  Up proposals:       {up}");
+    println!("  Down proposals:     {down}");
+    println!("  Accepted:           {accepted}");
+    println!("  MH rejections:      {rejected_mh}");
+    println!("  No-site self-loops: {no_site}");
+    println!("  Mean state:         {mean_state:+.4}");
+    println!("Delayed chunked telemetry complete");
+
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ rumdl_version := "0.2.3"
 taplo_version := "0.10.0"
 typos_version := "1.46.3"
 zizmor_version := "1.25.2"
-example_names := "detailed_balance normal_1d ising_1d iterator_sampling"
+example_names := "detailed_balance normal_1d ising_1d iterator_sampling delayed_chunked_telemetry"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes examples from reports while allowing tests to exercise library code.
@@ -669,6 +669,7 @@ validate-examples: _build-examples
     validate_example normal_1d "Sample mean" "Acceptance rate"
     validate_example ising_1d "<m>" "acceptance rate"
     validate_example iterator_sampling "Sample mean" "Acceptance rate"
+    validate_example delayed_chunked_telemetry "Per-step telemetry" "Delayed chunked telemetry complete"
 
 validate-json: _ensure-jq
     #!/usr/bin/env bash

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -98,11 +98,9 @@ fn check_committed_log_prob(scored: f64, committed: f64) -> Result<(), McmcError
 #[non_exhaustive]
 #[must_use]
 pub struct Step<I> {
-    /// Whether the move was accepted and committed.
-    pub accepted: bool,
-    /// Whether a proposal was produced.
-    pub proposed: bool,
-    /// Proposal-specific metadata, when a proposal was produced.
+    /// Step outcome encoded as a single invariant-bearing value.
+    pub outcome: StepOutcome,
+    /// Proposal-specific metadata for the concrete proposal or no-plan outcome.
     pub info: Option<I>,
     /// Cached log-probability before the step.
     pub log_prob_before: f64,
@@ -110,6 +108,187 @@ pub struct Step<I> {
     pub log_prob_after: Option<f64>,
     /// Metropolis-Hastings log acceptance ratio, when one was evaluated.
     pub log_alpha: Option<f64>,
+}
+
+impl<I> Step<I> {
+    /// Build telemetry for a no-proposal self-loop.
+    ///
+    /// This keeps the [`Step`] field-level contract synchronized whenever a
+    /// delayed proposal returns `Ok(None)`.
+    pub(crate) const fn no_proposal(info: Option<I>, log_prob_before: f64) -> Self {
+        Self {
+            outcome: StepOutcome::NoProposal,
+            info,
+            log_prob_before,
+            log_prob_after: None,
+            log_alpha: None,
+        }
+    }
+
+    /// Build telemetry for an accepted concrete proposal.
+    ///
+    /// This records the accepted outcome together with the post-commit
+    /// log-probability used by the chain cache.
+    pub(crate) const fn accepted_proposal(
+        info: I,
+        log_prob_before: f64,
+        log_prob_after: f64,
+        log_alpha: f64,
+    ) -> Self {
+        Self {
+            outcome: StepOutcome::Accepted,
+            info: Some(info),
+            log_prob_before,
+            log_prob_after: Some(log_prob_after),
+            log_alpha: Some(log_alpha),
+        }
+    }
+
+    /// Build telemetry for a concrete proposal rejected by the M-H draw.
+    ///
+    /// Rejected proposals leave the cached log-probability unchanged while
+    /// preserving the evaluated log-acceptance ratio for diagnostics.
+    pub(crate) const fn rejected_proposal(info: I, log_prob_before: f64, log_alpha: f64) -> Self {
+        Self {
+            outcome: StepOutcome::RejectedProposal,
+            info: Some(info),
+            log_prob_before,
+            log_prob_after: None,
+            log_alpha: Some(log_alpha),
+        }
+    }
+
+    /// Why a step was rejected, or `None` when it was accepted.
+    ///
+    /// This helper distinguishes proposal absence from a concrete proposal
+    /// rejected by the Metropolis-Hastings accept/reject draw.
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct Flat;
+    /// impl Target<()> for Flat {
+    ///     fn log_prob(&self, _: &()) -> f64 { 0.0 }
+    /// }
+    ///
+    /// struct NoMove;
+    /// impl DelayedProposal<()> for NoMove {
+    ///     type Plan = ();
+    ///     type Info = ();
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _: &(),
+    ///         _: &mut R,
+    ///     ) -> Result<Option<()>, Self::Error> {
+    ///         Ok(None)
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<()>>(
+    ///         &self,
+    ///         _: &(),
+    ///         _: &(),
+    ///         _: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         unreachable!("no plan should not be scored")
+    ///     }
+    ///
+    ///     fn info(&self, _: &()) {}
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _: &mut (),
+    ///         _: (),
+    ///         _: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         unreachable!("no plan should not be committed")
+    ///     }
+    /// }
+    ///
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let mut proposal = NoMove;
+    /// let mut chain = Chain::new((), &Flat).map_err(DelayedStepError::Mcmc)?;
+    /// let step = chain.step_delayed(&Flat, &mut proposal, &mut rng)?;
+    ///
+    /// assert_eq!(step.outcome, StepOutcome::NoProposal);
+    /// assert_eq!(step.rejection_reason(), Some(StepRejectionReason::NoProposal));
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    #[must_use]
+    pub const fn rejection_reason(&self) -> Option<StepRejectionReason> {
+        match self.outcome {
+            StepOutcome::Accepted => None,
+            StepOutcome::RejectedProposal => Some(StepRejectionReason::RejectedProposal),
+            StepOutcome::NoProposal => Some(StepRejectionReason::NoProposal),
+        }
+    }
+}
+
+/// Outcome of a completed Metropolis-Hastings step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+#[must_use]
+pub enum StepOutcome {
+    /// A concrete proposal was accepted and committed.
+    Accepted,
+    /// A concrete proposal was produced and then rejected by the
+    /// Metropolis-Hastings acceptance draw.
+    RejectedProposal,
+    /// No concrete proposal was available, so the step was an ordinary
+    /// self-loop without a Metropolis-Hastings acceptance draw.
+    NoProposal,
+}
+
+impl StepOutcome {
+    /// Whether this outcome accepted and committed a concrete proposal.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::StepOutcome;
+    ///
+    /// assert!(StepOutcome::Accepted.is_accepted());
+    /// assert!(!StepOutcome::RejectedProposal.is_accepted());
+    /// assert!(!StepOutcome::NoProposal.is_accepted());
+    /// ```
+    #[must_use]
+    pub const fn is_accepted(self) -> bool {
+        match self {
+            Self::Accepted => true,
+            Self::RejectedProposal | Self::NoProposal => false,
+        }
+    }
+
+    /// Whether this outcome includes a concrete proposal.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::StepOutcome;
+    ///
+    /// assert!(StepOutcome::Accepted.has_proposal());
+    /// assert!(StepOutcome::RejectedProposal.has_proposal());
+    /// assert!(!StepOutcome::NoProposal.has_proposal());
+    /// ```
+    #[must_use]
+    pub const fn has_proposal(self) -> bool {
+        match self {
+            Self::Accepted | Self::RejectedProposal => true,
+            Self::NoProposal => false,
+        }
+    }
+}
+
+/// Reason a completed step was counted as a rejection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+#[must_use]
+pub enum StepRejectionReason {
+    /// No concrete proposal was available, so the step was an ordinary
+    /// self-loop without a Metropolis-Hastings acceptance draw.
+    NoProposal,
+    /// A concrete proposal was produced and then rejected by the
+    /// Metropolis-Hastings acceptance draw.
+    RejectedProposal,
 }
 
 /// Telemetry for a delayed-commit Metropolis-Hastings step.
@@ -622,7 +801,7 @@ impl<S> Chain<S> {
     /// let mut chain = Chain::new(-1, &target)?;
     ///
     /// let step = chain.step_delayed(&target, &mut proposal, &mut rng)?;
-    /// assert!(step.accepted);
+    /// assert_eq!(step.outcome, StepOutcome::Accepted);
     /// assert_eq!(*chain.state(), 0);
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
@@ -646,15 +825,9 @@ impl<S> Chain<S> {
             .propose_plan(&self.state, rng)
             .map_err(DelayedStepError::Plan)?
         else {
+            let info = proposal.no_plan_info();
             self.rejected = self.rejected.saturating_add(1);
-            return Ok(Step {
-                accepted: false,
-                proposed: false,
-                info: None,
-                log_prob_before,
-                log_prob_after: None,
-                log_alpha: None,
-            });
+            return Ok(Step::no_proposal(info, log_prob_before));
         };
 
         let log_prob_new = proposal
@@ -677,24 +850,15 @@ impl<S> Chain<S> {
                 .map_err(DelayedStepError::Commit)?;
             self.log_prob = log_prob_new;
             self.accepted = self.accepted.saturating_add(1);
-            Ok(Step {
-                accepted: true,
-                proposed: true,
-                info: Some(info),
+            Ok(Step::accepted_proposal(
+                info,
                 log_prob_before,
-                log_prob_after: Some(log_prob_new),
-                log_alpha: Some(log_alpha),
-            })
+                log_prob_new,
+                log_alpha,
+            ))
         } else {
             self.rejected = self.rejected.saturating_add(1);
-            Ok(Step {
-                accepted: false,
-                proposed: true,
-                info: Some(info),
-                log_prob_before,
-                log_prob_after: None,
-                log_alpha: Some(log_alpha),
-            })
+            Ok(Step::rejected_proposal(info, log_prob_before, log_alpha))
         }
     }
 
@@ -773,7 +937,7 @@ impl<S> Chain<S> {
     /// let mut chain = Chain::new(-1, &target)?;
     ///
     /// let step = chain.step_delayed_checked(&target, &mut proposal, &mut rng)?;
-    /// assert!(step.accepted);
+    /// assert_eq!(step.outcome, StepOutcome::Accepted);
     /// assert_eq!(*chain.state(), 0);
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
@@ -802,15 +966,9 @@ impl<S> Chain<S> {
             .propose_plan(&self.state, rng)
             .map_err(DelayedStepError::Plan)?
         else {
+            let info = proposal.no_plan_info();
             self.rejected = self.rejected.saturating_add(1);
-            return Ok(Step {
-                accepted: false,
-                proposed: false,
-                info: None,
-                log_prob_before,
-                log_prob_after: None,
-                log_alpha: None,
-            });
+            return Ok(Step::no_proposal(info, log_prob_before));
         };
 
         let log_prob_new = proposal
@@ -842,24 +1000,15 @@ impl<S> Chain<S> {
 
             self.log_prob = committed_log_prob;
             self.accepted = self.accepted.saturating_add(1);
-            Ok(Step {
-                accepted: true,
-                proposed: true,
-                info: Some(info),
+            Ok(Step::accepted_proposal(
+                info,
                 log_prob_before,
-                log_prob_after: Some(committed_log_prob),
-                log_alpha: Some(log_alpha),
-            })
+                committed_log_prob,
+                log_alpha,
+            ))
         } else {
             self.rejected = self.rejected.saturating_add(1);
-            Ok(Step {
-                accepted: false,
-                proposed: true,
-                info: Some(info),
-                log_prob_before,
-                log_prob_after: None,
-                log_alpha: Some(log_alpha),
-            })
+            Ok(Step::rejected_proposal(info, log_prob_before, log_alpha))
         }
     }
 
@@ -2039,6 +2188,56 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum MoveFamily {
+        Add,
+    }
+
+    struct FamilyNoPlanProposal {
+        last_family: Option<MoveFamily>,
+    }
+
+    impl DelayedProposal<MutScalar> for FamilyNoPlanProposal {
+        type Plan = f64;
+        type Info = MoveFamily;
+        type Error = DelayedFixtureError;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            _state: &MutScalar,
+            _rng: &mut R,
+        ) -> Result<Option<f64>, Self::Error> {
+            self.last_family = Some(MoveFamily::Add);
+            Ok(None)
+        }
+
+        fn no_plan_info(&mut self) -> Option<Self::Info> {
+            self.last_family.take()
+        }
+
+        fn proposed_log_prob<T: Target<MutScalar>>(
+            &self,
+            _state: &MutScalar,
+            _plan: &f64,
+            _target: &T,
+        ) -> Result<f64, Self::Error> {
+            unreachable!("no plan should not be scored")
+        }
+
+        fn info(&self, _plan: &f64) -> Self::Info {
+            unreachable!("no plan should not produce plan info")
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            _state: &mut MutScalar,
+            _plan: f64,
+            _rng: &mut R,
+        ) -> Result<(), Self::Error> {
+            unreachable!("no plan should not be committed")
+        }
+    }
+
     struct CheckedCommitProposal {
         scored: f64,
         committed: f64,
@@ -2091,8 +2290,10 @@ mod tests {
             .step_delayed(&Normal, &mut proposal, &mut rng)
             .unwrap();
 
-        assert!(step.accepted);
-        assert!(step.proposed);
+        assert_eq!(step.outcome, StepOutcome::Accepted);
+        assert!(step.outcome.is_accepted());
+        assert!(step.outcome.has_proposal());
+        assert!(step.rejection_reason().is_none());
         assert_eq!(step.info, Some(0.0));
         assert_relative_eq!(step.log_prob_before, -2.0, epsilon = 1e-12);
         assert_eq!(step.log_prob_after, Some(0.0));
@@ -2112,8 +2313,13 @@ mod tests {
             .step_delayed(&Normal, &mut proposal, &mut rng)
             .unwrap();
 
-        assert!(!step.accepted);
-        assert!(step.proposed);
+        assert_eq!(step.outcome, StepOutcome::RejectedProposal);
+        assert!(!step.outcome.is_accepted());
+        assert!(step.outcome.has_proposal());
+        assert_eq!(
+            step.rejection_reason(),
+            Some(StepRejectionReason::RejectedProposal)
+        );
         assert_eq!(step.info, Some(100.0));
         assert_relative_eq!(step.log_prob_before, 0.0);
         assert_eq!(step.log_prob_after, None);
@@ -2134,13 +2340,41 @@ mod tests {
             .step_delayed(&Normal, &mut proposal, &mut rng)
             .unwrap();
 
-        assert!(!step.accepted);
-        assert!(!step.proposed);
+        assert_eq!(step.outcome, StepOutcome::NoProposal);
+        assert!(!step.outcome.is_accepted());
+        assert!(!step.outcome.has_proposal());
+        assert_eq!(
+            step.rejection_reason(),
+            Some(StepRejectionReason::NoProposal)
+        );
         assert_eq!(step.info, None);
         assert_relative_eq!(step.log_prob_before, log_prob);
         assert_eq!(step.log_prob_after, None);
         assert_eq!(step.log_alpha, None);
         assert_eq!(chain.state, MutScalar(1.0));
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 1);
+    }
+
+    #[test]
+    fn delayed_no_plan_can_report_family_info() {
+        let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let mut proposal = FamilyNoPlanProposal { last_family: None };
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let step = chain
+            .step_delayed(&Normal, &mut proposal, &mut rng)
+            .unwrap();
+
+        assert_eq!(step.outcome, StepOutcome::NoProposal);
+        assert!(!step.outcome.is_accepted());
+        assert!(!step.outcome.has_proposal());
+        assert_eq!(
+            step.rejection_reason(),
+            Some(StepRejectionReason::NoProposal)
+        );
+        assert_eq!(step.info, Some(MoveFamily::Add));
+        assert_eq!(proposal.last_family, None);
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 1);
     }
@@ -2443,7 +2677,7 @@ mod tests {
             .step_delayed_checked(&Normal, &mut proposal, &mut rng)
             .unwrap();
 
-        assert!(step.accepted);
+        assert_eq!(step.outcome, StepOutcome::Accepted);
         assert_eq!(chain.state, Scalar(0.0));
         assert_relative_eq!(chain.log_prob(), 0.0);
         assert_eq!(chain.accepted(), 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,12 @@
 //! rejection, while [`DelayedProposal::commit`] errors are reserved for
 //! exceptional failures applying an already accepted concrete move.
 //!
+//! Delayed steps return [`DelayedStep`] telemetry with a [`StepOutcome`].  Use
+//! [`Step::rejection_reason`] when you only need rejected-step categories.
+//! Implement
+//! [`DelayedProposal::no_plan_info`] when a no-plan self-loop should still
+//! report proposal-family metadata.
+//!
 //! Use [`DiscreteProposalRatio`] when a delayed combinatorial proposal chooses
 //! a move family and then samples uniformly among that family's valid concrete
 //! sites.
@@ -294,7 +300,7 @@
 //!     let mut chain = Chain::new(-1, &target).map_err(DelayedStepError::Mcmc)?;
 //!
 //!     let step = chain.step_delayed(&target, &mut proposal, &mut rng)?;
-//!     assert!(step.accepted);
+//!     assert_eq!(step.outcome, StepOutcome::Accepted);
 //!     assert_eq!(*chain.state(), 0);
 //!     Ok(())
 //! }
@@ -417,7 +423,9 @@ mod statistics;
 mod testing;
 mod traits;
 
-pub use chain::{Chain, ChainCheckpoint, DelayedStep, DelayedStepError, Step};
+pub use chain::{
+    Chain, ChainCheckpoint, DelayedStep, DelayedStepError, Step, StepOutcome, StepRejectionReason,
+};
 pub use error::McmcError;
 pub use observable::{
     Observable, ObservedStepError, ObservedStreamError, SampleBuffer, TryAccumulator, TryObservable,
@@ -531,9 +539,9 @@ pub mod prelude {
             DelayedStepError, DiscreteProposalRatio, DiscreteProposalRatioError, McmcError,
             Observable, ObservedDelayedIntoRunResult, ObservedDelayedStep,
             ObservedDelayedStepResult, ObservedStepError, ObservedStreamError, OnlineStats,
-            SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedDelayedIntoRunResult,
-            ThinnedRunResult, ThinningError, TryAccumulator, TryObservable,
-            TryObservedDelayedIntoRunResult, TryThinnedObservedDelayedIntoRunResult,
+            SampleBuffer, Sampler, StatisticsError, StepOutcome, StepRejectionReason, Target,
+            ThinnedObservedDelayedIntoRunResult, ThinnedRunResult, ThinningError, TryAccumulator,
+            TryObservable, TryObservedDelayedIntoRunResult, TryThinnedObservedDelayedIntoRunResult,
             TryThinnedObservedRunResult,
         };
     }
@@ -571,8 +579,8 @@ mod public_api_smoke_tests {
         DetailedBalanceBatchReport, DetailedBalanceConfig, DetailedBalanceDelayedTransition,
         DetailedBalanceDirection, DetailedBalanceError, DetailedBalanceFailure,
         DetailedBalanceReport, DetailedBalanceState, McmcError, Observable, ObservedDelayedStep,
-        OnlineStats, Proposal, ProposalMut, SampleBuffer, Sampler, StatisticsError, Step, Target,
-        ThinningError,
+        OnlineStats, Proposal, ProposalMut, SampleBuffer, Sampler, StatisticsError, Step,
+        StepOutcome, StepRejectionReason, Target, ThinningError,
         prelude::{self, by_value, delayed, in_place, testing},
     };
 
@@ -659,6 +667,8 @@ mod public_api_smoke_tests {
         let _: Option<ChainCheckpoint<f64>> = None;
         let _: Option<Step<()>> = None;
         let _: Option<DelayedStep<()>> = None;
+        let _: Option<StepOutcome> = None;
+        let _: Option<StepRejectionReason> = None;
         let _: Option<McmcError> = None;
         let _: Option<SampleBuffer<f64>> = None;
         let _: Option<Sampler<'_, f64, Smoke, Smoke, StdRng>> = None;
@@ -688,6 +698,8 @@ mod public_api_smoke_tests {
         > = None;
         let _: Option<delayed::DiscreteProposalRatio> = None;
         let _: Option<delayed::DiscreteProposalRatioError> = None;
+        let _: Option<delayed::StepOutcome> = None;
+        let _: Option<delayed::StepRejectionReason> = None;
         let _: Option<delayed::ThinnedObservedDelayedIntoRunResult<Infallible, Infallible>> = None;
         let _: Option<delayed::McmcError> = None;
         let _: Option<testing::DetailedBalanceConfig> = None;

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -2308,6 +2308,117 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
         Ok(self.checkpoint())
     }
 
+    /// Run a resumable delayed-commit chunk, observing every step's telemetry.
+    ///
+    /// This composes the resumable continuation of
+    /// [`run_delayed_chunk`](Self::run_delayed_chunk) with per-step
+    /// [`DelayedStep`] telemetry.  After each completed step, `on_step` is
+    /// invoked with the [`DelayedStep`] for that step — exposing its
+    /// [`StepOutcome`](crate::StepOutcome), proposal
+    /// [`info`](DelayedStep::info), and
+    /// [`rejection_reason`](DelayedStep::rejection_reason) — together with the
+    /// chain state *after* the step.  A downstream caller can therefore record
+    /// the selected proposal family, the rejection reason for every step, and
+    /// post-step measurements without re-implementing Metropolis-Hastings
+    /// acceptance: the chain retains ownership of the accept/reject draw and
+    /// counters.
+    ///
+    /// Like [`run_delayed_chunk`](Self::run_delayed_chunk), repeated chunks on
+    /// the same sampler preserve the chain counters and RNG stream exactly as a
+    /// one-shot run with the same total number of steps, and the returned
+    /// [`ChainCheckpoint`] resumes the next chunk.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// struct Flat;
+    /// impl Target<i32> for Flat {
+    ///     fn log_prob(&self, _: &i32) -> f64 { 0.0 }
+    /// }
+    ///
+    /// struct Increment;
+    /// impl DelayedProposal<i32> for Increment {
+    ///     type Plan = i32;
+    ///     type Info = i32;
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _: &i32,
+    ///         _: &mut R,
+    ///     ) -> Result<Option<i32>, Self::Error> {
+    ///         Ok(Some(1))
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<i32>>(
+    ///         &self,
+    ///         state: &i32,
+    ///         plan: &i32,
+    ///         target: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         Ok(target.log_prob(&(*state + *plan)))
+    ///     }
+    ///
+    ///     fn info(&self, plan: &i32) -> i32 {
+    ///         *plan
+    ///     }
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         state: &mut i32,
+    ///         plan: i32,
+    ///         _: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         *state += plan;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let target = Flat;
+    /// let mut proposal = Increment;
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    ///
+    /// // Record the selected family and post-step state for every step while
+    /// // the sampler owns acceptance, then resume from the continuation.
+    /// let mut families = Vec::new();
+    /// let continuation = sampler.run_delayed_chunk_observing(3, |step, state| {
+    ///     assert!(step.rejection_reason().is_none());
+    ///     if let Some(family) = step.info {
+    ///         families.push((family, *state));
+    ///     }
+    /// })?;
+    ///
+    /// assert_eq!(families, vec![(1, 1), (1, 2), (1, 3)]);
+    /// assert_eq!(**continuation.state(), 3);
+    /// assert_eq!(continuation.total_steps(), 3);
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`run_delayed`](Self::run_delayed):
+    /// [`DelayedStepError`] when delayed proposal planning, proposed-state
+    /// scoring, proposal-ratio evaluation, Metropolis-Hastings numeric
+    /// validation, or accepted-move commit fails.  On error the chunk stops at
+    /// the failing step and no continuation is returned.
+    pub fn run_delayed_chunk_observing(
+        &mut self,
+        steps: usize,
+        mut on_step: impl FnMut(&DelayedStep<P::Info>, &S),
+    ) -> Result<ChainCheckpoint<&S>, DelayedStepError<P::Error>> {
+        for _ in 0..steps {
+            let step = self.step_delayed()?;
+            on_step(&step, self.chain.state());
+        }
+        Ok(self.checkpoint())
+    }
+
     /// Run delayed-commit steps and collect cloned states every `thin_interval` steps.
     ///
     /// States are cloned after completed steps whose 1-based step number is
@@ -4097,6 +4208,67 @@ mod tests {
     }
 
     #[test]
+    fn run_delayed_chunk_observing_surfaces_telemetry_and_resumes() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = DelayedToZero;
+        let mut sampler = sampler!(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+
+        let mut outcomes = Vec::new();
+        let mut families = Vec::new();
+        let mut observed_states = Vec::new();
+        let continuation = sampler
+            .run_delayed_chunk_observing(3, |step, state| {
+                outcomes.push(step.outcome);
+                assert!(step.rejection_reason().is_none());
+                if let Some(family) = step.info {
+                    families.push(family);
+                }
+                observed_states.push(state.0);
+            })
+            .unwrap();
+
+        assert_eq!(
+            outcomes,
+            vec![
+                StepOutcome::Accepted,
+                StepOutcome::Accepted,
+                StepOutcome::Accepted,
+            ]
+        );
+        assert_eq!(families.len(), 3);
+        for family in families {
+            assert_relative_eq!(family, 0.0);
+        }
+        assert_eq!(observed_states.len(), 3);
+        for coordinate in observed_states {
+            assert_relative_eq!(coordinate, 0.0);
+        }
+        assert_eq!(continuation.state(), &&Scalar(0.0));
+        assert_eq!(continuation.total_steps(), 3);
+    }
+
+    #[test]
+    fn run_delayed_chunk_observing_resumes_across_chunks() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = DelayedToZero;
+        let mut sampler = sampler!(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
+
+        let mut observed = 0_usize;
+        let first = sampler
+            .run_delayed_chunk_observing(2, |_step, _state| observed += 1)
+            .unwrap();
+        assert_eq!(first.total_steps(), 2);
+
+        let second = sampler
+            .run_delayed_chunk_observing(3, |_step, _state| observed += 1)
+            .unwrap();
+
+        assert_eq!(observed, 5);
+        assert_eq!(second.total_steps(), 5);
+        assert_eq!(second.state(), &&Scalar(0.0));
+    }
+
+    #[test]
     fn run_delayed_with_thinning_collects_every_kth_state() {
         let mut rng = StdRng::seed_from_u64(42);
         let mut proposal = DelayedToZero;
@@ -4405,6 +4577,27 @@ mod tests {
             result,
             Err(DelayedStepError::Plan(DelayedRunError::PlannedStop))
         );
+        assert_eq!(sampler.chain_ref().state(), &MutScalar(0.0));
+        assert_eq!(sampler.chain_ref().total_steps(), 1);
+    }
+
+    #[test]
+    fn run_delayed_chunk_observing_stops_on_first_error() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
+        let mut proposal = StopAfterFirstDelayed { calls: 0 };
+        let mut sampler = sampler!(chain, &Normal, &mut proposal, &mut rng);
+        let mut observed = Vec::new();
+
+        let result = sampler.run_delayed_chunk_observing(3, |step, state| {
+            observed.push((step.outcome, step.info, state.0));
+        });
+
+        assert_matches!(
+            result,
+            Err(DelayedStepError::Plan(DelayedRunError::PlannedStop))
+        );
+        assert_eq!(observed, vec![(StepOutcome::Accepted, Some(0.0), 0.0)]);
         assert_eq!(sampler.chain_ref().state(), &MutScalar(0.0));
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -2058,7 +2058,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     ///
     /// let step = sampler.step_delayed()?;
-    /// assert!(step.accepted);
+    /// assert_eq!(step.outcome, StepOutcome::Accepted);
     /// assert_eq!(*sampler.chain_ref().state(), 0);
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
@@ -2137,7 +2137,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
     ///
     /// let step = sampler.step_delayed_checked()?;
-    /// assert!(step.accepted);
+    /// assert_eq!(step.outcome, StepOutcome::Accepted);
     /// assert_eq!(*sampler.chain_ref().state(), 0);
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
@@ -3057,7 +3057,7 @@ mod tests {
     use rand::{RngExt, SeedableRng, rngs::StdRng};
 
     use super::*;
-    use crate::{BinningAnalysis, OnlineStats, StatisticsError};
+    use crate::{BinningAnalysis, OnlineStats, StatisticsError, StepOutcome};
 
     // --- Shared fixtures ---
 
@@ -4078,7 +4078,7 @@ mod tests {
 
         let step = sampler.step_delayed().unwrap();
 
-        assert!(step.accepted);
+        assert_eq!(step.outcome, StepOutcome::Accepted);
         assert_eq!(sampler.chain_ref().state(), &MutScalar(0.0));
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -456,6 +456,11 @@ impl<S, P: ProposalMut<S> + ?Sized> ProposalMut<S> for &mut P {
 /// delta is cheap to compute from a concrete move descriptor.  If `commit`
 /// returns an error, it must be failure-atomic: either the accepted move is
 /// applied completely, or `state` is restored before returning `Err`.
+///
+/// Implement [`no_plan_info`](Self::no_plan_info) when planning may select a
+/// move family before discovering that no concrete site exists.  [`crate::Chain`]
+/// stores that metadata in [`crate::DelayedStep::info`] even though the step is
+/// counted as a rejection with no proposal.
 pub trait DelayedProposal<S> {
     /// Concrete move descriptor produced before the Metropolis-Hastings decision.
     type Plan;
@@ -479,6 +484,90 @@ pub trait DelayedProposal<S> {
         state: &S,
         rng: &mut R,
     ) -> Result<Option<Self::Plan>, Self::Error>;
+
+    /// Produce telemetry metadata for an `Ok(None)` planning result.
+    ///
+    /// The default returns no metadata.  Implementations that choose a move
+    /// family before discovering that no valid concrete site exists can store
+    /// that choice during [`propose_plan`](Self::propose_plan) and return it
+    /// here.  The value is attached to the resulting [`crate::DelayedStep`]
+    /// with [`crate::StepOutcome::NoProposal`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use core::convert::Infallible;
+    /// use markov_chain_monte_carlo::prelude::delayed::*;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// enum MoveFamily {
+    ///     Add,
+    /// }
+    ///
+    /// struct Flat;
+    /// impl Target<()> for Flat {
+    ///     fn log_prob(&self, _: &()) -> f64 { 0.0 }
+    /// }
+    ///
+    /// struct NoAddSite {
+    ///     last_family: Option<MoveFamily>,
+    /// }
+    ///
+    /// impl DelayedProposal<()> for NoAddSite {
+    ///     type Plan = ();
+    ///     type Info = MoveFamily;
+    ///     type Error = Infallible;
+    ///
+    ///     fn propose_plan<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _: &(),
+    ///         _: &mut R,
+    ///     ) -> Result<Option<()>, Self::Error> {
+    ///         self.last_family = Some(MoveFamily::Add);
+    ///         Ok(None)
+    ///     }
+    ///
+    ///     fn no_plan_info(&mut self) -> Option<Self::Info> {
+    ///         self.last_family.take()
+    ///     }
+    ///
+    ///     fn proposed_log_prob<T: Target<()>>(
+    ///         &self,
+    ///         _: &(),
+    ///         _: &(),
+    ///         _: &T,
+    ///     ) -> Result<f64, Self::Error> {
+    ///         unreachable!("no plan should not be scored")
+    ///     }
+    ///
+    ///     fn info(&self, _: &()) -> MoveFamily {
+    ///         MoveFamily::Add
+    ///     }
+    ///
+    ///     fn commit<R: Rng + ?Sized>(
+    ///         &mut self,
+    ///         _: &mut (),
+    ///         _: (),
+    ///         _: &mut R,
+    ///     ) -> Result<(), Self::Error> {
+    ///         unreachable!("no plan should not be committed")
+    ///     }
+    /// }
+    ///
+    /// let mut proposal = NoAddSite { last_family: None };
+    /// let mut rng = StdRng::seed_from_u64(42);
+    /// let mut chain = Chain::new((), &Flat).map_err(DelayedStepError::Mcmc)?;
+    ///
+    /// let step = chain.step_delayed(&Flat, &mut proposal, &mut rng)?;
+    ///
+    /// assert_eq!(step.outcome, StepOutcome::NoProposal);
+    /// assert_eq!(step.info, Some(MoveFamily::Add));
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
+    /// ```
+    fn no_plan_info(&mut self) -> Option<Self::Info> {
+        None
+    }
 
     /// Compute the concrete proposed state's log-probability without mutating
     /// `state`.
@@ -556,6 +645,10 @@ impl<S, P: DelayedProposal<S> + ?Sized> DelayedProposal<S> for &mut P {
         rng: &mut R,
     ) -> Result<Option<Self::Plan>, Self::Error> {
         (**self).propose_plan(state, rng)
+    }
+
+    fn no_plan_info(&mut self) -> Option<Self::Info> {
+        (**self).no_plan_info()
     }
 
     fn proposed_log_prob<T: Target<S>>(


### PR DESCRIPTION
- Replace delayed-step accepted/proposed booleans with StepOutcome so step state is represented by one invariant-bearing value.
- Add StepRejectionReason and DelayedProposal::no_plan_info for no-plan delayed steps that still need domain-specific telemetry.
- Re-export delayed telemetry through the root API and delayed prelude, and update docs and benchmarks to use outcome-based access.

BREAKING CHANGE: DelayedStep/Step no longer expose accepted or proposed fields; use step.outcome plus StepOutcome::is_accepted or StepOutcome::has_proposal instead.