### PR TITLE
fix: enforce fallible public Rust examples (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add AdditiveTarget for composing model and bias log-weight terms in the target distribution.
   - Re-export the adapter through the crate root and scoped preludes for by-value, in-place, delayed, and testing workflows.
   - Document additive energy/action semantics and keep proposal-ratio corrections separate from target bias terms.
+- Add trace recording diagnostics [#79](https://github.com/acgetchell/markov-chain-monte-carlo/pull/79) [`adbb84a`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/adbb84a60a509eaba0d37ac298f2a6196b6495ee)
+
+  * feat: add trace recording diagnostics
+
+  - Add ChainId, TraceStepOutcome, TraceRecord, Trace, and TraceRecorder for reusable numeric MCMC traces with accept/reject metadata and CSV export.
+  - Re-export trace diagnostics through the root API and scoped preludes so examples, doctests, benchmarks, and downstream users can import them consistently.
+  - Extend the Ising example with energy and magnetization trace export, add an individual just example recipe, and document the notebook workflow for inspecting the generated CSV.
+
+  * ci: add notebook validation checks
+
+  - Add notebook linting and in-memory execution recipes so tracked notebooks are checked in local validation and full CI simulation.
+  - Add notebook runtime dependencies and a reusable check-notebooks helper for JSON, code-cell syntax, and nbclient execution.
+  - Harden the Ising trace notebook with clearer missing-file errors and proposed-move acceptance-rate handling.
+  - Cover notebook checking and subprocess utility behavior with Python tests.
+
+  * fix(ci): use ASCII notebook checker output
+
+  - Replace Unicode status markers with ASCII text so notebook checks run on Windows consoles.
+
+  * fix(tooling): exclude notebook checkpoints from discovery
+
+  - Skip `.ipynb_checkpoints` copies in `discover_notebooks` so checkpoint duplicates are never linted or executed.
+  - Correct the `paths` CLI help text to describe discovery via `discover_notebooks` instead of tracked files.
+  - Treat `check_notebooks` as a first-party module for Ruff import sorting.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,8 +223,8 @@ The crate forbids `unsafe_code` and warns on `missing_docs`; broken intra-doc li
 ### Project-Specific Semgrep Rules
 
 The repo enforces some project conventions via Semgrep (`semgrep.yaml`). They cover things like avoiding `stdio` diagnostics in `src/`, banning `Box<dyn Error>`
-in `src/`/examples/benches/doctests, requiring `expect()` reasons, and forbidding unwrap-default-on-non-finite. Run them with `just semgrep` and
-`just semgrep-test`.
+in `src/`/examples/benches/doctests, banning `unwrap()`/`expect()` in doctests/examples/benches (prefer `?` and concrete errors, or a benches fixture helper),
+requiring `expect()` reasons, and forbidding unwrap-default-on-non-finite. Run them with `just semgrep` and `just semgrep-test`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![codecov](https://codecov.io/gh/acgetchell/markov-chain-monte-carlo/graph/badge.svg)](https://codecov.io/gh/acgetchell/markov-chain-monte-carlo)
 [![Audit dependencies](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/audit.yml/badge.svg)](https://github.com/acgetchell/markov-chain-monte-carlo/actions/workflows/audit.yml)
 
-![Ising energy trace](docs/assets/ising_energy_trace.png)
+![Ising energy trace](https://raw.githubusercontent.com/acgetchell/markov-chain-monte-carlo/main/docs/assets/ising_energy_trace.png)
 
 Small, explicit Metropolis-Hastings tools in Rust for ordinary numeric states, large combinatorial state spaces, and proposal implementations that need
 rollback-safe mutation or delayed commits.

--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -1,6 +1,6 @@
 //! Criterion benchmarks for core Metropolis-Hastings stepping paths.
 
-use core::convert::Infallible;
+use core::{convert::Infallible, fmt};
 use std::hint::black_box;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -158,9 +158,21 @@ impl DelayedProposal<Scalar> for NoDelayedPlan {
     }
 }
 
+/// Require a benchmark setup or step operation to succeed, panicking with context
+/// so Criterion failures identify the benchmark path that failed.
+fn require<T, E: fmt::Display>(result: Result<T, E>, context: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(err) => panic!("{context}: {err}"),
+    }
+}
+
 /// Build a scalar chain with a valid cached log-probability for scalar benches.
 fn scalar_chain(target: &impl Target<Scalar>) -> Chain<Scalar> {
-    Chain::new(Scalar(0.0), target).expect("valid scalar benchmark state")
+    require(
+        Chain::new(Scalar(0.0), target),
+        "valid scalar benchmark state",
+    )
 }
 
 /// Build a non-`Clone` spin-chain state used to exercise in-place rollback.
@@ -168,7 +180,7 @@ fn spin_chain(target: &Alignment) -> Chain<SpinChain> {
     let state = SpinChain {
         spins: vec![1; SPIN_COUNT],
     };
-    Chain::new(state, target).expect("valid spin benchmark state")
+    require(Chain::new(state, target), "valid spin benchmark state")
 }
 
 /// Register single-step chain benchmarks for by-value, in-place, and rollback paths.
@@ -184,7 +196,10 @@ fn bench_chain_steps(c: &mut Criterion) {
         let mut rng = StdRng::seed_from_u64(SEED);
 
         b.iter(|| {
-            chain.step(&target, &proposal, &mut rng).unwrap();
+            require(
+                chain.step(&target, &proposal, &mut rng),
+                "chain step by value",
+            );
             black_box(chain.state().0);
         });
     });
@@ -194,7 +209,10 @@ fn bench_chain_steps(c: &mut Criterion) {
         let mut rng = StdRng::seed_from_u64(SEED);
 
         b.iter(|| {
-            black_box(chain.step_mut(&flat, &spin_proposal, &mut rng).unwrap());
+            black_box(require(
+                chain.step_mut(&flat, &spin_proposal, &mut rng),
+                "in-place chain step on flat target",
+            ));
             black_box(chain.state().spins[0]);
         });
     });
@@ -204,11 +222,10 @@ fn bench_chain_steps(c: &mut Criterion) {
         let mut rng = StdRng::seed_from_u64(SEED);
 
         b.iter(|| {
-            black_box(
-                chain
-                    .step_mut(&spin_target, &spin_proposal, &mut rng)
-                    .unwrap(),
-            );
+            black_box(require(
+                chain.step_mut(&spin_target, &spin_proposal, &mut rng),
+                "in-place chain step with rollback",
+            ));
             black_box(chain.state().spins[0]);
         });
     });
