### PR TITLE
feat: add additive target composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Use this crate when you want:
 - a generic Metropolis-Hastings chain over user-defined state spaces
 - by-value, in-place, and delayed-commit proposal APIs
 - log-space acceptance calculations with NaN/+infinity checks
+- additive target composition for bias potentials, energy terms, learned regularizers, and other log-weight modifiers
 - observable measurement APIs, streaming statistics, and binning error estimates
 - thinning helpers for long sampler runs
 - optional `serde` checkpointing with validated resume flows
@@ -40,6 +41,7 @@ responsibilities.
 
 - Generic `Chain<S>` over user-defined state spaces with explicit accepted/rejected counters.
 - Log-space Metropolis-Hastings acceptance with typed errors for NaN and positive-infinite target or proposal values.
+- `AdditiveTarget` for composing model and bias log-weight terms without mixing them into proposal-ratio corrections.
 - Three proposal workflows: by-value `Proposal`, rollback-safe in-place `ProposalMut`, and delayed-commit `DelayedProposal`.
 - `Sampler` helpers for repeated and chunked runs, iterator-style sampling, thinning, observations, and counter resets after burn-in.
 - Streaming `OnlineStats` and `BinningAnalysis` for long correlated runs without retaining every sample.
@@ -124,6 +126,7 @@ fn main() -> Result<(), McmcError> {
 - Start with `Proposal` and `Chain::step` when state cloning is cheap.
 - Use `ProposalMut` and `Chain::step_mut` when cloning state is expensive and rollback is simple.
 - Use `DelayedProposal` and `Chain::step_delayed` when you need to plan and score a concrete move before mutating state.
+- Use `AdditiveTarget` when the target log weight is the sum of model, bias, regularization, energy, or action terms.
 - Use `DelayedStep` telemetry, `StepOutcome`, and `DelayedProposal::no_plan_info` when delayed proposals need domain-specific per-step records.
 - Use `Sampler` when you want ergonomic repeated runs, resumable chunks, iterator-based sampling, or observing helpers.
 - Use `Sampler::run_delayed_chunk_observing` to record per-step delayed telemetry and post-step state while resuming chunked runs from a `ChainCheckpoint`.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Complete runnable examples live in [`examples/`](https://github.com/acgetchell/m
   and batch detailed-balance checks
 - [`examples/delayed_chunked_telemetry.rs`](https://github.com/acgetchell/markov-chain-monte-carlo/blob/main/examples/delayed_chunked_telemetry.rs) — per-step
   delayed telemetry and post-step state recorded across resumable chunks
+- [`examples/additive_target_bias.rs`](https://github.com/acgetchell/markov-chain-monte-carlo/blob/main/examples/additive_target_bias.rs) — model and bias
+  log-weight terms composed with `AdditiveTarget`
 
 Run them with:
 

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -58,6 +58,7 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 │   └── scientific_basis.md
 ├── dprint.json
 ├── examples/
+│   ├── additive_target_bias.rs
 │   ├── delayed_chunked_telemetry.rs
 │   ├── detailed_balance.rs
 │   ├── ising_1d.rs
@@ -218,6 +219,7 @@ sampling imports.
 
 New examples go in `examples/`. Each is a complete, runnable workflow:
 
+- `examples/additive_target_bias.rs` — additive model and bias log-weight composition with `AdditiveTarget`.
 - `examples/detailed_balance.rs` — by-value, in-place, delayed, and batch detailed-balance checks.
 - `examples/normal_1d.rs` — simple by-value random-walk sampler.
 - `examples/ising_1d.rs` — in-place mutation with rollback.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,6 +34,11 @@ MSRV/toolchain refresh.
 - [#48](https://github.com/acgetchell/markov-chain-monte-carlo/issues/48) - Investigate detailed balance for delayed proposals with variable valid-site counts
 - [#62](https://github.com/acgetchell/markov-chain-monte-carlo/issues/62) - Clean up doctest/example unwraps and enforce with Semgrep
 
+Resumable chunked runs shipped as `Sampler::run_chunk`, `run_mut_chunk`, and `run_delayed_chunk`, each returning a checkpoint-compatible continuation, plus
+`run_delayed_chunk_observing` for per-step delayed telemetry. A combined `(measurements, continuation)` return shape is intentionally deferred: callers keep
+measurements in their own buffers and accumulate across chunks today. Revisit the combined shape once `causal-triangulations` integrates against v0.4.0 and
+shows whether the callback-plus-continuation composition is sufficient in practice.
+
 ### v0.5.0 Adaptive Diagnostics
 
 After the CDT-facing continuation and acceptance APIs settle, invest in classical adaptive sampling and diagnostics that help users decide whether a run is

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,7 +30,7 @@ MSRV/toolchain refresh.
 - [#65](https://github.com/acgetchell/markov-chain-monte-carlo/issues/65) - Update Rust toolchain and MSRV to 1.96.0
 - [x] [#60](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60) - Expose resumable sampler state for chunked runs
 - [#61](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61) - Expose delayed-step hooks or telemetry for domain-specific sampler integration
-- [#59](https://github.com/acgetchell/markov-chain-monte-carlo/issues/59) - Support additive target bias terms in Metropolis-Hastings acceptance
+- [x] [#59](https://github.com/acgetchell/markov-chain-monte-carlo/issues/59) - Support additive target bias terms in Metropolis-Hastings acceptance
 - [#48](https://github.com/acgetchell/markov-chain-monte-carlo/issues/48) - Investigate detailed balance for delayed proposals with variable valid-site counts
 - [#62](https://github.com/acgetchell/markov-chain-monte-carlo/issues/62) - Clean up doctest/example unwraps and enforce with Semgrep
 

--- a/docs/scientific_basis.md
+++ b/docs/scientific_basis.md
@@ -22,6 +22,34 @@ log proposal ratio through:
 These ratios must describe the same concrete transition that was proposed. For combinatorial systems, this usually means accounting for move-kind probabilities,
 site counts, reverse-site counts, and invalid-move handling.
 
+## Additive Target Terms
+
+Bias potentials, energy-based model terms, learned regularizers, umbrella-sampling weights, softened constraints, and auxiliary energy/action terms should be
+included in the target distribution itself. For separate model and bias terms, use `AdditiveTarget` or an equivalent `Target` implementation that returns the
+combined log weight:
+
+```text
+log pi(state) = log pi_model(state) + log pi_bias(state)
+```
+
+When the model is written as an action or energy, each component should return the negative component action:
+
+```text
+log pi(state) = -S_model(state) - S_bias(state)
+```
+
+The Metropolis-Hastings target contribution is therefore:
+
+```text
+log pi(y) - log pi(x) = -(Delta S_model + Delta S_bias)
+```
+
+Proposal asymmetry is not folded into the bias term. Keep it in the appropriate `log_q_ratio` implementation so the full acceptance ratio remains:
+
+```text
+log_alpha = -(Delta S_model + Delta S_bias) + log q(x | y) - log q(y | x)
+```
+
 ## What the Crate Checks
 
 The library enforces several local invariants:

--- a/docs/scientific_basis.md
+++ b/docs/scientific_basis.md
@@ -50,6 +50,9 @@ Proposal asymmetry is not folded into the bias term. Keep it in the appropriate 
 log_alpha = -(Delta S_model + Delta S_bias) + log q(x | y) - log q(y | x)
 ```
 
+The runnable [`examples/additive_target_bias.rs`](../examples/additive_target_bias.rs) demonstrates this split on a two-state target: a flat model term is
+combined with a bias weight through `AdditiveTarget`, while the symmetric flip proposal keeps the proposal-ratio correction at its default zero value.
+
 ## What the Crate Checks
 
 The library enforces several local invariants:

--- a/examples/additive_target_bias.rs
+++ b/examples/additive_target_bias.rs
@@ -1,0 +1,84 @@
+//! Add a target-bias term to Metropolis-Hastings acceptance.
+//!
+//! Demonstrates [`AdditiveTarget`] for composing a model log weight with an
+//! auxiliary bias term.  The proposal remains symmetric, so the Hastings
+//! correction is still supplied by the proposal API and defaults to zero here.
+//!
+//! Run with: `cargo run --example additive_target_bias`
+
+use markov_chain_monte_carlo::prelude::by_value::*;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+// --- Target components over a two-state model ---
+
+struct FlatModel;
+impl Target<bool> for FlatModel {
+    fn log_prob(&self, _: &bool) -> f64 {
+        0.0
+    }
+}
+
+struct BiasTowardTrue {
+    true_log_weight: f64,
+}
+impl Target<bool> for BiasTowardTrue {
+    fn log_prob(&self, state: &bool) -> f64 {
+        if *state { self.true_log_weight } else { 0.0 }
+    }
+}
+
+// --- Proposal: symmetric flip between the two states ---
+
+struct Flip;
+impl Proposal<bool> for Flip {
+    fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
+        !*current
+    }
+}
+
+fn main() -> Result<(), McmcError> {
+    let seed = 42;
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    let target = AdditiveTarget::new(
+        FlatModel,
+        BiasTowardTrue {
+            true_log_weight: 3.0_f64.ln(),
+        },
+    );
+    let proposal = Flip;
+    let chain = Chain::new(false, &target)?;
+    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng)?;
+
+    let false_weight = target.log_prob(&false).exp();
+    let true_weight = target.log_prob(&true).exp();
+    let expected_true_fraction = true_weight / (false_weight + true_weight);
+
+    println!("AdditiveTarget bias example (seed={seed})");
+    println!("  model log weight: flat");
+    println!("  bias log weight for true: ln(3)");
+    println!("  proposal log_q_ratio: symmetric default 0");
+    println!("  expected P(true): {expected_true_fraction:.3}");
+
+    sampler.run(1_000)?;
+    sampler.reset_counters();
+
+    let n_samples: u32 = 20_000;
+    let mut true_count = 0_u32;
+    for _ in 0..n_samples {
+        sampler.step()?;
+        true_count += u32::from(*sampler.chain_ref().state());
+    }
+
+    let observed_true_fraction = f64::from(true_count) / f64::from(n_samples);
+
+    println!("\nResults ({n_samples} samples):");
+    println!("  observed P(true): {observed_true_fraction:.3}");
+    println!(
+        "  acceptance rate: {:.1}%",
+        sampler.chain_ref().acceptance_rate() * 100.0
+    );
+
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ rumdl_version := "0.2.3"
 taplo_version := "0.10.0"
 typos_version := "1.46.3"
 zizmor_version := "1.25.2"
-example_names := "detailed_balance normal_1d ising_1d iterator_sampling delayed_chunked_telemetry"
+example_names := "detailed_balance normal_1d ising_1d iterator_sampling delayed_chunked_telemetry additive_target_bias"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes examples from reports while allowing tests to exercise library code.
@@ -670,6 +670,7 @@ validate-examples: _build-examples
     validate_example ising_1d "<m>" "acceptance rate"
     validate_example iterator_sampling "Sample mean" "Acceptance rate"
     validate_example delayed_chunked_telemetry "Per-step telemetry" "Delayed chunked telemetry complete"
+    validate_example additive_target_bias "AdditiveTarget bias example" "observed P(true)"
 
 validate-json: _ensure-jq
     #!/usr/bin/env bash

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1300,6 +1300,7 @@ impl<S> Chain<S> {
 
 #[cfg(test)]
 mod tests {
+    use core::convert::Infallible;
     use std::assert_matches;
 
     use approx::assert_relative_eq;
@@ -1596,7 +1597,7 @@ mod tests {
     impl DelayedProposal<bool> for DelayedFlip {
         type Plan = bool;
         type Info = bool;
-        type Error = core::convert::Infallible;
+        type Error = Infallible;
 
         fn propose_plan<R: Rng + ?Sized>(
             &mut self,
@@ -1655,6 +1656,30 @@ mod tests {
         assert!(step.outcome.has_proposal());
         assert_relative_eq!(step.log_alpha.unwrap(), -2.0_f64.ln(), epsilon = 1e-12);
         assert_eq!(step.info, Some(true));
+    }
+
+    #[test]
+    fn delayed_additive_target_commits_accepted_bias_move() {
+        let target = AdditiveTarget::new(
+            FlatBool,
+            FavorTrue {
+                true_log_weight: 3.0_f64.ln(),
+            },
+        );
+        let mut proposal = DelayedFlip { log_q: 0.0 };
+        let mut chain = Chain::new(false, &target).unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let step = chain
+            .step_delayed(&target, &mut proposal, &mut rng)
+            .unwrap();
+
+        assert_eq!(step.outcome, StepOutcome::Accepted);
+        assert_relative_eq!(step.log_alpha.unwrap(), 3.0_f64.ln(), epsilon = 1e-12);
+        assert_eq!(step.info, Some(true));
+        assert!(*chain.state());
+        assert_eq!(chain.accepted(), 1);
+        assert_eq!(chain.rejected(), 0);
     }
 
     // --- Error handling ---

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1306,6 +1306,7 @@ mod tests {
     use rand::{SeedableRng, rngs::StdRng};
 
     use super::*;
+    use crate::AdditiveTarget;
 
     // --- Test fixtures ---
 
@@ -1521,6 +1522,139 @@ mod tests {
         );
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 1);
+    }
+
+    struct FlatBool;
+    impl Target<bool> for FlatBool {
+        fn log_prob(&self, _: &bool) -> f64 {
+            0.0
+        }
+    }
+
+    struct FavorTrue {
+        true_log_weight: f64,
+    }
+    impl Target<bool> for FavorTrue {
+        fn log_prob(&self, state: &bool) -> f64 {
+            if *state { self.true_log_weight } else { 0.0 }
+        }
+    }
+
+    struct FlipBool;
+    impl Proposal<bool> for FlipBool {
+        fn propose<R: Rng + ?Sized>(&self, current: &bool, _: &mut R) -> bool {
+            !*current
+        }
+    }
+
+    #[test]
+    fn unbiased_two_state_baseline_samples_uniformly() {
+        let mut chain = Chain::new(false, &FlatBool).unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let samples = 1_000_u32;
+        let mut true_count = 0_u32;
+        for _ in 0..samples {
+            chain.step(&FlatBool, &FlipBool, &mut rng).unwrap();
+            true_count += u32::from(*chain.state());
+        }
+
+        assert_eq!(true_count, samples / 2);
+        assert_eq!(chain.accepted(), usize::try_from(samples).unwrap());
+        assert_eq!(chain.rejected(), 0);
+    }
+
+    #[test]
+    fn additive_bias_changes_observed_stationary_distribution() {
+        let target = AdditiveTarget::new(
+            FlatBool,
+            FavorTrue {
+                true_log_weight: 3.0_f64.ln(),
+            },
+        );
+        let mut chain = Chain::new(false, &target).unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for _ in 0..5_000 {
+            chain.step(&target, &FlipBool, &mut rng).unwrap();
+        }
+
+        let samples = 50_000_u32;
+        let mut true_count = 0_u32;
+        for _ in 0..samples {
+            chain.step(&target, &FlipBool, &mut rng).unwrap();
+            true_count += u32::from(*chain.state());
+        }
+
+        let true_fraction = f64::from(true_count) / f64::from(samples);
+        assert_relative_eq!(true_fraction, 0.75, epsilon = 0.03);
+    }
+
+    struct DelayedFlip {
+        log_q: f64,
+    }
+    impl DelayedProposal<bool> for DelayedFlip {
+        type Plan = bool;
+        type Info = bool;
+        type Error = core::convert::Infallible;
+
+        fn propose_plan<R: Rng + ?Sized>(
+            &mut self,
+            state: &bool,
+            _: &mut R,
+        ) -> Result<Option<bool>, Self::Error> {
+            Ok(Some(!*state))
+        }
+
+        fn proposed_log_prob<T: Target<bool>>(
+            &self,
+            _: &bool,
+            plan: &bool,
+            target: &T,
+        ) -> Result<f64, Self::Error> {
+            Ok(target.log_prob(plan))
+        }
+
+        fn log_q_ratio(&self, _: &bool, _: &bool) -> Result<f64, Self::Error> {
+            Ok(self.log_q)
+        }
+
+        fn info(&self, plan: &bool) -> bool {
+            *plan
+        }
+
+        fn commit<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut bool,
+            plan: bool,
+            _: &mut R,
+        ) -> Result<(), Self::Error> {
+            *state = plan;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn delayed_log_alpha_adds_target_bias_and_proposal_ratio_with_correct_sign() {
+        let target = AdditiveTarget::new(
+            FlatBool,
+            FavorTrue {
+                true_log_weight: 3.0_f64.ln(),
+            },
+        );
+        let mut proposal = DelayedFlip {
+            log_q: -6.0_f64.ln(),
+        };
+        let mut chain = Chain::new(false, &target).unwrap();
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let step = chain
+            .step_delayed(&target, &mut proposal, &mut rng)
+            .unwrap();
+
+        assert!(step.outcome.has_proposal());
+        assert_relative_eq!(step.log_alpha.unwrap(), -2.0_f64.ln(), epsilon = 1e-12);
+        assert_eq!(step.info, Some(true));
     }
 
     // --- Error handling ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,31 @@
 //! For a fuller discussion, see
 //! [docs/scientific_basis.md](https://github.com/acgetchell/markov-chain-monte-carlo/blob/main/docs/scientific_basis.md).
 //!
+//! # Additive target terms
+//!
+//! Bias potentials, energy-based model terms, learned regularizers,
+//! auxiliary actions, umbrella-sampling weights, and other target modifiers
+//! should be sampled as part of the target distribution, not applied as ad hoc
+//! rejection filters after a proposal has been generated.  Use
+//! [`AdditiveTarget`] when model and bias terms are easiest to express as
+//! separate log-weight components.
+//!
+//! If a downstream model is written in action form, implement each component
+//! with the same sign convention: return `-S_component(state)`.  Then the
+//! acceptance calculation uses the combined action delta naturally:
+//!
+//! ```text
+//! log pi(y) - log pi(x) = -(Delta S_model + Delta S_bias)
+//! ```
+//!
+//! The Hastings correction remains independent and is still supplied through
+//! [`Proposal::log_q_ratio`], [`ProposalMut::log_q_ratio`], or
+//! [`DelayedProposal::log_q_ratio`]:
+//!
+//! ```text
+//! log_alpha = -(Delta S_model + Delta S_bias) + log q(x | y) - log q(y | x)
+//! ```
+//!
 //! # Numerical semantics
 //!
 //! The core Metropolis-Hastings acceptance calculation is performed in log
@@ -448,8 +473,8 @@ pub use testing::{
     verify_detailed_balance_mut, verify_detailed_balance_mut_many,
 };
 pub use traits::{
-    DelayedProposal, DiscreteProposalRatio, DiscreteProposalRatioError, Proposal, ProposalMut,
-    Target,
+    AdditiveTarget, DelayedProposal, DiscreteProposalRatio, DiscreteProposalRatioError, Proposal,
+    ProposalMut, Target,
 };
 
 /// Convenience re-exports for common usage.
@@ -492,10 +517,10 @@ pub use traits::{
 /// ```
 pub mod prelude {
     pub use crate::{
-        BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, McmcError, Observable,
-        ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats, SampleBuffer,
-        Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult, ThinnedRunResult,
-        ThinningError, TryAccumulator, TryObservable, TryObservedIntoRunResult,
+        AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, McmcError,
+        Observable, ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats,
+        SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult,
+        ThinnedRunResult, ThinningError, TryAccumulator, TryObservable, TryObservedIntoRunResult,
         TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
     };
 
@@ -505,12 +530,12 @@ pub mod prelude {
     /// importing the in-place or delayed proposal traits.
     pub mod by_value {
         pub use crate::{
-            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DiscreteProposalRatio,
-            DiscreteProposalRatioError, McmcError, Observable, ObservedIntoRunResult,
-            ObservedStepError, ObservedStreamError, OnlineStats, Proposal, SampleBuffer, Sampler,
-            StatisticsError, Target, ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningError,
-            TryAccumulator, TryObservable, TryObservedIntoRunResult,
-            TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
+            AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint,
+            DiscreteProposalRatio, DiscreteProposalRatioError, McmcError, Observable,
+            ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats, Proposal,
+            SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult,
+            ThinnedRunResult, ThinningError, TryAccumulator, TryObservable,
+            TryObservedIntoRunResult, TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
         };
     }
 
@@ -520,12 +545,13 @@ pub mod prelude {
     /// importing the by-value or delayed proposal traits.
     pub mod in_place {
         pub use crate::{
-            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DiscreteProposalRatio,
-            DiscreteProposalRatioError, McmcError, Observable, ObservedIntoRunResult,
-            ObservedStepError, ObservedStreamError, OnlineStats, ProposalMut, SampleBuffer,
-            Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult, ThinnedRunResult,
-            ThinningError, TryAccumulator, TryObservable, TryObservedIntoRunResult,
-            TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
+            AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint,
+            DiscreteProposalRatio, DiscreteProposalRatioError, McmcError, Observable,
+            ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats,
+            ProposalMut, SampleBuffer, Sampler, StatisticsError, Target,
+            ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningError, TryAccumulator,
+            TryObservable, TryObservedIntoRunResult, TryThinnedObservedIntoRunResult,
+            TryThinnedObservedRunResult,
         };
     }
 
@@ -535,14 +561,14 @@ pub mod prelude {
     /// errors, without importing the by-value or in-place proposal traits.
     pub mod delayed {
         pub use crate::{
-            BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DelayedProposal, DelayedStep,
-            DelayedStepError, DiscreteProposalRatio, DiscreteProposalRatioError, McmcError,
-            Observable, ObservedDelayedIntoRunResult, ObservedDelayedStep,
-            ObservedDelayedStepResult, ObservedStepError, ObservedStreamError, OnlineStats,
-            SampleBuffer, Sampler, StatisticsError, StepOutcome, StepRejectionReason, Target,
-            ThinnedObservedDelayedIntoRunResult, ThinnedRunResult, ThinningError, TryAccumulator,
-            TryObservable, TryObservedDelayedIntoRunResult, TryThinnedObservedDelayedIntoRunResult,
-            TryThinnedObservedRunResult,
+            AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint,
+            DelayedProposal, DelayedStep, DelayedStepError, DiscreteProposalRatio,
+            DiscreteProposalRatioError, McmcError, Observable, ObservedDelayedIntoRunResult,
+            ObservedDelayedStep, ObservedDelayedStepResult, ObservedStepError, ObservedStreamError,
+            OnlineStats, SampleBuffer, Sampler, StatisticsError, StepOutcome, StepRejectionReason,
+            Target, ThinnedObservedDelayedIntoRunResult, ThinnedRunResult, ThinningError,
+            TryAccumulator, TryObservable, TryObservedDelayedIntoRunResult,
+            TryThinnedObservedDelayedIntoRunResult, TryThinnedObservedRunResult,
         };
     }
 
@@ -555,7 +581,7 @@ pub mod prelude {
     /// inspect [`crate::DetailedBalanceReport`] values.
     pub mod testing {
         pub use crate::{
-            DelayedProposal, DetailedBalanceBatchReport, DetailedBalanceConfig,
+            AdditiveTarget, DelayedProposal, DetailedBalanceBatchReport, DetailedBalanceConfig,
             DetailedBalanceDelayedTransition, DetailedBalanceDirection, DetailedBalanceError,
             DetailedBalanceFailure, DetailedBalanceReport, DetailedBalanceState,
             DiscreteProposalRatio, DiscreteProposalRatioError, Proposal, ProposalMut, Target,
@@ -575,7 +601,7 @@ mod public_api_smoke_tests {
     use serde_json::{Error as JsonError, json, to_value};
 
     use super::{
-        BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DelayedStep,
+        AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, DelayedStep,
         DetailedBalanceBatchReport, DetailedBalanceConfig, DetailedBalanceDelayedTransition,
         DetailedBalanceDirection, DetailedBalanceError, DetailedBalanceFailure,
         DetailedBalanceReport, DetailedBalanceState, McmcError, Observable, ObservedDelayedStep,
@@ -663,6 +689,7 @@ mod public_api_smoke_tests {
         let mut observable = |state: &f64| *state;
         needs_observable(&mut observable);
 
+        let _: Option<AdditiveTarget<Smoke, Smoke>> = None;
         let _: Option<Chain<f64>> = None;
         let _: Option<ChainCheckpoint<f64>> = None;
         let _: Option<Step<()>> = None;
@@ -686,16 +713,20 @@ mod public_api_smoke_tests {
         let _: Option<DetailedBalanceBatchReport> = None;
         let _: Option<DetailedBalanceReport> = None;
         let _: Option<DetailedBalanceState> = None;
+        let _: Option<prelude::AdditiveTarget<Smoke, Smoke>> = None;
         let _: Option<prelude::ThinnedRunResult<(), McmcError>> = None;
         let _: Option<prelude::TryThinnedObservedRunResult<f64, McmcError, Infallible>> = None;
+        let _: Option<by_value::AdditiveTarget<Smoke, Smoke>> = None;
         let _: Option<by_value::DiscreteProposalRatio> = None;
         let _: Option<by_value::DiscreteProposalRatioError> = None;
         let _: Option<by_value::ThinnedObservedIntoRunResult<McmcError, Infallible>> = None;
+        let _: Option<in_place::AdditiveTarget<Smoke, Smoke>> = None;
         let _: Option<in_place::DiscreteProposalRatio> = None;
         let _: Option<in_place::DiscreteProposalRatioError> = None;
         let _: Option<
             in_place::TryThinnedObservedIntoRunResult<McmcError, Infallible, Infallible>,
         > = None;
+        let _: Option<delayed::AdditiveTarget<Smoke, Smoke>> = None;
         let _: Option<delayed::DiscreteProposalRatio> = None;
         let _: Option<delayed::DiscreteProposalRatioError> = None;
         let _: Option<delayed::StepOutcome> = None;
@@ -705,6 +736,7 @@ mod public_api_smoke_tests {
         let _: Option<testing::DetailedBalanceConfig> = None;
         let _: Option<testing::DetailedBalanceError> = None;
         let _: Option<testing::DetailedBalanceReport> = None;
+        let _: Option<testing::AdditiveTarget<Smoke, Smoke>> = None;
         let _: Option<testing::DiscreteProposalRatio> = None;
         let _: Option<testing::DiscreteProposalRatioError> = None;
         let _: Option<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,65 @@
 //! stream and return a checkpoint-compatible view containing the current state
 //! and counters.
 //!
+//! # Resumable chunked runs
+//!
+//! Chunked runs advance the chain by a chosen number of steps, then return a
+//! checkpoint-compatible continuation so a caller can inspect the updated state,
+//! choose the next chunk length, and resume without losing RNG state or
+//! counters.  Reusing the same [`Sampler`] preserves the RNG stream, so a
+//! sequence of chunks reproduces an equivalent one-shot run with the same seed.
+//!
+//! Measurements stay on the caller side: keep domain-specific statistics in your
+//! own buffers and accumulate them across chunks rather than having the sampler
+//! own a measurement buffer.  The delayed observing variant
+//! [`Sampler::run_delayed_chunk_observing`] hands each step's [`DelayedStep`]
+//! telemetry and post-step state to a callback while still returning the
+//! continuation, so the chain keeps ownership of the accept/reject draw and
+//! counters.  Between chunks a caller can size the next chunk from the current
+//! state and stop on an elapsed-time budget.
+//!
+//! ```
+//! use core::convert::Infallible;
+//! use markov_chain_monte_carlo::prelude::delayed::*;
+//! use rand::{Rng, SeedableRng, rngs::StdRng};
+//!
+//! # struct Flat;
+//! # impl Target<i32> for Flat {
+//! #     fn log_prob(&self, _: &i32) -> f64 { 0.0 }
+//! # }
+//! # struct Advance;
+//! # impl DelayedProposal<i32> for Advance {
+//! #     type Plan = i32;
+//! #     type Info = i32;
+//! #     type Error = Infallible;
+//! #     fn propose_plan<R: Rng + ?Sized>(&mut self, _: &i32, _: &mut R) -> Result<Option<i32>, Self::Error> { Ok(Some(1)) }
+//! #     fn proposed_log_prob<T: Target<i32>>(&self, s: &i32, p: &i32, t: &T) -> Result<f64, Self::Error> { Ok(t.log_prob(&(*s + *p))) }
+//! #     fn info(&self, plan: &i32) -> i32 { *plan }
+//! #     fn commit<R: Rng + ?Sized>(&mut self, s: &mut i32, p: i32, _: &mut R) -> Result<(), Self::Error> { *s += p; Ok(()) }
+//! # }
+//! let mut rng = StdRng::seed_from_u64(42);
+//! let mut proposal = Advance;
+//! let chain = Chain::new(0, &Flat).map_err(DelayedStepError::Mcmc)?;
+//! let mut sampler = Sampler::new(chain, &Flat, &mut proposal, &mut rng)
+//!     .map_err(DelayedStepError::Mcmc)?;
+//!
+//! // Domain-specific measurements stay outside the generic sampler.
+//! let mut samples: Vec<i32> = Vec::new();
+//! let mut next_chunk = 4;
+//!
+//! for _ in 0..3 {
+//!     let continuation = sampler.run_delayed_chunk_observing(next_chunk, |_step, state| {
+//!         samples.push(*state);
+//!     })?;
+//!     // Size the next chunk from the updated state and resume on the same RNG
+//!     // stream.  A real caller can also break here on an elapsed-time budget.
+//!     next_chunk = usize::try_from(**continuation.state()).unwrap_or(1).max(1);
+//! }
+//!
+//! assert_eq!(sampler.chain_ref().total_steps(), samples.len());
+//! # Ok::<(), DelayedStepError<Infallible>>(())
+//! ```
+//!
 //! # Proposal validation
 //!
 //! The [`verify_detailed_balance`] family of helpers gives proposal authors a

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -293,6 +293,173 @@ fn count_ln(count: NonZeroUsize) -> f64 {
     (count.get() as f64).ln()
 }
 
+/// Additive composition of two target log-weight components.
+///
+/// `AdditiveTarget` is a small adapter for targets whose log weight is a sum
+/// of independent model terms, such as an energy-based model term, learned
+/// regularizer, physics action, umbrella-sampling bias, or softened
+/// constraint.  Each component implements [`Target`] using this crate's
+/// ordinary sign convention: return a log probability/log weight, or return
+/// negative energy/action when the model is written as `exp(-S)`.
+///
+/// For action terms, this means:
+///
+/// ```text
+/// log pi(state) = -S_model(state) - S_bias(state)
+/// ```
+///
+/// so Metropolis-Hastings uses:
+///
+/// ```text
+/// log pi(y) - log pi(x) = -(Delta S_model + Delta S_bias)
+/// ```
+///
+/// Proposal-ratio corrections remain separate in [`Proposal::log_q_ratio`],
+/// [`ProposalMut::log_q_ratio`], or [`DelayedProposal::log_q_ratio`].
+///
+/// # Examples
+///
+/// ```
+/// use markov_chain_monte_carlo::{AdditiveTarget, Target};
+///
+/// struct ModelAction;
+/// impl Target<i32> for ModelAction {
+///     fn log_prob(&self, state: &i32) -> f64 {
+///         -0.5 * f64::from(*state * *state)
+///     }
+/// }
+///
+/// struct BiasTowardTwo;
+/// impl Target<i32> for BiasTowardTwo {
+///     fn log_prob(&self, state: &i32) -> f64 {
+///         let distance = f64::from(*state - 2);
+///         -distance * distance
+///     }
+/// }
+///
+/// let target = AdditiveTarget::new(ModelAction, BiasTowardTwo);
+///
+/// assert_eq!(target.log_prob(&2), -2.0);
+/// assert_eq!(target.log_prob(&0), -4.0);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+pub struct AdditiveTarget<A, B> {
+    primary: A,
+    additive: B,
+}
+
+impl<A, B> AdditiveTarget<A, B> {
+    /// Create a target whose log weight is `primary + additive`.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{AdditiveTarget, Target};
+    ///
+    /// struct Flat;
+    /// impl Target<()> for Flat {
+    ///     fn log_prob(&self, _: &()) -> f64 { 0.0 }
+    /// }
+    ///
+    /// struct Offset;
+    /// impl Target<()> for Offset {
+    ///     fn log_prob(&self, _: &()) -> f64 { -2.0 }
+    /// }
+    ///
+    /// let target = AdditiveTarget::new(Flat, Offset);
+    ///
+    /// assert_eq!(target.log_prob(&()), -2.0);
+    /// ```
+    pub const fn new(primary: A, additive: B) -> Self {
+        Self { primary, additive }
+    }
+
+    /// Primary target component.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{AdditiveTarget, Target};
+    ///
+    /// struct Model;
+    /// impl Target<i32> for Model {
+    ///     fn log_prob(&self, state: &i32) -> f64 { -f64::from(*state) }
+    /// }
+    ///
+    /// struct Bias;
+    /// impl Target<i32> for Bias {
+    ///     fn log_prob(&self, _: &i32) -> f64 { 0.0 }
+    /// }
+    ///
+    /// let target = AdditiveTarget::new(Model, Bias);
+    ///
+    /// assert_eq!(target.primary().log_prob(&3), -3.0);
+    /// ```
+    #[must_use]
+    pub const fn primary(&self) -> &A {
+        &self.primary
+    }
+
+    /// Additive target component, such as a bias or auxiliary log weight.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{AdditiveTarget, Target};
+    ///
+    /// struct Model;
+    /// impl Target<i32> for Model {
+    ///     fn log_prob(&self, _: &i32) -> f64 { 0.0 }
+    /// }
+    ///
+    /// struct Bias;
+    /// impl Target<i32> for Bias {
+    ///     fn log_prob(&self, state: &i32) -> f64 {
+    ///         -f64::from((*state - 1).abs())
+    ///     }
+    /// }
+    ///
+    /// let target = AdditiveTarget::new(Model, Bias);
+    ///
+    /// assert_eq!(target.additive().log_prob(&3), -2.0);
+    /// ```
+    #[must_use]
+    pub const fn additive(&self) -> &B {
+        &self.additive
+    }
+
+    /// Consume the adapter into its component targets.
+    ///
+    /// ```
+    /// use markov_chain_monte_carlo::{AdditiveTarget, Target};
+    ///
+    /// struct Model;
+    /// impl Target<()> for Model {
+    ///     fn log_prob(&self, _: &()) -> f64 { -1.0 }
+    /// }
+    ///
+    /// struct Bias;
+    /// impl Target<()> for Bias {
+    ///     fn log_prob(&self, _: &()) -> f64 { -2.0 }
+    /// }
+    ///
+    /// let target = AdditiveTarget::new(Model, Bias);
+    /// let (model, bias) = target.into_parts();
+    ///
+    /// assert_eq!(model.log_prob(&()), -1.0);
+    /// assert_eq!(bias.log_prob(&()), -2.0);
+    /// ```
+    #[must_use]
+    pub fn into_parts(self) -> (A, B) {
+        (self.primary, self.additive)
+    }
+}
+
+impl<S, A, B> Target<S> for AdditiveTarget<A, B>
+where
+    A: Target<S>,
+    B: Target<S>,
+{
+    fn log_prob(&self, state: &S) -> f64 {
+        self.primary.log_prob(state) + self.additive.log_prob(state)
+    }
+}
+
 /// Target distribution.
 ///
 /// `log_prob` returns a value proportional to the natural logarithm of the

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -859,6 +859,13 @@ mod tests {
     #[derive(Clone, Debug)]
     struct Scalar(f64);
 
+    struct WeightedTarget(f64);
+    impl Target<Scalar> for WeightedTarget {
+        fn log_prob(&self, state: &Scalar) -> f64 {
+            self.0 * state.0
+        }
+    }
+
     struct SymmetricProposal;
     impl Proposal<Scalar> for SymmetricProposal {
         fn propose<R: Rng + ?Sized>(&self, current: &Scalar, _rng: &mut R) -> Scalar {
@@ -882,6 +889,20 @@ mod tests {
     }
 
     // --- Default log_q_ratio tests ---
+
+    #[test]
+    fn additive_target_exposes_components_and_parts() {
+        let target = AdditiveTarget::new(WeightedTarget(2.0), WeightedTarget(-0.5));
+
+        assert_relative_eq!(target.log_prob(&Scalar(4.0)), 6.0);
+        assert_relative_eq!(target.primary().log_prob(&Scalar(4.0)), 8.0);
+        assert_relative_eq!(target.additive().log_prob(&Scalar(4.0)), -2.0);
+
+        let (primary, additive) = target.into_parts();
+
+        assert_relative_eq!(primary.log_prob(&Scalar(3.0)), 6.0);
+        assert_relative_eq!(additive.log_prob(&Scalar(3.0)), -1.5);
+    }
 
     #[test]
     fn proposal_default_log_q_zero() {


### PR DESCRIPTION
- Add AdditiveTarget for composing model and bias log-weight terms in the target distribution.
- Re-export the adapter through the crate root and scoped preludes for by-value, in-place, delayed, and testing workflows.
- Document additive energy/action semantics and keep proposal-ratio corrections separate from target bias terms.

Closes #59