### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-05-30
 
 ### Added
 
@@ -101,6 +101,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Repair the historical changelog body for escaped Rust generic examples.
   - Filter changelog-only body noise from generated release notes.
   - Regenerate CHANGELOG.md with the corrected commit preprocessing.
+- Enforce fallible public Rust examples [#62](https://github.com/acgetchell/markov-chain-monte-carlo/pull/62) [#80](https://github.com/acgetchell/markov-chain-monte-carlo/pull/80) [`ca2ba16`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/ca2ba169385a8fa99aced9100a392fb402fa29bf)
+
+  * fix: enforce fallible public Rust examples [#62](https://github.com/acgetchell/markov-chain-monte-carlo/pull/62)
+
+  - Replace unwrap and expect flows in doctests, examples, and benchmarks with typed error propagation or contextual benchmark failure handling.
+  - Add Semgrep guardrails and fixtures that catch unwrap and expect usage in public doctests, examples, and benchmarks.
+  - Keep generated documentation and tooling metadata aligned with the updated validation surface.
+
+  * fix(semgrep): catch doctest unwrap continuations [#62](https://github.com/acgetchell/markov-chain-monte-carlo/pull/62)
+
+  - Detect unwrap and expect calls on rustfmt-style continuation lines in doctests.
+  - Cover line and block doctest fixtures for public panic-based example flows.
+  - Document the no-unwrap doctest, example, and benchmark convention.
 
 ### Maintenance
 
@@ -395,7 +408,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial commit: scaffold MCMC crate [`5d7f706`](https://github.com/acgetchell/markov-chain-monte-carlo/commit/5d7f706da2d7c41af619a2f5669cdcd56dae94ba)
 
-[Unreleased]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.3.0...HEAD
+[0.4.0]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/acgetchell/markov-chain-monte-carlo/compare/v0.1.0...v0.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
 title: "markov-chain-monte-carlo: A composable MCMC framework for Rust"
-version: "0.3.0"
+version: "0.4.0"
 doi: 10.5281/zenodo.20033111
 url: "https://github.com/acgetchell/markov-chain-monte-carlo"
 repository-code: "https://github.com/acgetchell/markov-chain-monte-carlo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "markov-chain-monte-carlo"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markov-chain-monte-carlo"
-version = "0.3.0"
+version = "0.4.0"
 authors = [ "Adam Getchell" ]
 edition = "2024"
 rust-version = "1.96.0"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -54,8 +54,11 @@ Then refresh lockfiles/build metadata:
 
 ```bash
 cargo check
-uv sync --group dev
+uv sync
 ```
+
+`uv sync` installs the default `dev` and `notebook` dependency groups (configured in `[tool.uv] default-groups`), refreshing `uv.lock` so the notebook
+execution dependencies exercised by `just ci` are provisioned during release validation.
 
 ### 3. Generate the changelog
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,24 +20,23 @@ The v0.3.0 milestone made the crate useful as the sampling layer for downstream 
 - [x] Optional `serde` checkpointing
 - [x] Detailed-balance verification for by-value, in-place, and delayed proposals
 
-## Planned Milestones
-
 ### v0.4.0 Resumable CDT Integration
 
-The next feature release should focus on downstream sampler integration rather than a grab bag of diagnostics. This is the right place for the Rust 1.96.0
-MSRV/toolchain refresh.
+The v0.4.0 milestone focused on downstream sampler integration and included the Rust 1.96.0 MSRV/toolchain refresh.
 
-- [#65](https://github.com/acgetchell/markov-chain-monte-carlo/issues/65) - Update Rust toolchain and MSRV to 1.96.0
+- [x] [#65](https://github.com/acgetchell/markov-chain-monte-carlo/issues/65) - Update Rust toolchain and MSRV to 1.96.0
 - [x] [#60](https://github.com/acgetchell/markov-chain-monte-carlo/issues/60) - Expose resumable sampler state for chunked runs
-- [#61](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61) - Expose delayed-step hooks or telemetry for domain-specific sampler integration
+- [x] [#61](https://github.com/acgetchell/markov-chain-monte-carlo/issues/61) - Expose delayed-step hooks or telemetry for domain-specific sampler integration
 - [x] [#59](https://github.com/acgetchell/markov-chain-monte-carlo/issues/59) - Support additive target bias terms in Metropolis-Hastings acceptance
-- [#48](https://github.com/acgetchell/markov-chain-monte-carlo/issues/48) - Investigate detailed balance for delayed proposals with variable valid-site counts
+- [x] [#48](https://github.com/acgetchell/markov-chain-monte-carlo/issues/48) - Detailed balance for delayed proposals with variable valid-site counts
 - [x] [#62](https://github.com/acgetchell/markov-chain-monte-carlo/issues/62) - Clean up doctest/example unwraps and enforce with Semgrep
 
 Resumable chunked runs shipped as `Sampler::run_chunk`, `run_mut_chunk`, and `run_delayed_chunk`, each returning a checkpoint-compatible continuation, plus
 `run_delayed_chunk_observing` for per-step delayed telemetry. A combined `(measurements, continuation)` return shape is intentionally deferred: callers keep
 measurements in their own buffers and accumulate across chunks today. Revisit the combined shape once `causal-triangulations` integrates against v0.4.0 and
 shows whether the callback-plus-continuation composition is sufficient in practice.
+
+## Planned Milestones
 
 ### v0.5.0 Adaptive Diagnostics
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "markov-chain-monte-carlo-tooling"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python utility scripts for the markov-chain-monte-carlo Rust library"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -822,7 +822,7 @@ wheels = [
 
 [[package]]
 name = "markov-chain-monte-carlo-tooling"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- Bump crate, tooling, citation, and lockfile versions to 0.4.0.
- Promote the changelog from Unreleased to the 2026-05-30 v0.4.0 release.
- Mark the v0.4.0 roadmap items complete and document release sync behavior for default uv groups.