@@ -225,7 +242,10 @@ fn bench_delayed_steps(c: &mut Criterion) {
         let mut rng = StdRng::seed_from_u64(SEED);
 
         b.iter(|| {
-            let step = chain.step_delayed(&flat, &mut proposal, &mut rng).unwrap();
+            let step = require(
+                chain.step_delayed(&flat, &mut proposal, &mut rng),
+                "delayed accepted chain step",
+            );
             black_box(step.outcome.is_accepted());
             black_box(chain.state().0);
         });
@@ -237,9 +257,10 @@ fn bench_delayed_steps(c: &mut Criterion) {
         let mut rng = StdRng::seed_from_u64(SEED);
 
         b.iter(|| {
-            let step = chain
-                .step_delayed(&normal, &mut proposal, &mut rng)
-                .unwrap();
+            let step = require(
+                chain.step_delayed(&normal, &mut proposal, &mut rng),
+                "delayed rejected chain step",
+            );
             black_box(step.outcome.is_accepted());
             black_box(chain.state().0);
         });
@@ -251,9 +272,10 @@ fn bench_delayed_steps(c: &mut Criterion) {
         let mut rng = StdRng::seed_from_u64(SEED);
 
         b.iter(|| {
-            let step = chain
-                .step_delayed(&normal, &mut proposal, &mut rng)
-                .unwrap();
+            let step = require(
+                chain.step_delayed(&normal, &mut proposal, &mut rng),
+                "delayed no-plan chain step",
+            );
             black_box(step.outcome.has_proposal());
             black_box(chain.rejected());
         });
@@ -269,27 +291,37 @@ fn bench_sampler_runs(c: &mut Criterion) {
 
     c.bench_function("sampler/run_by_value_100", |b| {
         let mut rng = StdRng::seed_from_u64(SEED);
-        let mut sampler =
-            Sampler::new(scalar_chain(&target), &target, &proposal, &mut rng).unwrap();
+        let mut sampler = require(
+            Sampler::new(scalar_chain(&target), &target, &proposal, &mut rng),
+            "sampler by-value setup",
+        );
 
         b.iter(|| {
-            sampler.run(black_box(BULK_STEPS)).unwrap();
+            require(
+                sampler.run(black_box(BULK_STEPS)),
+                "sampler by-value bulk run",
+            );
             black_box(sampler.chain_ref().state().0);
         });
     });
 
     c.bench_function("sampler/run_mut_100", |b| {
         let mut rng = StdRng::seed_from_u64(SEED);
-        let mut sampler = Sampler::new(
-            spin_chain(&Alignment { beta: 0.0 }),
-            &flat,
-            &spin_proposal,
-            &mut rng,
-        )
-        .unwrap();
+        let mut sampler = require(
+            Sampler::new(
+                spin_chain(&Alignment { beta: 0.0 }),
+                &flat,
+                &spin_proposal,
+                &mut rng,
+            ),
+            "sampler in-place setup",
+        );
 
         b.iter(|| {
-            sampler.run_mut(black_box(BULK_STEPS)).unwrap();
+            require(
+                sampler.run_mut(black_box(BULK_STEPS)),
+                "sampler in-place bulk run",
+            );
             black_box(sampler.chain_ref().state().spins[0]);
         });
     });
@@ -297,10 +329,16 @@ fn bench_sampler_runs(c: &mut Criterion) {
     c.bench_function("sampler/run_delayed_100", |b| {
         let mut delayed = DelayedWalk { delta: 1.0 };
         let mut rng = StdRng::seed_from_u64(SEED);
-        let mut sampler = Sampler::new(scalar_chain(&flat), &flat, &mut delayed, &mut rng).unwrap();
+        let mut sampler = require(
+            Sampler::new(scalar_chain(&flat), &flat, &mut delayed, &mut rng),
+            "sampler delayed setup",
+        );
 
         b.iter(|| {
-            sampler.run_delayed(black_box(BULK_STEPS)).unwrap();
+            require(
+                sampler.run_delayed(black_box(BULK_STEPS)),
+                "sampler delayed bulk run",
+            );
             black_box(sampler.chain_ref().state().0);
         });
     });
@@ -313,14 +351,17 @@ fn bench_observing(c: &mut Criterion) {
 
     c.bench_function("observing/run_observing_buffer_100", |b| {
         let mut rng = StdRng::seed_from_u64(SEED);
-        let mut sampler =
-            Sampler::new(scalar_chain(&target), &target, &proposal, &mut rng).unwrap();
+        let mut sampler = require(
+            Sampler::new(scalar_chain(&target), &target, &proposal, &mut rng),
+            "observing buffer sampler setup",
+        );
         let mut square = |state: &Scalar| state.0 * state.0;
 
         b.iter(|| {
-            let observations = sampler
-                .run_observing(black_box(BULK_STEPS), &mut square)
-                .unwrap();
+            let observations = require(
+                sampler.run_observing(black_box(BULK_STEPS), &mut square),
+                "observing buffer run",
+            );
             black_box(observations.as_slice());
         });
     });
@@ -331,7 +372,10 @@ fn bench_observing(c: &mut Criterion) {
             |(mut chain, mut rng)| {
                 let mut sum = 0.0;
                 for _ in 0..black_box(BULK_STEPS) {
-                    chain.step(&target, &proposal, &mut rng).unwrap();
+                    require(
+                        chain.step(&target, &proposal, &mut rng),
+                        "manual observing chain step",
+                    );
                     let sample = chain.state().0;
                     sum = sample.mul_add(sample, sum);
                 }
@@ -345,12 +389,16 @@ fn bench_observing(c: &mut Criterion) {
         b.iter_batched(
             || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
             |(chain, mut rng)| {
-                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng).unwrap();
+                let mut sampler = require(
+                    Sampler::new(chain, &target, &proposal, &mut rng),
+                    "online stats sampler setup",
+                );
                 let mut square = |state: &Scalar| state.0 * state.0;
                 let mut stats = OnlineStats::new();
-                sampler
-                    .run_observing_into(black_box(BULK_STEPS), &mut square, &mut stats)
-                    .unwrap();
+                require(
+                    sampler.run_observing_into(black_box(BULK_STEPS), &mut square, &mut stats),
+                    "online stats observing run",
+                );
                 black_box(stats.count());
             },
             BatchSize::SmallInput,
@@ -361,12 +409,16 @@ fn bench_observing(c: &mut Criterion) {
         b.iter_batched(
             || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
             |(chain, mut rng)| {
-                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng).unwrap();
+                let mut sampler = require(
+                    Sampler::new(chain, &target, &proposal, &mut rng),
+                    "binning sampler setup",
+                );
                 let mut square = |state: &Scalar| state.0 * state.0;
                 let mut bins = BinningAnalysis::new();
-                sampler
-                    .run_observing_into(black_box(BULK_STEPS), &mut square, &mut bins)
-                    .unwrap();
+                require(
+                    sampler.run_observing_into(black_box(BULK_STEPS), &mut square, &mut bins),
+                    "binning observing run",
+                );
                 black_box(bins.standard_error());
             },
             BatchSize::SmallInput,

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -102,11 +102,13 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 │   └── semgrep/
 │       ├── benches/
 │       │   ├── erased_error.rs
-│       │   └── typed_error.rs
+│       │   ├── typed_error.rs
+│       │   └── unwrap_expect.rs
 │       ├── examples/
 │       │   ├── deep_import.rs
 │       │   ├── erased_error.rs
-│       │   └── typed_error.rs
+│       │   ├── typed_error.rs
+│       │   └── unwrap_expect.rs
 │       ├── github-actions/
 │       │   └── workflow_actions.yml
 │       ├── docs/
@@ -117,7 +119,8 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 │       └── src/
 │           ├── doctests/
 │           │   ├── erased_error.rs
-│           │   └── typed_error.rs
+│           │   ├── typed_error.rs
+│           │   └── unwrap_expect.rs
 │           └── project_rules/
 │               └── rust_style.rs
 ├── ty.toml

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -165,6 +165,7 @@ Keep these checks focused. Avoid broad community rule packs unless they prove lo
 - Only take ownership or allocate returned `Vec`s when required.
 - Keep production fallible paths typed; prefer `McmcError` or a specific error type over dynamic error erasure.
 - Avoid `unwrap`, `expect`, and `panic!` in production `src/` code.
+- Avoid `unwrap()`/`expect()` in doctests, examples, and benchmarks too; prefer `?` with concrete errors, or an explicit fixture helper in benches.
 - Use `#[expect(..., reason = "...")]` rather than `#[allow(clippy::...)]`.
 
 ## Publishing

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,7 @@ MSRV/toolchain refresh.
 - [#61](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61) - Expose delayed-step hooks or telemetry for domain-specific sampler integration
 - [x] [#59](https://github.com/acgetchell/markov-chain-monte-carlo/issues/59) - Support additive target bias terms in Metropolis-Hastings acceptance
 - [#48](https://github.com/acgetchell/markov-chain-monte-carlo/issues/48) - Investigate detailed balance for delayed proposals with variable valid-site counts
-- [#62](https://github.com/acgetchell/markov-chain-monte-carlo/issues/62) - Clean up doctest/example unwraps and enforce with Semgrep
+- [x] [#62](https://github.com/acgetchell/markov-chain-monte-carlo/issues/62) - Clean up doctest/example unwraps and enforce with Semgrep
 
 Resumable chunked runs shipped as `Sampler::run_chunk`, `run_mut_chunk`, and `run_delayed_chunk`, each returning a checkpoint-compatible continuation, plus
 `run_delayed_chunk_observing` for per-step delayed telemetry. A combined `(measurements, continuation)` return shape is intentionally deferred: callers keep

--- a/examples/ising_1d.rs
+++ b/examples/ising_1d.rs
@@ -145,16 +145,18 @@ fn main() -> Result<(), ExampleError> {
     let seed = 42;
     let mut rng = StdRng::seed_from_u64(seed);
 
-    let n_spins = 50_u32;
+    let n_spins = 50_usize;
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "example spin count is small enough to represent exactly"
+    )]
+    let n_spins_f64 = n_spins as f64;
     let beta = 0.5; // moderate temperature
     let coupling = 1.0;
 
     let target = Ising { coupling, beta };
     let proposal = SpinFlip;
-    let chain = Chain::new(
-        SpinChain::all_up(usize::try_from(n_spins).expect("example spin count fits usize")),
-        &target,
-    )?;
+    let chain = Chain::new(SpinChain::all_up(n_spins), &target)?;
     let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng)?;
 
     println!("1-D Ising model ({n_spins} spins, β={beta}, J={coupling}, seed={seed})");
@@ -199,7 +201,7 @@ fn main() -> Result<(), ExampleError> {
 
     let mean_mag = mag_sum / f64::from(n_samples);
     let mean_mag_sq = mag_sq_sum / f64::from(n_samples);
-    let susceptibility = beta * f64::from(n_spins) * (mean_mag_sq - mean_mag * mean_mag);
+    let susceptibility = beta * n_spins_f64 * (mean_mag_sq - mean_mag * mean_mag);
 
     println!("\nResults ({n_samples} samples):");
     println!("  <m>:             {mean_mag:+.4}");

--- a/justfile
+++ b/justfile
@@ -488,7 +488,7 @@ semgrep-test: _ensure-uv
     expect_semgrep_count 0 mcmc.rust.no-box-dyn-error-in-examples-benches benches/typed_error.rs
     expect_semgrep_count 3 mcmc.rust.no-box-dyn-error-in-doctests src/doctests/erased_error.rs
     expect_semgrep_count 0 mcmc.rust.no-box-dyn-error-in-doctests src/doctests/typed_error.rs
-    expect_semgrep_count 2 mcmc.rust.no-unwrap-expect-in-doctests src/doctests/unwrap_expect.rs
+    expect_semgrep_count 7 mcmc.rust.no-unwrap-expect-in-doctests src/doctests/unwrap_expect.rs
     expect_semgrep_count 2 mcmc.rust.no-unwrap-expect-in-benches-examples examples/unwrap_expect.rs
     expect_semgrep_count 2 mcmc.rust.no-unwrap-expect-in-benches-examples benches/unwrap_expect.rs
     expect_semgrep_count 1 mcmc.github-actions.external-action-sha-pinned github-actions/workflow_actions.yml

--- a/justfile
+++ b/justfile
@@ -21,6 +21,10 @@ _coverage_base_args := '''--ignore-filename-regex '(^|/)examples/' \
   --workspace --all-features --lib --tests \
   --verbose'''
 
+# Examples
+_build-examples:
+    cargo build --locked --examples
+
 # Internal helpers: ensure external tooling is installed
 _ensure-actionlint:
     #!/usr/bin/env bash
@@ -182,14 +186,6 @@ changelog-unreleased version: _ensure-git-cliff python-sync
     GIT_CLIFF_OFFLINE=true git-cliff --tag {{version}} -o CHANGELOG.md
     uv run postprocess-changelog
 
-# Rust validation that is meaningful for source portability and user-facing API correctness.
-check-rust: fmt-check clippy
-    @echo "✅ Rust checks complete!"
-
-# Repository tooling that does not need to be repeated across operating systems.
-check-repository-tooling: python-check notebook-lint yaml-check action-lint zizmor toml-fmt-check toml-lint markdown-check spell-check semgrep semgrep-test
-    @echo "✅ Repository tooling checks complete!"
-
 # Non-mutating validation gate
 check: check-rust check-repository-tooling
     @echo "✅ Checks complete!"
@@ -198,9 +194,18 @@ check: check-rust check-repository-tooling
 check-fast:
     cargo check --locked
 
-# CI subset for Rust correctness.
-ci-rust: check-rust doc test test-integration validate-examples
-    @echo "✅ Rust CI checks complete!"
+# Repository tooling that does not need to be repeated across operating systems.
+check-repository-tooling: python-check notebook-lint yaml-check action-lint zizmor toml-fmt-check toml-lint markdown-check spell-check semgrep semgrep-test
+    @echo "✅ Repository tooling checks complete!"
+
+# Rust validation that is meaningful for source portability and user-facing API correctness.
+check-rust: fmt-check clippy
+    @echo "✅ Rust checks complete!"
+
+# CI simulation: comprehensive validation.
+# Depends on repository tooling, including `zizmor` GitHub Actions security analysis.
+ci: ci-repository-tooling ci-rust notebook-check bench-compile
+    @echo "🎯 CI checks complete!"
 
 # CI subset for macOS and Windows portability confidence.
 ci-portability: check-fast test test-integration validate-examples
@@ -210,10 +215,9 @@ ci-portability: check-fast test test-integration validate-examples
 ci-repository-tooling: check-repository-tooling test-python
     @echo "✅ Repository tooling CI checks complete!"
 
-# CI simulation: comprehensive validation.
-# Depends on repository tooling, including `zizmor` GitHub Actions security analysis.
-ci: ci-repository-tooling ci-rust notebook-check bench-compile
-    @echo "🎯 CI checks complete!"
+# CI subset for Rust correctness.
+ci-rust: check-rust doc test test-integration validate-examples
+    @echo "✅ Rust CI checks complete!"
 
 # Clean build artifacts
 clean:
@@ -249,10 +253,6 @@ default:
 # Documentation
 doc:
     cargo doc --locked --no-deps --document-private-items
-
-# Examples
-_build-examples:
-    cargo build --locked --examples
 
 # Run one example by name, e.g. `just example ising_1d`.
 example name:
@@ -324,18 +324,6 @@ lint-config: validate-json toml-fmt-check toml-lint yaml-check action-lint zizmo
 
 lint-docs: markdown-check spell-check
 
-notebook-check: notebook-sync
-    #!/usr/bin/env bash
-    set -euo pipefail
-    just example ising_1d
-    MPLBACKEND=Agg uv run --group dev --group notebook check-notebooks execute
-
-notebook-lint: _ensure-uv
-    uv run --group dev check-notebooks lint
-
-notebook-sync: _ensure-uv
-    uv sync --group dev --group notebook
-
 markdown-check: _ensure-rumdl
     #!/usr/bin/env bash
     set -euo pipefail
@@ -369,6 +357,18 @@ markdown-fix: _ensure-rumdl
     fi
 
 markdown-lint: markdown-check
+
+notebook-check: notebook-sync
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just example ising_1d
+    MPLBACKEND=Agg uv run --group dev --group notebook check-notebooks execute
+
+notebook-lint: _ensure-uv
+    uv run --group dev check-notebooks lint
+
+notebook-sync: _ensure-uv
+    uv sync --group dev --group notebook
 
 # Pre-publish validation: checks crates.io metadata rules that cargo publish --dry-run does NOT catch
 publish-check: _ensure-jq
@@ -488,6 +488,9 @@ semgrep-test: _ensure-uv
     expect_semgrep_count 0 mcmc.rust.no-box-dyn-error-in-examples-benches benches/typed_error.rs
     expect_semgrep_count 3 mcmc.rust.no-box-dyn-error-in-doctests src/doctests/erased_error.rs
     expect_semgrep_count 0 mcmc.rust.no-box-dyn-error-in-doctests src/doctests/typed_error.rs
+    expect_semgrep_count 2 mcmc.rust.no-unwrap-expect-in-doctests src/doctests/unwrap_expect.rs
+    expect_semgrep_count 2 mcmc.rust.no-unwrap-expect-in-benches-examples examples/unwrap_expect.rs
+    expect_semgrep_count 2 mcmc.rust.no-unwrap-expect-in-benches-examples benches/unwrap_expect.rs
     expect_semgrep_count 1 mcmc.github-actions.external-action-sha-pinned github-actions/workflow_actions.yml
     expect_semgrep_count 1 mcmc.github-actions.external-action-approved-allowlist github-actions/workflow_actions.yml
     expect_semgrep_count 1 mcmc.github-actions.external-action-version-comment github-actions/workflow_actions.yml
@@ -600,22 +603,24 @@ tag-force version: python-sync
 # Testing: runnable Rust tests use nextest; rustdoc doctests remain on cargo test.
 test: test-lib test-doc
 
-test-lib: _ensure-cargo-nextest
-    cargo nextest run --locked --lib --verbose
-
-test-doc:
-    cargo test --locked --doc --verbose
-
 # All tests (lib + doc + integration + Python tooling)
 test-all: test test-integration test-python
     @echo "✅ All tests passed"
+
+test-doc:
+    cargo test --locked --doc --verbose
 
 # Integration tests
 test-integration: _ensure-cargo-nextest
     cargo nextest run --locked --test '*' --verbose
 
+test-lib: _ensure-cargo-nextest
+    cargo nextest run --locked --lib --verbose
+
 test-python: python-sync
     uv run pytest -q
+
+toml-fix: toml-fmt
 
 toml-fmt: _ensure-taplo
     #!/usr/bin/env bash
@@ -655,8 +660,6 @@ toml-lint: _ensure-taplo
     else
         echo "No TOML files found to lint."
     fi
-
-toml-fix: toml-fmt
 
 # Validate example output (seeded, deterministic)
 validate-examples: _build-examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,4 @@ python_functions = [ "test_*" ]
 
 [tool.uv]
 package = true
+default-groups = [ "dev", "notebook" ]

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -264,6 +264,35 @@ rules:
           - pattern-regex: >-
               (?s)/\*!.*?(Box\s*<\s*dyn\s+(std::error::)?Error|&\s*dyn\s+(std::error::)?Error|anyhow::Error).*?\*/
 
+  - id: mcmc.rust.no-unwrap-expect-in-doctests
+    languages:
+      - generic
+    severity: WARNING
+    message: "Use fallible doctest flow instead of unwrap() or expect() in public documentation examples."
+    metadata:
+      category: correctness
+      rationale: "Public Rust documentation examples should model typed error handling with concrete errors and ? rather than panic-based control flow."
+    paths:
+      include:
+        - "/src/**/*.rs"
+    pattern-regex: '^\s*//[!/]\s*(?:#\s*)?.*(?:\b[\w:]+|[\]\)])\.(unwrap|expect)\s*\('
+
+  - id: mcmc.rust.no-unwrap-expect-in-benches-examples
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use explicit fixture error handling instead of unwrap() or expect() in benchmarks and examples."
+    metadata:
+      category: correctness
+      rationale: "Benchmarks and public examples should keep failure modes explicit so users and CI see the operation that failed instead of a panic-only unwrap/expect path."
+    paths:
+      include:
+        - "/benches/**/*.rs"
+        - "/examples/**/*.rs"
+    pattern-either:
+      - pattern: $VALUE.unwrap()
+      - pattern: $VALUE.expect(...)
+
   - id: mcmc.rust.public-error-enums-non-exhaustive
     languages:
       - rust

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -275,7 +275,10 @@ rules:
     paths:
       include:
         - "/src/**/*.rs"
-    pattern-regex: '^\s*//[!/]\s*(?:#\s*)?.*(?:\b[\w:]+|[\]\)])\.(unwrap|expect)\s*\('
+    pattern-either:
+      - pattern-regex: '^\s*//[!/]\s*(?:#\s*)?(?:\s*\.|.*(?:\b[\w:]+|[\]\)?])\.)(unwrap|expect)\s*\('
+      - pattern-regex: '(?s)/\*\*.*?(?:\b[\w:]+|[\]\)?])\.(unwrap|expect)\s*\(.*?\*/'
+      - pattern-regex: '(?s)/\*!.*?(?:\b[\w:]+|[\]\)?])\.(unwrap|expect)\s*\(.*?\*/'
 
   - id: mcmc.rust.no-unwrap-expect-in-benches-examples
     languages:

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -513,9 +513,21 @@ impl Trace {
     /// was created.
     ///
     /// ```
+    /// # use std::io;
     /// use markov_chain_monte_carlo::prelude::{
     ///     ChainId, Trace, TraceError, TraceRecord, TraceStepOutcome,
     /// };
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     Trace(TraceError),
+    /// #     Io(io::Error),
+    /// # }
+    /// # impl From<TraceError> for ExampleError {
+    /// #     fn from(err: TraceError) -> Self { Self::Trace(err) }
+    /// # }
+    /// # impl From<io::Error> for ExampleError {
+    /// #     fn from(err: io::Error) -> Self { Self::Io(err) }
+    /// # }
     ///
     /// let mut trace = Trace::new(["energy"])?;
     /// trace.push(TraceRecord::new(
@@ -527,13 +539,13 @@ impl Trace {
     /// ))?;
     ///
     /// let mut csv = Vec::new();
-    /// trace.write_csv(&mut csv).expect("writing to Vec cannot fail");
+    /// trace.write_csv(&mut csv)?;
     ///
     /// assert_eq!(
-    ///     String::from_utf8(csv).expect("CSV output is UTF-8"),
-    ///     "chain_id,step,accepted,proposed,log_prob,energy\n0,1,true,true,-1,1.5\n",
+    ///     csv,
+    ///     b"chain_id,step,accepted,proposed,log_prob,energy\n0,1,true,true,-1,1.5\n",
     /// );
-    /// # Ok::<(), TraceError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     ///
     /// # Errors
@@ -622,22 +634,33 @@ impl TraceRecorder {
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::{
-    ///     Chain, ChainId, Target, TraceError, TraceRecorder, TraceStepOutcome,
+    ///     Chain, ChainId, McmcError, Target, TraceError, TraceRecorder, TraceStepOutcome,
     /// };
+    ///
+    /// # #[derive(Debug)]
+    /// # enum ExampleError {
+    /// #     Mcmc(McmcError),
+    /// #     Trace(TraceError),
+    /// # }
+    /// # impl From<McmcError> for ExampleError {
+    /// #     fn from(err: McmcError) -> Self { Self::Mcmc(err) }
+    /// # }
+    /// # impl From<TraceError> for ExampleError {
+    /// #     fn from(err: TraceError) -> Self { Self::Trace(err) }
+    /// # }
     ///
     /// struct Flat;
     /// impl Target<i32> for Flat {
     ///     fn log_prob(&self, _: &i32) -> f64 { 0.0 }
     /// }
     ///
-    /// let chain = Chain::new(4, &Flat)
-    ///     .expect("flat target returns a finite log-probability");
+    /// let chain = Chain::new(4, &Flat)?;
     /// let mut recorder = TraceRecorder::new(ChainId::new(0), ["value"])?;
     ///
     /// recorder.record(&chain, TraceStepOutcome::accepted(), [f64::from(*chain.state())])?;
     ///
     /// assert_eq!(recorder.trace().records()[0].observable_values(), &[4.0]);
-    /// # Ok::<(), TraceError>(())
+    /// # Ok::<(), ExampleError>(())
     /// ```
     ///
     /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,17 @@
 //! and RNG streams are reconstructed by the caller for portable resumes.
 //!
 //! ```
+//! # #[derive(Debug)]
+//! # enum ExampleError {
+//! #     Mcmc(markov_chain_monte_carlo::McmcError),
+//! #     Json(serde_json::Error),
+//! # }
+//! # impl From<markov_chain_monte_carlo::McmcError> for ExampleError {
+//! #     fn from(err: markov_chain_monte_carlo::McmcError) -> Self { Self::Mcmc(err) }
+//! # }
+//! # impl From<serde_json::Error> for ExampleError {
+//! #     fn from(err: serde_json::Error) -> Self { Self::Json(err) }
+//! # }
 //! # #[cfg(feature = "serde")] {
 //! use approx::assert_relative_eq;
 //! use markov_chain_monte_carlo::prelude::*;
@@ -235,20 +246,18 @@
 //!     fn log_prob(&self, state: &f64) -> f64 { -0.5 * state * state }
 //! }
 //!
-//! let chain = Chain::new(1.0, &Normal)
-//!     .expect("normal target returns a finite log probability");
+//! let chain = Chain::new(1.0, &Normal)?;
 //! let checkpoint = chain.checkpoint();
 //! let checkpoint = serde_json::to_string(&checkpoint)?;
 //! let checkpoint: ChainCheckpoint<f64> = serde_json::from_str(&checkpoint)?;
-//! let restored = Chain::from_checkpoint(checkpoint, &Normal)
-//!     .expect("normal target returns a finite checkpoint log probability");
+//! let restored = Chain::from_checkpoint(checkpoint, &Normal)?;
 //! assert_relative_eq!(
 //!     restored.log_prob(),
 //!     Normal.log_prob(restored.state()),
 //!     epsilon = 1e-12
 //! );
 //! # }
-//! # Ok::<(), serde_json::Error>(())
+//! # Ok::<(), ExampleError>(())
 //! ```
 //!
 //! # In-place mutation with rollback
@@ -490,7 +499,8 @@
 //! # }
 //! let mut rng = StdRng::seed_from_u64(42);
 //! let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
-//! let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+//! let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+//!     .map_err(ObservedStreamError::Step)?;
 //! let mut coordinate = |state: &f64| *state;
 //! let mut stats = OnlineStats::new();
 //!

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -388,7 +388,7 @@ impl<S, T, P, R: ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
     ///
     /// sampler.run(4)?;
     /// sampler.reset_counters();
@@ -479,7 +479,7 @@ impl<'a, S, T: Target<S>, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// [`McmcError::InfiniteCurrentLogProb`] if the target returns NaN or +∞
     /// for the chain's current state.
     ///
-    /// ```should_panic
+    /// ```
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -499,12 +499,13 @@ impl<'a, S, T: Target<S>, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// #     }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0.0, &ValidTarget).unwrap();
-    /// // This will return Err(McmcError::NanCurrentLogProb)
-    /// let sampler = Sampler::new(chain, &NanTarget, &P, &mut rng).unwrap();
+    /// let chain = Chain::new(0.0, &ValidTarget)?;
+    /// let sampler = Sampler::new(chain, &NanTarget, &P, &mut rng);
+    /// assert!(matches!(sampler, Err(McmcError::NanCurrentLogProb)));
+    /// # Ok::<(), McmcError>(())
     /// ```
     ///
-    /// ```should_panic
+    /// ```
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -524,9 +525,10 @@ impl<'a, S, T: Target<S>, P, R: ?Sized> Sampler<'a, S, T, P, R> {
     /// #     }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0.0, &ValidTarget).unwrap();
-    /// // This will return Err(McmcError::InfiniteCurrentLogProb)
-    /// let sampler = Sampler::new(chain, &InfTarget, &P, &mut rng).unwrap();
+    /// let chain = Chain::new(0.0, &ValidTarget)?;
+    /// let sampler = Sampler::new(chain, &InfTarget, &P, &mut rng);
+    /// assert!(matches!(sampler, Err(McmcError::InfiniteCurrentLogProb)));
+    /// # Ok::<(), McmcError>(())
     /// ```
     pub fn new(
         mut chain: Chain<S>,
@@ -718,7 +720,8 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ThinningError::Run)?;
     ///
     /// let states = sampler.run_with_thinning(5, 2)?;
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
@@ -849,7 +852,8 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &i32| *state;
     ///
     /// let samples = sampler.run_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -901,7 +905,8 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &S| state.0;
     /// let mut stats = OnlineStats::new();
     ///
@@ -961,7 +966,9 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// let chain = Chain::new(0, &Flat)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
     ///
@@ -1018,7 +1025,8 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut finite = |state: &f64| {
     ///     if state.is_finite() { Ok(*state) } else { Err("non-finite") }
     /// };
@@ -1058,7 +1066,8 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut nonnegative = |state: &f64| {
     ///     if *state >= 0.0 { Ok(*state) } else { Err("negative state") }
     /// };
@@ -1108,7 +1117,9 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// let chain = Chain::new(0, &Flat)
     ///     .map_err(ObservedStepError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ObservedStepError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &i32| Ok::<i32, Infallible>(*state);
     ///
     /// let samples = sampler.try_run_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -1155,7 +1166,8 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0.0, &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut nonnegative = |state: &f64| {
     ///     if *state >= 0.0 { Ok(*state) } else { Err("negative state") }
     /// };
@@ -1216,7 +1228,9 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// let chain = Chain::new(0, &Flat)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &i32| Ok::<f64, Infallible>(f64::from(*state));
     /// let mut stats = OnlineStats::new();
     ///
@@ -1320,7 +1334,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(Spins(vec![1; 20]), &Ising)?;
-    /// let mut sampler = Sampler::new(chain, &Ising, &Flip, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Ising, &Flip, &mut rng)?;
     ///
     /// sampler.run_mut(1000)?;
     /// assert_eq!(sampler.chain_ref().total_steps(), 1000);
@@ -1417,7 +1431,8 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ThinningError::Run)?;
     ///
     /// let states = sampler.run_mut_with_thinning(5, 2)?;
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
@@ -1561,7 +1576,8 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &S| state.0;
     ///
     /// let samples = sampler.run_mut_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -1613,7 +1629,8 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &S| state.0;
     /// let mut bins = BinningAnalysis::new();
     ///
@@ -1678,7 +1695,9 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// let chain = Chain::new(S(0), &Flat)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &S| f64::from(state.0);
     /// let mut stats = OnlineStats::new();
     ///
@@ -1736,7 +1755,8 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut finite = |state: &S| {
     ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
     /// };
@@ -1780,7 +1800,8 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut finite = |state: &S| {
     ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
     /// };
@@ -1836,7 +1857,9 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// let chain = Chain::new(S(0), &Flat)
     ///     .map_err(ObservedStepError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ObservedStepError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &S| Ok::<i32, Infallible>(state.0);
     ///
     /// let samples = sampler.try_run_mut_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -1889,7 +1912,8 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut finite = |state: &S| {
     ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
     /// };
@@ -1955,7 +1979,9 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// let chain = Chain::new(S(0), &Flat)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &S| Ok::<f64, Infallible>(f64::from(state.0));
     /// let mut stats = OnlineStats::new();
     ///
@@ -2055,7 +2081,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = MoveRight;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(-1, &target)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)?;
     ///
     /// let step = sampler.step_delayed()?;
     /// assert_eq!(step.outcome, StepOutcome::Accepted);
@@ -2134,7 +2160,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = MoveRight;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(-1, &target)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)?;
     ///
     /// let step = sampler.step_delayed_checked()?;
     /// assert_eq!(step.outcome, StepOutcome::Accepted);
@@ -2210,7 +2236,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)?;
     ///
     /// sampler.run_delayed(3)?;
     /// assert_eq!(*sampler.chain_ref().state(), 3);
@@ -2286,7 +2312,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)?;
     ///
     /// let continuation = sampler.run_delayed_chunk(3)?;
     /// assert_eq!(**continuation.state(), 3);
@@ -2382,7 +2408,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)?;
     ///
     /// // Record the selected family and post-step state for every step while
     /// // the sampler owns acceptance, then resume from the continuation.
@@ -2478,7 +2504,9 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(S(0), &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ThinningError::Run)?;
     ///
     /// let states = sampler.run_delayed_with_thinning(5, 2)?;
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
@@ -2536,7 +2564,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)?;
     /// let mut coordinate = |state: &i32| *state;
     ///
     /// let (_step, sample) = sampler.step_delayed_observing(&mut coordinate)?;
@@ -2608,7 +2636,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target).map_err(DelayedStepError::Mcmc)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)?;
     /// let mut coordinate = |state: &i32| *state;
     ///
     /// let samples = sampler.run_delayed_observing(3, &mut coordinate)?;
@@ -2660,7 +2688,9 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &i32| *state;
     ///
     /// let samples = sampler.run_delayed_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -2717,7 +2747,9 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
     ///
@@ -2781,7 +2813,10 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
     ///
@@ -2845,7 +2880,9 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut positive = |state: &i32| {
     ///     if *state > 0 { Ok(*state) } else { Err("not positive") }
     /// };
@@ -2895,7 +2932,9 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut positive = |state: &i32| {
     ///     if *state > 0 { Ok(*state) } else { Err("not positive") }
     /// };
@@ -2950,7 +2989,10 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStepError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStepError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &i32| Ok::<i32, Infallible>(*state);
     ///
     /// let samples = sampler.try_run_delayed_observing_with_thinning(5, 2, &mut coordinate)?;
@@ -3009,7 +3051,9 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut positive = |state: &i32| {
     ///     if *state > 0 { Ok(f64::from(*state)) } else { Err("not positive") }
     /// };
@@ -3074,7 +3118,10 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     ///     .map_err(DelayedStepError::Mcmc)
     ///     .map_err(ObservedStreamError::Step)
     ///     .map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
+    ///     .map_err(DelayedStepError::Mcmc)
+    ///     .map_err(ObservedStreamError::Step)
+    ///     .map_err(ThinningError::Run)?;
     /// let mut coordinate = |state: &i32| Ok::<f64, Infallible>(f64::from(*state));
     /// let mut stats = OnlineStats::new();
     ///
@@ -3146,7 +3193,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Iterator for Sampler<'_, 
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(Val(0.0), &Flat)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Walk, &mut rng).unwrap();
+    /// let mut sampler = Sampler::new(chain, &Flat, &Walk, &mut rng)?;
     ///
     /// // Take exactly 100 steps using iterator
     /// let errors: Vec<_> = sampler.by_ref().take(100).filter_map(Result::err).collect();

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -126,15 +126,14 @@ const fn check_stats(stats: &OnlineStats) -> Result<(), StatisticsError> {
 /// the accumulator state.
 ///
 /// ```
-/// use approx::assert_relative_eq;
 /// use markov_chain_monte_carlo::prelude::{OnlineStats, StatisticsError};
 ///
 /// let mut stats = OnlineStats::new();
 /// stats.try_extend([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0])?;
 ///
 /// assert_eq!(stats.count(), 8);
-/// assert_relative_eq!(stats.mean().unwrap(), 5.0, epsilon = 1e-12);
-/// assert_relative_eq!(stats.population_variance().unwrap(), 4.0, epsilon = 1e-12);
+/// assert_eq!(stats.mean(), Some(5.0));
+/// assert_eq!(stats.population_variance(), Some(4.0));
 /// # Ok::<(), StatisticsError>(())
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -307,12 +306,13 @@ impl OnlineStats {
     /// Whether the accumulator is empty.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::OnlineStats;
+    /// use markov_chain_monte_carlo::prelude::{OnlineStats, StatisticsError};
     ///
     /// let mut stats = OnlineStats::new();
     /// assert!(stats.is_empty());
-    /// stats.try_push(1.0).unwrap();
+    /// stats.try_push(1.0)?;
     /// assert!(!stats.is_empty());
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub const fn is_empty(&self) -> bool {
@@ -454,7 +454,7 @@ impl BinningEstimate {
     /// use markov_chain_monte_carlo::prelude::{BinningAnalysis, StatisticsError};
     ///
     /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
-    /// assert_eq!(bins.estimates().nth(1).unwrap().block_size(), 2);
+    /// assert_eq!(bins.estimates().nth(1).map(|estimate| estimate.block_size()), Some(2));
     /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
@@ -468,7 +468,7 @@ impl BinningEstimate {
     /// use markov_chain_monte_carlo::prelude::{BinningAnalysis, StatisticsError};
     ///
     /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
-    /// assert_eq!(bins.estimates().next().unwrap().block_count(), 4);
+    /// assert_eq!(bins.estimates().next().map(|estimate| estimate.block_count()), Some(4));
     /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
@@ -482,7 +482,7 @@ impl BinningEstimate {
     /// use markov_chain_monte_carlo::prelude::{BinningAnalysis, StatisticsError};
     ///
     /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
-    /// assert_eq!(bins.estimates().next().unwrap().mean(), 2.5);
+    /// assert_eq!(bins.estimates().next().map(|estimate| estimate.mean()), Some(2.5));
     /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
@@ -498,7 +498,10 @@ impl BinningEstimate {
     /// use markov_chain_monte_carlo::prelude::{BinningAnalysis, StatisticsError};
     ///
     /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
-    /// assert_eq!(bins.estimates().nth(2).unwrap().sample_variance(), None);
+    /// assert_eq!(
+    ///     bins.estimates().nth(2).and_then(|estimate| estimate.sample_variance()),
+    ///     None
+    /// );
     /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
@@ -514,7 +517,12 @@ impl BinningEstimate {
     /// use markov_chain_monte_carlo::prelude::{BinningAnalysis, StatisticsError};
     ///
     /// let bins = BinningAnalysis::try_from_iter((1..=4).map(f64::from))?;
-    /// assert!(bins.estimates().next().unwrap().standard_error().is_some());
+    /// assert!(
+    ///     bins.estimates()
+    ///         .next()
+    ///         .and_then(|estimate| estimate.standard_error())
+    ///         .is_some()
+    /// );
     /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
@@ -774,12 +782,13 @@ impl BinningAnalysis {
     /// Whether the analysis contains no measurements.
     ///
     /// ```
-    /// use markov_chain_monte_carlo::prelude::BinningAnalysis;
+    /// use markov_chain_monte_carlo::prelude::{BinningAnalysis, StatisticsError};
     ///
     /// let mut bins = BinningAnalysis::new();
     /// assert!(bins.is_empty());
-    /// bins.try_push(1.0).unwrap();
+    /// bins.try_push(1.0)?;
     /// assert!(!bins.is_empty());
+    /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]
     pub const fn is_empty(&self) -> bool {
@@ -831,7 +840,10 @@ impl BinningAnalysis {
     /// use markov_chain_monte_carlo::prelude::{BinningAnalysis, StatisticsError};
     ///
     /// let bins = BinningAnalysis::try_from_iter((1..=8).map(f64::from))?;
-    /// assert_eq!(bins.coarsest_estimate().unwrap().block_size(), 4);
+    /// assert_eq!(
+    ///     bins.coarsest_estimate().map(|estimate| estimate.block_size()),
+    ///     Some(4)
+    /// );
     /// # Ok::<(), StatisticsError>(())
     /// ```
     #[must_use]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -231,7 +231,6 @@ impl DetailedBalanceReport {
     /// # Examples
     ///
     /// ```
-    /// use approx::assert_relative_eq;
     /// use markov_chain_monte_carlo::prelude::testing::DetailedBalanceReport;
     ///
     /// let report = DetailedBalanceReport::new(
@@ -239,7 +238,7 @@ impl DetailedBalanceReport {
     /// );
     ///
     /// assert_eq!(report.samples, 128);
-    /// assert_relative_eq!(report.z_score().unwrap(), 0.2, epsilon = 1e-12);
+    /// assert!(matches!(report.z_score(), Some(z) if (z - 0.2).abs() < 1e-12));
     /// ```
     #[expect(
         clippy::too_many_arguments,

--- a/tests/semgrep/benches/unwrap_expect.rs
+++ b/tests/semgrep/benches/unwrap_expect.rs
@@ -1,0 +1,12 @@
+#![allow(dead_code)]
+
+fn bench_fixture(result: Result<u32, &'static str>, value: Option<u32>) {
+    // ruleid: mcmc.rust.no-unwrap-expect-in-benches-examples
+    let _ = result.unwrap();
+
+    // ruleid: mcmc.rust.no-unwrap-expect-in-benches-examples
+    let _ = value.expect("benchmarks should avoid expect");
+
+    // ok: mcmc.rust.no-unwrap-expect-in-benches-examples
+    let _ = result.unwrap_or(0);
+}

--- a/tests/semgrep/examples/unwrap_expect.rs
+++ b/tests/semgrep/examples/unwrap_expect.rs
@@ -1,0 +1,12 @@
+#![allow(dead_code)]
+
+fn example_fixture(result: Result<u32, &'static str>, value: Option<u32>) {
+    // ruleid: mcmc.rust.no-unwrap-expect-in-benches-examples
+    let _ = result.unwrap();
+
+    // ruleid: mcmc.rust.no-unwrap-expect-in-benches-examples
+    let _ = value.expect("examples should avoid expect");
+
+    // ok: mcmc.rust.no-unwrap-expect-in-benches-examples
+    let _ = result.unwrap_or(0);
+}

--- a/tests/semgrep/src/doctests/unwrap_expect.rs
+++ b/tests/semgrep/src/doctests/unwrap_expect.rs
@@ -1,0 +1,14 @@
+// ruleid: mcmc.rust.no-unwrap-expect-in-doctests
+/// let value = Some(1_u32).unwrap();
+
+// ruleid: mcmc.rust.no-unwrap-expect-in-doctests
+//! let value = Ok::<u32, &'static str>(1).expect("doctest should not panic");
+
+// ok: mcmc.rust.no-unwrap-expect-in-doctests
+/// # fn main() -> Result<(), markov_chain_monte_carlo::McmcError> { Ok(()) }
+
+// ok: mcmc.rust.no-unwrap-expect-in-doctests
+/// Do not use `.unwrap()` in public examples.
+
+// ok: mcmc.rust.no-unwrap-expect-in-doctests
+/// Prefer `?` to `.expect("message")` in public examples.

--- a/tests/semgrep/src/doctests/unwrap_expect.rs
+++ b/tests/semgrep/src/doctests/unwrap_expect.rs
@@ -4,6 +4,21 @@
 // ruleid: mcmc.rust.no-unwrap-expect-in-doctests
 //! let value = Ok::<u32, &'static str>(1).expect("doctest should not panic");
 
+// ruleid: mcmc.rust.no-unwrap-expect-in-doctests
+///     .unwrap();
+
+// ruleid: mcmc.rust.no-unwrap-expect-in-doctests
+//!     .expect("doctest should not panic");
+
+// ruleid: mcmc.rust.no-unwrap-expect-in-doctests
+/// let value = parse_value()?.unwrap();
+
+// ruleid: mcmc.rust.no-unwrap-expect-in-doctests
+/** let value = Some(1_u32).unwrap(); */
+
+// ruleid: mcmc.rust.no-unwrap-expect-in-doctests
+/*! let value = Ok::<u32, &'static str>(1).expect("doctest should not panic"); */
+
 // ok: mcmc.rust.no-unwrap-expect-in-doctests
 /// # fn main() -> Result<(), markov_chain_monte_carlo::McmcError> { Ok(()) }
 
@@ -12,3 +27,6 @@
 
 // ok: mcmc.rust.no-unwrap-expect-in-doctests
 /// Prefer `?` to `.expect("message")` in public examples.
+
+// ok: mcmc.rust.no-unwrap-expect-in-doctests
+/** Avoid `.unwrap()` in block doctests; prefer `?`. */


### PR DESCRIPTION
- Replace unwrap and expect flows in doctests, examples, and benchmarks with typed error propagation or contextual benchmark failure handling.
- Add Semgrep guardrails and fixtures that catch unwrap and expect usage in public doctests, examples, and benchmarks.
- Keep generated documentation and tooling metadata aligned with the updated validation surface.