### PR TITLE
build!: require Rust 1.97.1

### DIFF
--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -1,0 +1,51 @@
+name: Set up just
+description: Resolve the pinned just version from justfile and install it.
+
+outputs:
+  version:
+    description: Resolved just version from justfile.
+    value: ${{ steps.resolve.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve just version
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s extglob
+
+        version=""
+        declaration_re='^[[:space:]]*just_version[[:space:]]*:=[[:space:]]*(.*)$'
+        while IFS= read -r line; do
+          if [[ "$line" =~ $declaration_re ]]; then
+            value="${BASH_REMATCH[1]}"
+            value="${value%%#*}"
+            value="${value##+([[:space:]])}"
+            value="${value%%+([[:space:]])}"
+
+            if [[ ${#value} -ge 2 ]]; then
+              first="${value:0:1}"
+              last="${value: -1}"
+              if [[ "$first" == "$last" && ( "$first" == '"' || "$first" == "'" ) ]]; then
+                value="${value:1:${#value}-2}"
+              fi
+            fi
+
+            version="$value"
+            break
+          fi
+        done < justfile
+
+        if [[ -z "$version" ]]; then
+          echo "::error::Could not resolve just_version from justfile"
+          exit 1
+        fi
+
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Install just
+      uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+      with:
+        tool: just@${{ steps.resolve.outputs.version }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,19 @@ updates:
       dependencies:
         patterns:
           - "*"
+
+  # Enable version updates for Python development dependencies locked by uv
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,40 @@ jobs:
         id: tool_versions
         shell: bash
         run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          cargo_nextest_version="$(resolve_version cargo_nextest_version)"
+          dprint_version="$(resolve_version dprint_version)"
+          rumdl_version="$(resolve_version rumdl_version)"
+          taplo_version="$(resolve_version taplo_version)"
+          typos_version="$(resolve_version typos_version)"
+          uv_version="$(resolve_version uv_version)"
+          zizmor_version="$(resolve_version zizmor_version)"
+
           {
-            echo "CARGO_NEXTEST_VERSION=$(just --evaluate cargo_nextest_version)"
-            echo "DPRINT_VERSION=$(just --evaluate dprint_version)"
-            echo "RUMDL_VERSION=$(just --evaluate rumdl_version)"
-            echo "TAPLO_VERSION=$(just --evaluate taplo_version)"
-            echo "TYPOS_VERSION=$(just --evaluate typos_version)"
-            echo "UV_VERSION=$(just --evaluate uv_version)"
-            echo "ZIZMOR_VERSION=$(just --evaluate zizmor_version)"
+            echo "CARGO_NEXTEST_VERSION=$cargo_nextest_version"
+            echo "DPRINT_VERSION=$dprint_version"
+            echo "RUMDL_VERSION=$rumdl_version"
+            echo "TAPLO_VERSION=$taplo_version"
+            echo "TYPOS_VERSION=$typos_version"
+            echo "UV_VERSION=$uv_version"
+            echo "ZIZMOR_VERSION=$zizmor_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  CARGO_NEXTEST_VERSION: "0.9.137"
-  DPRINT_VERSION: "0.54.0"
-  JUST_VERSION: "1.51.0"
-  RUMDL_VERSION: "0.2.14"
-  TAPLO_VERSION: "0.10.0"
-  TYPOS_VERSION: "1.47.2"
-  UV_VERSION: "0.11.16"
-  ZIZMOR_VERSION: "1.25.2"
 
 jobs:
   build:
@@ -70,6 +62,23 @@ jobs:
           cache: true
           # toolchain, components, etc. are specified in rust-toolchain.toml
 
+      - name: Set up just
+        uses: ./.github/actions/setup-just
+
+      - name: Export tool versions
+        id: tool_versions
+        shell: bash
+        run: |
+          {
+            echo "CARGO_NEXTEST_VERSION=$(just --evaluate cargo_nextest_version)"
+            echo "DPRINT_VERSION=$(just --evaluate dprint_version)"
+            echo "RUMDL_VERSION=$(just --evaluate rumdl_version)"
+            echo "TAPLO_VERSION=$(just --evaluate taplo_version)"
+            echo "TYPOS_VERSION=$(just --evaluate typos_version)"
+            echo "UV_VERSION=$(just --evaluate uv_version)"
+            echo "ZIZMOR_VERSION=$(just --evaluate zizmor_version)"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -78,53 +87,50 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: ${{ env.UV_VERSION }}
+          version: ${{ steps.tool_versions.outputs.UV_VERSION }}
           enable-cache: true
 
       - name: Sync Python tooling
         run: uv sync --locked --group dev
 
-      - name: Install just
-        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
-        with:
-          tool: just@${{ env.JUST_VERSION }}
-
       - name: Install dprint
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: dprint@${{ env.DPRINT_VERSION }}
+          tool: dprint@${{ steps.tool_versions.outputs.DPRINT_VERSION }}
 
       - name: Install rumdl
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: rumdl@${{ env.RUMDL_VERSION }}
+          tool: rumdl@${{ steps.tool_versions.outputs.RUMDL_VERSION }}
 
       - name: Install taplo
         id: install-taplo
         continue-on-error: ${{ matrix.os == 'windows-latest' }}
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: taplo-cli@${{ env.TAPLO_VERSION }}
+          tool: taplo-cli@${{ steps.tool_versions.outputs.TAPLO_VERSION }}
 
       - name: Install taplo on Windows after cached install failure
         if: matrix.os == 'windows-latest' && steps.install-taplo.outcome == 'failure'
         shell: pwsh
         run: cargo install --locked taplo-cli --version $env:TAPLO_VERSION
+        env:
+          TAPLO_VERSION: ${{ steps.tool_versions.outputs.TAPLO_VERSION }}
 
       - name: Install typos
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: typos-cli@${{ env.TYPOS_VERSION }}
+          tool: typos-cli@${{ steps.tool_versions.outputs.TYPOS_VERSION }}
 
       - name: Install zizmor
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: zizmor@${{ env.ZIZMOR_VERSION }}
+          tool: zizmor@${{ steps.tool_versions.outputs.ZIZMOR_VERSION }}
 
       - name: Install cargo-nextest
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: cargo-nextest@${{ env.CARGO_NEXTEST_VERSION }}
+          tool: cargo-nextest@${{ steps.tool_versions.outputs.CARGO_NEXTEST_VERSION }}
 
       - name: Run CI checks
         run: just ci

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,9 +20,6 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
-    env:
-      CARGO_LLVM_COV_VERSION: "0.8.7"
-      JUST_VERSION: "1.51.0"
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -38,15 +35,24 @@ jobs:
       - name: Install LLVM coverage tools
         run: rustup component add llvm-tools-preview
 
+      - name: Set up just
+        uses: ./.github/actions/setup-just
+
+      - name: Resolve cargo-llvm-cov version
+        id: cargo_llvm_cov_version
+        shell: bash
+        run: |
+          version="$(just --evaluate cargo_llvm_cov_version)"
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not resolve cargo_llvm_cov_version from justfile"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: cargo-llvm-cov@${{ env.CARGO_LLVM_COV_VERSION }}
-
-      - name: Install just
-        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
-        with:
-          tool: just@${{ env.JUST_VERSION }}
+          tool: cargo-llvm-cov@${{ steps.cargo_llvm_cov_version.outputs.version }}
 
       - name: Run coverage
         run: |

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -23,9 +23,6 @@ jobs:
   clippy-sarif:
     name: Clippy SARIF Analysis
     runs-on: ubuntu-latest
-    env:
-      CLIPPY_SARIF_VERSION: "0.8.0"
-      SARIF_FMT_VERSION: "0.8.0"
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -37,15 +34,48 @@ jobs:
         with:
           cache: true # toolchain/components are specified in rust-toolchain.toml
 
+      - name: Set up just
+        uses: ./.github/actions/setup-just
+
+      - name: Export tool versions
+        id: tool_versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          clippy_sarif_version="$(resolve_version clippy_sarif_version)"
+          sarif_fmt_version="$(resolve_version sarif_fmt_version)"
+
+          {
+            echo "CLIPPY_SARIF_VERSION=$clippy_sarif_version"
+            echo "SARIF_FMT_VERSION=$sarif_fmt_version"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Install clippy-sarif
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: clippy-sarif@${{ env.CLIPPY_SARIF_VERSION }}
+          tool: clippy-sarif@${{ steps.tool_versions.outputs.CLIPPY_SARIF_VERSION }}
 
       - name: Install sarif-fmt
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: sarif-fmt@${{ env.SARIF_FMT_VERSION }}
+          tool: sarif-fmt@${{ steps.tool_versions.outputs.SARIF_FMT_VERSION }}
 
       - name: Run clippy with SARIF output
         run: |

--- a/.github/workflows/semgrep-sarif.yml
+++ b/.github/workflows/semgrep-sarif.yml
@@ -23,9 +23,6 @@ permissions:
   security-events: write
   actions: read
 
-env:
-  UV_VERSION: "0.11.16"
-
 jobs:
   semgrep-sarif:
     name: Repository Rule SARIF Analysis
@@ -37,10 +34,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up just
+        uses: ./.github/actions/setup-just
+
+      - name: Resolve uv version
+        id: uv_version
+        shell: bash
+        run: |
+          version="$(just --evaluate uv_version)"
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not resolve uv_version from justfile"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: ${{ env.UV_VERSION }}
+          version: ${{ steps.uv_version.outputs.version }}
 
       - name: Run repository Semgrep rules
         id: semgrep

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ This project is governed by [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). The comm
 
 Before you begin, ensure you have:
 
-1. **Rust 1.96.0** (pinned via [`rust-toolchain.toml`](rust-toolchain.toml) — automatically handled by rustup)
+1. **Rust 1.97.1** (pinned via [`rust-toolchain.toml`](rust-toolchain.toml) — automatically handled by rustup)
 2. **Git** for version control
 3. **Just** (command runner): `cargo install just`
 4. **uv** (Python tooling): install from [astral.sh/uv][uv]
@@ -89,7 +89,7 @@ Before you begin, ensure you have:
 
 This project pins its Rust toolchain via [`rust-toolchain.toml`](rust-toolchain.toml). When you enter the project directory, `rustup` will automatically:
 
-- install the correct Rust version (1.96.0) if you don't have it
+- install the correct Rust version (1.97.1) if you don't have it
 - switch to the pinned version for this project
 - install required components (clippy, rustfmt, rust-docs, rust-std, rust-src, rust-analyzer)
 
@@ -196,7 +196,7 @@ just help-workflows  # Detailed workflow guidance
 ### Rust Code Style
 
 - **Edition**: Rust 2024
-- **MSRV**: 1.96.0 (pinned in `rust-toolchain.toml`)
+- **MSRV**: 1.97.1 (pinned in `rust-toolchain.toml`)
 - **Formatting**: `cargo fmt --all` (configured in `rustfmt.toml`)
 - **Linting**: strict clippy with warnings as errors
 
@@ -205,10 +205,12 @@ just help-workflows  # Detailed workflow guidance
 `just clippy` runs:
 
 ```bash
-cargo clippy --workspace --all-targets -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo -A clippy::multiple_crate_versions
+CARGO_BUILD_WARNINGS=deny cargo clippy --locked --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo -A clippy::multiple_crate_versions
 ```
 
-The crate forbids `unsafe_code` and warns on `missing_docs`; broken intra-doc links are denied.
+Cargo owns the warning-as-error policy so changing the policy does not invalidate compiled artifacts. The explicit `-W` flags remain because they enable
+Clippy lint groups; `CARGO_BUILD_WARNINGS=deny` changes the severity of enabled lints but does not select those groups. The crate forbids `unsafe_code` and
+warns on `missing_docs`; broken intra-doc links are denied.
 
 ### API Style
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -444,7 +444,7 @@ dependencies = [
  "approx",
  "criterion",
  "proptest",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_json",
 ]
@@ -536,7 +536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -746,9 +746,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -756,22 +756,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -804,6 +804,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -920,7 +931,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1053,7 +1064,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1069,7 +1080,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1128,7 +1139,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -558,7 +558,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -596,9 +596,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -776,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "markov-chain-monte-carlo"
 version = "0.4.0"
 authors = [ "Adam Getchell" ]
 edition = "2024"
-rust-version = "1.96.0"
+rust-version = "1.97.1"
 
 description = "A composable Markov Chain Monte Carlo (MCMC) framework for arbitrary state spaces in Rust"
 homepage = "https://github.com/acgetchell/markov-chain-monte-carlo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ all-features = true
 approx = "0.5.1"
 criterion = "0.8.2"
 proptest = "1.11.0"
-serde_json = "1.0.150"
+serde_json = "1.0.151"
 
 [[bench]]
 name = "stepping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ keywords = [ "mcmc", "markov-chain", "monte-carlo", "sampling", "metropolis-hast
 categories = [ "science", "mathematics", "algorithms" ]
 
 [dependencies]
-rand = "0.10.1"
-serde = { version = "1.0.228", features = [ "derive" ], optional = true }
+rand = "0.10.2"
+serde = { version = "1.0.229", features = [ "derive" ], optional = true }
 
 [features]
 serde = [ "dep:serde" ]

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Enable checkpoint serialization when needed:
 cargo add markov-chain-monte-carlo --features serde
 ```
 
-Rust 1.96.0 or newer is required.
+Rust 1.97.1 or newer is required.
 
 Minimal by-value Metropolis-Hastings sampler. This example demonstrates the transition mechanics; convergence assessment remains a separate analysis step.
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
 # Clippy configuration for IDE and local consistency.
 
 # Minimum Supported Rust Version - matches Cargo.toml and rust-toolchain.toml.
-msrv = "1.96.0"
+msrv = "1.97.1"

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -22,6 +22,9 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 │   └── nextest.toml
 ├── .github/
 │   ├── CODEOWNERS
+│   ├── actions/
+│   │   └── setup-just/
+│   │       └── action.yml
 │   ├── dependabot.yml
 │   └── workflows/
 │       ├── audit.yml

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -1,6 +1,6 @@
 # Rust Development
 
-This repository is a single Rust library crate using Rust 1.96.0 and edition 2024.
+This repository is a single Rust library crate using Rust 1.97.1 and edition 2024.
 
 ## Core Commands
 
@@ -57,6 +57,22 @@ The full command is factored into named subsets so CI-shape trade-offs are expli
 
 The GitHub Actions `CI` workflow intentionally runs `just ci` on Linux, macOS, and Windows so all supported development platforms exercise the same
 comprehensive validation gate.
+
+## Rust 1.97.1 Audit
+
+The MSRV and contributor toolchain use Rust 1.97.1 rather than 1.97.0 because the point release fixes an LLVM miscompilation. The audit below follows the
+official [Rust 1.97.0 release notes](https://doc.rust-lang.org/stable/releases.html#version-1970-2026-07-09) and
+[Rust 1.97.1 announcement](https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/).
+
+| Surface | Decision |
+| --- | --- |
+| Cargo warning policy | `just clippy` uses `CARGO_BUILD_WARNINGS=deny` instead of `-D warnings`, so changing warning severity does not invalidate the build cache. The explicit Clippy `-W` selectors remain because Cargo changes the severity of enabled lints but does not enable `pedantic`, `nursery`, or `cargo`. The standalone rustdoc command keeps `RUSTDOCFLAGS="-D warnings"` to express rustdoc-specific policy at that command boundary. |
+| `Result<T, Infallible>` must-use behavior | Keep the typed infallible results. Library tests, doctests, examples, integration tests, and benchmark compilation exercise these APIs under 1.97.1 without exposing ignored results. |
+| Symbol mangling and code generation | Keep the new v0 symbol mangling default. Repository benchmarks, backtraces, and LLVM coverage do not parse legacy symbol names. The 1.97.1 LLVM fix is the reason to require the point release rather than 1.97.0. |
+| Linker messages | Keep the lint enabled and add no suppression. Local validation checks the host linker, while the Linux, macOS, and Windows CI matrix checks the supported platform linkers. Any future suppression must be limited to a demonstrated platform-specific false positive. |
+| Integer, `NonZero`, and `RepeatN` APIs | No change. Existing `NonZeroUsize` values model validated counts rather than bit masks, and the crate does not construct a reusable `RepeatN`; adopting the new APIs would add churn without clarifying an invariant. |
+| `resolver.lockfile-path` | No change. The crate commits `Cargo.lock`, and its build, benchmark, release, and coverage workflows use writable checkouts; there is no read-only source workflow that needs a relocated lockfile. |
+| Clippy, rustfmt, and rustdoc | Keep the current configuration. The 1.97 Clippy lint set is enforced by `just clippy`; rustfmt produces no formatting changes; and the new rustdoc `--emit` and path-remapping options do not improve the current local or docs.rs workflow. |
 
 ## Setup
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,6 +51,7 @@ API breaks are acceptable when they make invalid states unrepresentable or prese
 After the CDT-facing continuation and acceptance APIs settle, invest in classical adaptive sampling and diagnostics that help users decide whether a run is
 scientifically trustworthy. This should happen before learned-proposal work so there is a baseline to compare against.
 
+- [x] [#104](https://github.com/acgetchell/markov-chain-monte-carlo/issues/104) - Update Rust toolchain and MSRV to 1.97.1
 - [#10](https://github.com/acgetchell/markov-chain-monte-carlo/issues/10) - Adaptive Metropolis-Hastings
 - [#13](https://github.com/acgetchell/markov-chain-monte-carlo/issues/13) - Diagnostics: ESS, autocorrelation, and R-hat
 - [#42](https://github.com/acgetchell/markov-chain-monte-carlo/issues/42) - Continuous proposal diagnostics

--- a/justfile
+++ b/justfile
@@ -7,9 +7,9 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 
 cargo_nextest_version := "0.9.137"
 cargo_llvm_cov_version := "0.8.7"
-dprint_version := "0.54.0"
+dprint_version := "0.55.2"
 git_cliff_version := "2.13.1"
-rumdl_version := "0.2.14"
+rumdl_version := "0.2.48"
 taplo_version := "0.10.0"
 typos_version := "1.47.2"
 zizmor_version := "1.25.2"
@@ -227,7 +227,7 @@ clean:
 
 # Clippy linting
 clippy:
-    cargo clippy --locked --workspace --all-targets -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo -A clippy::multiple_crate_versions
+    CARGO_BUILD_WARNINGS=deny cargo clippy --locked --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo -A clippy::multiple_crate_versions
 
 # Coverage analysis for local development (HTML output)
 coverage: _ensure-cargo-llvm-cov

--- a/justfile
+++ b/justfile
@@ -5,14 +5,16 @@
 # Use bash with strict error handling for all recipes
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
-cargo_nextest_version := "0.9.137"
+cargo_nextest_version := "0.9.140"
 cargo_llvm_cov_version := "0.8.7"
 dprint_version := "0.55.2"
 git_cliff_version := "2.13.1"
+just_version := "1.57.0"
 rumdl_version := "0.2.48"
 taplo_version := "0.10.0"
-typos_version := "1.47.2"
-zizmor_version := "1.25.2"
+typos_version := "1.48.0"
+uv_version := "0.12.0"
+zizmor_version := "1.28.0"
 example_names := "detailed_balance normal_1d ising_1d iterator_sampling delayed_chunked_telemetry additive_target_bias"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
@@ -39,9 +41,9 @@ _ensure-cargo-llvm-cov:
     if command -v cargo-llvm-cov >/dev/null; then
         installed_version="$(cargo llvm-cov --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
     fi
-    if [[ "$installed_version" != "{{cargo_llvm_cov_version}}" ]]; then
-        echo "❌ 'cargo-llvm-cov' {{cargo_llvm_cov_version}} not found. Install with:"
-        echo "   cargo install --locked cargo-llvm-cov --version {{cargo_llvm_cov_version}}"
+    if [[ "$installed_version" != "{{ cargo_llvm_cov_version }}" ]]; then
+        echo "❌ 'cargo-llvm-cov' {{ cargo_llvm_cov_version }} not found. Install with:"
+        echo "   cargo install --locked cargo-llvm-cov --version {{ cargo_llvm_cov_version }}"
         exit 1
     fi
 
@@ -52,9 +54,9 @@ _ensure-cargo-nextest:
     if cargo nextest --version >/dev/null 2>&1; then
         installed_version="$(cargo nextest --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
     fi
-    if [[ "$installed_version" != "{{cargo_nextest_version}}" ]]; then
-        echo "❌ 'cargo-nextest' {{cargo_nextest_version}} not found. Install with:"
-        echo "   cargo install --locked cargo-nextest --version {{cargo_nextest_version}}"
+    if [[ "$installed_version" != "{{ cargo_nextest_version }}" ]]; then
+        echo "❌ 'cargo-nextest' {{ cargo_nextest_version }} not found. Install with:"
+        echo "   cargo install --locked cargo-nextest --version {{ cargo_nextest_version }}"
         exit 1
     fi
 
@@ -65,9 +67,9 @@ _ensure-dprint:
     if command -v dprint >/dev/null; then
         installed_version="$(dprint --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
     fi
-    if [[ "$installed_version" != "{{dprint_version}}" ]]; then
-        echo "❌ 'dprint' {{dprint_version}} not found. Install with:"
-        echo "   cargo install --locked dprint --version {{dprint_version}}"
+    if [[ "$installed_version" != "{{ dprint_version }}" ]]; then
+        echo "❌ 'dprint' {{ dprint_version }} not found. Install with:"
+        echo "   cargo install --locked dprint --version {{ dprint_version }}"
         exit 1
     fi
 
@@ -78,9 +80,9 @@ _ensure-git-cliff:
     if command -v git-cliff >/dev/null; then
         installed_version="$(git-cliff --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
     fi
-    if [[ "$installed_version" != "{{git_cliff_version}}" ]]; then
-        echo "❌ 'git-cliff' {{git_cliff_version}} not found. Install with:"
-        echo "   cargo install --locked git-cliff --version {{git_cliff_version}}"
+    if [[ "$installed_version" != "{{ git_cliff_version }}" ]]; then
+        echo "❌ 'git-cliff' {{ git_cliff_version }} not found. Install with:"
+        echo "   cargo install --locked git-cliff --version {{ git_cliff_version }}"
         exit 1
     fi
 
@@ -96,9 +98,9 @@ _ensure-rumdl:
     if command -v rumdl >/dev/null; then
         installed_version="$(rumdl --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
     fi
-    if [[ "$installed_version" != "{{rumdl_version}}" ]]; then
-        echo "❌ 'rumdl' {{rumdl_version}} not found. Install with:"
-        echo "   cargo install --locked rumdl --version {{rumdl_version}}"
+    if [[ "$installed_version" != "{{ rumdl_version }}" ]]; then
+        echo "❌ 'rumdl' {{ rumdl_version }} not found. Install with:"
+        echo "   cargo install --locked rumdl --version {{ rumdl_version }}"
         exit 1
     fi
 
@@ -109,9 +111,9 @@ _ensure-taplo:
     if command -v taplo >/dev/null; then
         installed_version="$(taplo --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
     fi
-    if [[ "$installed_version" != "{{taplo_version}}" ]]; then
-        echo "❌ 'taplo' {{taplo_version}} not found. Install with:"
-        echo "   cargo install --locked taplo-cli --version {{taplo_version}}"
+    if [[ "$installed_version" != "{{ taplo_version }}" ]]; then
+        echo "❌ 'taplo' {{ taplo_version }} not found. Install with:"
+        echo "   cargo install --locked taplo-cli --version {{ taplo_version }}"
         exit 1
     fi
 
@@ -122,9 +124,9 @@ _ensure-typos:
     if command -v typos >/dev/null; then
         installed_version="$(typos --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
     fi
-    if [[ "$installed_version" != "{{typos_version}}" ]]; then
-        echo "❌ 'typos' {{typos_version}} not found. Install with:"
-        echo "   cargo install --locked typos-cli --version {{typos_version}}"
+    if [[ "$installed_version" != "{{ typos_version }}" ]]; then
+        echo "❌ 'typos' {{ typos_version }} not found. Install with:"
+        echo "   cargo install --locked typos-cli --version {{ typos_version }}"
         exit 1
     fi
 
@@ -140,9 +142,9 @@ _ensure-zizmor:
     if command -v zizmor >/dev/null; then
         installed_version="$(zizmor --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
     fi
-    if [[ "$installed_version" != "{{zizmor_version}}" ]]; then
-        echo "❌ 'zizmor' {{zizmor_version}} not found. Install with:"
-        echo "   cargo install --locked zizmor --version {{zizmor_version}}"
+    if [[ "$installed_version" != "{{ zizmor_version }}" ]]; then
+        echo "❌ 'zizmor' {{ zizmor_version }} not found. Install with:"
+        echo "   cargo install --locked zizmor --version {{ zizmor_version }}"
         exit 1
     fi
 
@@ -183,7 +185,7 @@ changelog: _ensure-git-cliff python-sync
 changelog-unreleased version: _ensure-git-cliff python-sync
     #!/usr/bin/env bash
     set -euo pipefail
-    GIT_CLIFF_OFFLINE=true git-cliff --tag {{version}} -o CHANGELOG.md
+    GIT_CLIFF_OFFLINE=true git-cliff --tag {{ version }} -o CHANGELOG.md
     uv run postprocess-changelog
 
 # Non-mutating validation gate
@@ -235,7 +237,7 @@ coverage: _ensure-cargo-llvm-cov
     set -euo pipefail
 
     mkdir -p target/llvm-cov
-    cargo llvm-cov {{_coverage_base_args}} --open --output-dir target/llvm-cov
+    cargo llvm-cov {{ _coverage_base_args }} --open --output-dir target/llvm-cov
     echo "Coverage report generated: target/llvm-cov/html/index.html"
 
 # Coverage analysis for CI (XML output for codecov)
@@ -244,7 +246,7 @@ coverage-ci: _ensure-cargo-llvm-cov
     set -euo pipefail
 
     mkdir -p coverage
-    cargo llvm-cov {{_coverage_base_args}} --cobertura --output-path coverage/cobertura.xml
+    cargo llvm-cov {{ _coverage_base_args }} --cobertura --output-path coverage/cobertura.xml
 
 # Default recipe shows available commands
 default:
@@ -256,7 +258,7 @@ doc:
 
 # Run one example by name, e.g. `just example ising_1d`.
 example name:
-    cargo run --locked --example "{{name}}"
+    cargo run --locked --example "{{ name }}"
 
 examples: _build-examples
     #!/usr/bin/env bash
@@ -265,7 +267,7 @@ examples: _build-examples
     if [[ "${OS:-}" == "Windows_NT" ]]; then
         suffix=".exe"
     fi
-    for example in {{example_names}}; do
+    for example in {{ example_names }}; do
         "target/debug/examples/${example}${suffix}"
     done
 
@@ -510,35 +512,35 @@ setup-tools:
     echo ""
 
     echo "Ensuring cargo tools..."
-    cargo_llvm_cov_version="{{cargo_llvm_cov_version}}"
+    cargo_llvm_cov_version="{{ cargo_llvm_cov_version }}"
     if ! have cargo-llvm-cov || [[ "$(cargo llvm-cov --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$cargo_llvm_cov_version" ]]; then
         cargo install --locked cargo-llvm-cov --version "$cargo_llvm_cov_version"
     fi
-    cargo_nextest_version="{{cargo_nextest_version}}"
+    cargo_nextest_version="{{ cargo_nextest_version }}"
     if ! cargo nextest --version >/dev/null 2>&1 || [[ "$(cargo nextest --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$cargo_nextest_version" ]]; then
         cargo install --locked cargo-nextest --version "$cargo_nextest_version"
     fi
-    dprint_version="{{dprint_version}}"
+    dprint_version="{{ dprint_version }}"
     if ! have dprint || [[ "$(dprint --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$dprint_version" ]]; then
         cargo install --locked dprint --version "$dprint_version"
     fi
-    git_cliff_version="{{git_cliff_version}}"
+    git_cliff_version="{{ git_cliff_version }}"
     if ! have git-cliff || [[ "$(git-cliff --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$git_cliff_version" ]]; then
         cargo install --locked git-cliff --version "$git_cliff_version"
     fi
-    taplo_version="{{taplo_version}}"
+    taplo_version="{{ taplo_version }}"
     if ! have taplo || [[ "$(taplo --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$taplo_version" ]]; then
         cargo install --locked taplo-cli --version "$taplo_version"
     fi
-    rumdl_version="{{rumdl_version}}"
+    rumdl_version="{{ rumdl_version }}"
     if ! have rumdl || [[ "$(rumdl --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$rumdl_version" ]]; then
         cargo install --locked rumdl --version "$rumdl_version"
     fi
-    typos_version="{{typos_version}}"
+    typos_version="{{ typos_version }}"
     if ! have typos || [[ "$(typos --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$typos_version" ]]; then
         cargo install --locked typos-cli --version "$typos_version"
     fi
-    zizmor_version="{{zizmor_version}}"
+    zizmor_version="{{ zizmor_version }}"
     if ! have zizmor || [[ "$(zizmor --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" != "$zizmor_version" ]]; then
         cargo install --locked zizmor --version "$zizmor_version"
     fi
@@ -594,11 +596,11 @@ spell-check: _ensure-typos
 
 # Create an annotated git tag from the CHANGELOG.md section for the given version
 tag version: python-sync
-    uv run tag-release {{version}}
+    uv run tag-release {{ version }}
 
 # Recreate an existing tag from the CHANGELOG.md section for the given version
 tag-force version: python-sync
-    uv run tag-release {{version}} --force
+    uv run tag-release {{ version }} --force
 
 # Testing: runnable Rust tests use nextest; rustdoc doctests remain on cargo test.
 test: test-lib test-doc

--- a/justfile
+++ b/justfile
@@ -7,10 +7,12 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 
 cargo_nextest_version := "0.9.140"
 cargo_llvm_cov_version := "0.8.7"
+clippy_sarif_version := "0.8.0"
 dprint_version := "0.55.2"
 git_cliff_version := "2.13.1"
 just_version := "1.57.0"
 rumdl_version := "0.2.48"
+sarif_fmt_version := "0.8.0"
 taplo_version := "0.10.0"
 typos_version := "1.48.0"
 uv_version := "0.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
     "actionlint-py==1.7.12.24",
     "pytest>=9.0.3",
     "ruff>=0.15.14",
-    "semgrep==1.164.0",
+    "semgrep==1.172.0",
     "ty>=0.0.40",
 ]
 notebook = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Pin to MSRV as specified in Cargo.toml
-channel = "1.96.0"
+channel = "1.97.1"
 
 # Essential components for development
 components = [

--- a/scripts/tag_release.py
+++ b/scripts/tag_release.py
@@ -263,7 +263,7 @@ def create_tag(tag_version: str, *, force: bool = False) -> None:
         print(f"  1. Force-push the tag: {_BLUE}git push --force origin {tag_version}{_RESET}")
     else:
         print(f"  1. Push the tag: {_BLUE}git push origin {tag_version}{_RESET}")
-    print(f"  2. Create GitHub release: {_BLUE}gh release create {tag_version} --notes-from-tag{_RESET}")
+    print(f"  2. Create GitHub release: {_BLUE}gh release create {tag_version} --title {tag_version} --notes-from-tag{_RESET}")
     if is_truncated:
         print(f"\n{_YELLOW}Note: Tag annotation references CHANGELOG.md due to size (>125KB).{_RESET}")
 

--- a/scripts/tests/test_tag_release.py
+++ b/scripts/tests/test_tag_release.py
@@ -228,6 +228,25 @@ class TestCreateTag:
     @patch("tag_release._tag_exists", return_value=False)
     @patch("tag_release.find_changelog")
     @patch("tag_release.extract_changelog_section", return_value="### Added\n\n- Something new")
+    def test_next_step_sets_release_title(
+        self,
+        _mock_extract: MagicMock,
+        mock_find: MagicMock,
+        _mock_exists: MagicMock,
+        _mock_git_input: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        mock_find.return_value = tmp_path / "CHANGELOG.md"
+
+        tag_release.create_tag("v1.0.0")
+
+        assert "gh release create v1.0.0 --title v1.0.0 --notes-from-tag" in capsys.readouterr().out
+
+    @patch("tag_release.run_git_command_with_input")
+    @patch("tag_release._tag_exists", return_value=False)
+    @patch("tag_release.find_changelog")
+    @patch("tag_release.extract_changelog_section", return_value="### Added\n\n- Something new")
     def test_creates_annotated_tag(
         self,
         _mock_extract: MagicMock,

--- a/uv.lock
+++ b/uv.lock
@@ -216,14 +216,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -848,7 +848,7 @@ dev = [
     { name = "actionlint-py", specifier = "==1.7.12.24" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.15.14" },
-    { name = "semgrep", specifier = "==1.164.0" },
+    { name = "semgrep", specifier = "==1.172.0" },
     { name = "ty", specifier = ">=0.0.40" },
 ]
 notebook = [
@@ -1545,11 +1545,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -1877,7 +1877,7 @@ wheels = [
 
 [[package]]
 name = "semgrep"
-version = "1.164.0"
+version = "1.172.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1908,15 +1908,15 @@ dependencies = [
     { name = "urllib3" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/ce/6b778f43cc0896c4515f87bf48cb42da689de6539a75e1a0d4a4486b1a24/semgrep-1.164.0.tar.gz", hash = "sha256:a197bda58931d2e223e2ab7e45c3fd7b9ac37abd69516184ae09f1512f2d9b12", size = 55549587, upload-time = "2026-05-27T14:38:34.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/a3/5fb66c45b192916656884b6cc47c517f71c332bb4f66c9a7e5a4eaad21ad/semgrep-1.172.0.tar.gz", hash = "sha256:7377cc350c64c7b83de20090cb2843d875da1d806690fd604e446ed544b56d71", size = 499524, upload-time = "2026-07-28T22:41:36.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/cd/61521a6a593d6eea8c3f12374f2cb1d5c007915ebe33f47de06d406593c9/semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_10_14_x86_64.whl", hash = "sha256:3b4912696a2ee467a8568d5430fe09da6e1101039052a03e606dcf68ebe37c0a", size = 44965926, upload-time = "2026-05-27T14:38:06.867Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/98/f87f5a32e8798410293e5b01e75d4fb69f27e57eba8e4a5367774d7f7865/semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl", hash = "sha256:02c2b10395a6cb7344409d244baca5137dddd16f3a7bd178f786a2224c32adc0", size = 48896546, upload-time = "2026-05-27T14:38:10.844Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/82/1cc9e1bac12b8ce407f9f3b6204f09a95a6d05a657fa869e139e98dcdb18/semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_34_aarch64.whl", hash = "sha256:376e04f713b244eee95e8a51b3e81240cda7c07136d7819f727b5ca07ec7eca9", size = 70762505, upload-time = "2026-05-27T14:38:14.591Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/3f/df691763c0ccc0b02360647dbbcc7ccb6622aa69bd9f62a7816cdd909c7c/semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_34_x86_64.whl", hash = "sha256:745ae5ce1bef7c9b03c92b431d174ca6ee7801a5e2a047c64ac2104c7e6952fb", size = 68651973, upload-time = "2026-05-27T14:38:18.174Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e5/fe4c0b307283a643d4483fd6ac918b2ad7fc60f0081d8ea683fb490bb6f9/semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_aarch64.whl", hash = "sha256:341d3b32dbb652dcaa5ebe6f47f2bf79af1555bf357f2e14b2c54553b59e30d6", size = 78677869, upload-time = "2026-05-27T14:38:22.219Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/3b/740d597bb217ddaacc6f9c5b732fcf925246a3ceb964c11852ddc9c7ff11/semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ad8550639c9f7881d9551919b09aab86cfd0464417f113cfd6290d9f9cfcc4d", size = 76186419, upload-time = "2026-05-27T14:38:25.944Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/09/9fcb561fae64b7ba7dcb98139739e9208d7c6ad14b731669bd796fbc3ee3/semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:f0fc972bd0e33893ef73e8144c2c2293f7acafa86c00cca4e22673bc1b6c35ca", size = 56482229, upload-time = "2026-05-27T14:38:30.043Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7b/ac982bfb94cbc94da4b4144f538dc30b4c124ef970292b5c360785b44788/semgrep-1.172.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_10_14_x86_64.whl", hash = "sha256:7bcac633a0ffb7dfe75b7b99e44876f839590f2c01cd159c44caecc35e591df4", size = 45329663, upload-time = "2026-07-28T22:43:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/53ce7d543898b7f4da49e6f97471cbd80a91620c0111d26e3f6b741c6f20/semgrep-1.172.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl", hash = "sha256:09e92c9e6c1635a1549d4e297b2d4a9684dcd351b216ed7f2eb51cfc55479c49", size = 49305567, upload-time = "2026-07-28T22:43:25.348Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/45/35488f2f609db23eed350ada093722484a6f8cb3b1eaf8ecfd54e2338521/semgrep-1.172.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_34_aarch64.whl", hash = "sha256:c881a305b965e594b88b15c2c6419b398e76e438ec61e60916c8b2effe927240", size = 71707066, upload-time = "2026-07-28T22:43:29.623Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a5/21624510b65271a673961a894af7511b5123d662e84c74c765560ea28b27/semgrep-1.172.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_34_x86_64.whl", hash = "sha256:d8b94af4266a575287ad2cd844573743ab4fe58f6bfb6d9229327807937eade3", size = 69575334, upload-time = "2026-07-28T22:43:34.598Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5a/625d5b736e386cec4a7cc8cdf79bdf3ef00d24b668f656373a2282ba9b31/semgrep-1.172.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_aarch64.whl", hash = "sha256:8ba0d661c8cb3a451b27d4300b2d958483d6761262ce84e4dd5ff4f94e700346", size = 78491563, upload-time = "2026-07-28T22:43:40.194Z" },
+    { url = "https://files.pythonhosted.org/packages/97/1a/b08bc7644ece6700f4ccce24630ffb9cd01d25a7473ace69c62df599e985/semgrep-1.172.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_x86_64.whl", hash = "sha256:f13ddebc870e784b03c9247f095720f49f67244eca1e7da493364f55c65b4493", size = 75992900, upload-time = "2026-07-28T22:43:45.91Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2b/db00aa8b50d4a3172f7d1a90005d359875004cf840b50db4b8606845453b/semgrep-1.172.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:e32868faeb67b241bbd3fabd82a12fba4b467464dedde9da285b9bf78e808ba3", size = 57257253, upload-time = "2026-07-28T22:43:51.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #104

- Raise the crate MSRV and contributor toolchain to Rust 1.97.1.
- Adopt Cargo-owned Clippy warning denial and update dprint and rumdl pins.
- Set explicit GitHub release titles from version tags.

BREAKING CHANGE: Rust 1.97.1 is now the minimum supported version.