### PR TITLE
refactor!: make thinning and step telemetry invariant-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,15 @@ fn main() -> Result<(), McmcError> {
 - Use `AdditiveTarget` when the target log weight is the sum of model, bias, energy, action, or externally supplied regularizer terms.
 - Use `DelayedStep` telemetry, `StepOutcome`, and `DelayedProposal::no_plan_info` when delayed proposals need domain-specific per-step records.
 - Use `Sampler` when you want ergonomic repeated runs, resumable chunks, iterator-based sampling, or observing helpers.
+- Parse raw positive thinning counts with `ThinningInterval::new`, then reuse the validated interval across `Sampler::*_with_thinning` calls.
 - Use `Sampler::run_delayed_chunk_observing` to record per-step delayed telemetry and post-step state while resuming chunked runs from a `ChainCheckpoint`.
 - Use `TraceRecorder` when you need reusable numeric traces with chain IDs, acceptance metadata, target log-probabilities, and CSV export.
 - Use `verify_detailed_balance*` helpers in proposal tests for representative discrete transitions.
 - Use `OnlineStats` and `BinningAnalysis` when long runs should stream statistics instead of retaining every sample.
+
+When migrating from the previous thinning and delayed-telemetry APIs, replace raw thinning `usize` arguments with a parsed `ThinningInterval`, handle the
+underlying sampler or observation error directly instead of matching `ThinningError::Run`, and replace `Step` field reads with the corresponding
+`outcome()`, `info()`, `log_prob_before()`, `log_prob_after()`, and `log_alpha()` accessors.
 
 ## 📦 Cargo features
 

--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -258,7 +258,7 @@ fn bench_delayed_steps(c: &mut Criterion) {
             let step = chain
                 .step_delayed(&flat, &mut proposal, &mut rng)
                 .or_abort("delayed accepted chain step");
-            black_box(step.outcome.is_accepted());
+            black_box(step.outcome().is_accepted());
             black_box(chain.state().0);
         });
     });
@@ -272,7 +272,7 @@ fn bench_delayed_steps(c: &mut Criterion) {
             let step = chain
                 .step_delayed(&normal, &mut proposal, &mut rng)
                 .or_abort("delayed rejected chain step");
-            black_box(step.outcome.is_accepted());
+            black_box(step.outcome().is_accepted());
             black_box(chain.state().0);
         });
     });
@@ -286,7 +286,7 @@ fn bench_delayed_steps(c: &mut Criterion) {
             let step = chain
                 .step_delayed(&normal, &mut proposal, &mut rng)
                 .or_abort("delayed no-plan chain step");
-            black_box(step.outcome.has_proposal());
+            black_box(step.outcome().has_proposal());
             black_box(chain.rejected());
         });
     });

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -208,6 +208,7 @@ This module owns:
 
 - current state and current log-probability
 - accepted/rejected counters
+- invariant-preserving delayed-step telemetry and its read-only accessors
 - by-value `step`
 - in-place `step_mut`
 - state accessors and replacement helpers
@@ -223,6 +224,7 @@ This module owns:
 
 - single-step forwarding methods
 - bulk `run` and `run_mut` loops
+- `ThinningInterval` parsing and shared thinned-run loops
 - observing variants that measure derived quantities after sampling steps
 - by-value `Iterator` support
 - access to the bundled `Chain`

--- a/examples/delayed_chunked_telemetry.rs
+++ b/examples/delayed_chunked_telemetry.rs
@@ -127,7 +127,7 @@ fn main() -> Result<(), DelayedStepError<Infallible>> {
     for chunk in 1..=chunks {
         let continuation = sampler.run_delayed_chunk_observing(chunk_len, |step, state| {
             // Selected family is available for every step, including no-site loops.
-            if let Some(family) = step.info {
+            if let Some(family) = step.info() {
                 match family {
                     Move::Up => up += 1,
                     Move::Down => down += 1,
@@ -137,7 +137,7 @@ fn main() -> Result<(), DelayedStepError<Infallible>> {
             // The sampler owns the accept/reject draw; we only classify the
             // recorded outcome. `rejection_reason` is non-exhaustive, so the
             // breakdown keeps a wildcard arm for forward compatibility.
-            if step.outcome.is_accepted() {
+            if step.outcome().is_accepted() {
                 accepted += 1;
             } else {
                 rejected += 1;

--- a/justfile
+++ b/justfile
@@ -517,6 +517,8 @@ semgrep-test: _ensure-uv
     expect_semgrep_count 2 mcmc.rust.no-stdio-diagnostics-in-src src/project_rules/rust_style.rs
     expect_semgrep_count 1 mcmc.rust.no-nonfinite-unwrap-defaults src/project_rules/rust_style.rs
     expect_semgrep_count 3 mcmc.rust.no-production-unwrap-panic src/project_rules/rust_style.rs
+    expect_semgrep_count 2 mcmc.rust.thinning-interval-parameters-use-refined-type src/project_rules/rust_style.rs
+    expect_semgrep_count 5 mcmc.rust.step-telemetry-fields-private src/project_rules/rust_style.rs
     expect_semgrep_count 1 mcmc.rust.no-box-dyn-error-in-src src/project_rules/rust_style.rs
     expect_semgrep_count 2 mcmc.rust.public-error-enums-non-exhaustive src/project_rules/rust_style.rs
     expect_semgrep_count 1 mcmc.rust.no-clippy-allow-lints src/project_rules/rust_style.rs

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -166,6 +166,40 @@ rules:
               }
           - pattern-regex: '^\s*forward_site_count\s*:\s*usize\b'
 
+  - id: mcmc.rust.thinning-interval-parameters-use-refined-type
+    languages:
+      - rust
+    severity: WARNING
+    message: "Accept ThinningInterval in *_with_thinning APIs so zero is rejected before sampler execution."
+    metadata:
+      category: correctness
+      rationale: "A proof-bearing interval removes repeated zero checks and makes division by zero unrepresentable in thinning loops."
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    pattern-regex: >-
+      (?s)^\s*pub\s+fn\s+[A-Za-z_][A-Za-z0-9_]*_with_thinning(?:\s*<[^\{;]*>)?\s*\([^)]*\bthin_interval\s*:\s*usize\b
+
+  - id: mcmc.rust.step-telemetry-fields-private
+    languages:
+      - rust
+    severity: WARNING
+    message: "Keep Step telemetry fields private and expose read-only accessors so outcome-dependent fields cannot be mutated independently."
+    metadata:
+      category: correctness
+      rationale: "Accepted, rejected, and no-proposal telemetry require coordinated outcome, log-probability, and acceptance-ratio fields."
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/src/**/*.rs"
+    patterns:
+      - pattern-inside: |
+          pub struct Step<$INFO> {
+              ...
+          }
+      - pattern-regex: '^\s*pub\s+(?:outcome|info|log_prob_before|log_prob_after|log_alpha)\s*:'
+
   - id: mcmc.rust.no-public-unit-validators
     languages:
       - rust

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -99,15 +99,15 @@ fn check_committed_log_prob(scored: f64, committed: f64) -> Result<(), McmcError
 #[must_use]
 pub struct Step<I> {
     /// Step outcome encoded as a single invariant-bearing value.
-    pub outcome: StepOutcome,
+    outcome: StepOutcome,
     /// Proposal-specific metadata for the concrete proposal or no-plan outcome.
-    pub info: Option<I>,
+    info: Option<I>,
     /// Cached log-probability before the step.
-    pub log_prob_before: f64,
+    log_prob_before: f64,
     /// Cached log-probability after the step, when it changed.
-    pub log_prob_after: Option<f64>,
+    log_prob_after: Option<f64>,
     /// Metropolis-Hastings log acceptance ratio, when one was evaluated.
-    pub log_alpha: Option<f64>,
+    log_alpha: Option<f64>,
 }
 
 impl<I> Step<I> {
@@ -156,6 +156,45 @@ impl<I> Step<I> {
             log_prob_after: None,
             log_alpha: Some(log_alpha),
         }
+    }
+
+    /// Outcome of the completed step.
+    ///
+    /// The outcome and optional telemetry fields are constructed together, so
+    /// callers cannot create contradictory combinations such as an accepted
+    /// step without a post-commit log-probability.
+    pub const fn outcome(&self) -> StepOutcome {
+        self.outcome
+    }
+
+    /// Proposal-specific metadata for the concrete proposal or no-plan outcome.
+    #[must_use]
+    pub const fn info(&self) -> Option<&I> {
+        self.info.as_ref()
+    }
+
+    /// Cached log-probability before the step.
+    #[must_use]
+    pub const fn log_prob_before(&self) -> f64 {
+        self.log_prob_before
+    }
+
+    /// Cached log-probability after the step, when it changed.
+    ///
+    /// This is `Some` exactly when [`Self::outcome`] is
+    /// [`StepOutcome::Accepted`].
+    #[must_use]
+    pub const fn log_prob_after(&self) -> Option<f64> {
+        self.log_prob_after
+    }
+
+    /// Metropolis-Hastings log acceptance ratio, when one was evaluated.
+    ///
+    /// This is `Some` for accepted and rejected concrete proposals and `None`
+    /// when no proposal was available.
+    #[must_use]
+    pub const fn log_alpha(&self) -> Option<f64> {
+        self.log_alpha
     }
 
     /// Why a step was rejected, or `None` when it was accepted.
@@ -213,7 +252,7 @@ impl<I> Step<I> {
     /// let mut chain = Chain::new((), &Flat).map_err(DelayedStepError::Mcmc)?;
     /// let step = chain.step_delayed(&Flat, &mut proposal, &mut rng)?;
     ///
-    /// assert_eq!(step.outcome, StepOutcome::NoProposal);
+    /// assert_eq!(step.outcome(), StepOutcome::NoProposal);
     /// assert_eq!(step.rejection_reason(), Some(StepRejectionReason::NoProposal));
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
@@ -801,7 +840,7 @@ impl<S> Chain<S> {
     /// let mut chain = Chain::new(-1, &target)?;
     ///
     /// let step = chain.step_delayed(&target, &mut proposal, &mut rng)?;
-    /// assert_eq!(step.outcome, StepOutcome::Accepted);
+    /// assert_eq!(step.outcome(), StepOutcome::Accepted);
     /// assert_eq!(*chain.state(), 0);
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
@@ -937,7 +976,7 @@ impl<S> Chain<S> {
     /// let mut chain = Chain::new(-1, &target)?;
     ///
     /// let step = chain.step_delayed_checked(&target, &mut proposal, &mut rng)?;
-    /// assert_eq!(step.outcome, StepOutcome::Accepted);
+    /// assert_eq!(step.outcome(), StepOutcome::Accepted);
     /// assert_eq!(*chain.state(), 0);
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
@@ -1653,9 +1692,9 @@ mod tests {
             .step_delayed(&target, &mut proposal, &mut rng)
             .unwrap();
 
-        assert!(step.outcome.has_proposal());
-        assert_relative_eq!(step.log_alpha.unwrap(), -2.0_f64.ln(), epsilon = 1e-12);
-        assert_eq!(step.info, Some(true));
+        assert!(step.outcome().has_proposal());
+        assert_relative_eq!(step.log_alpha().unwrap(), -2.0_f64.ln(), epsilon = 1e-12);
+        assert_eq!(step.info(), Some(&true));
     }
 
     #[test]
@@ -1674,9 +1713,9 @@ mod tests {
             .step_delayed(&target, &mut proposal, &mut rng)
             .unwrap();
 
-        assert_eq!(step.outcome, StepOutcome::Accepted);
-        assert_relative_eq!(step.log_alpha.unwrap(), 3.0_f64.ln(), epsilon = 1e-12);
-        assert_eq!(step.info, Some(true));
+        assert_eq!(step.outcome(), StepOutcome::Accepted);
+        assert_relative_eq!(step.log_alpha().unwrap(), 3.0_f64.ln(), epsilon = 1e-12);
+        assert_eq!(step.info(), Some(&true));
         assert!(*chain.state());
         assert_eq!(chain.accepted(), 1);
         assert_eq!(chain.rejected(), 0);
@@ -2449,14 +2488,14 @@ mod tests {
             .step_delayed(&Normal, &mut proposal, &mut rng)
             .unwrap();
 
-        assert_eq!(step.outcome, StepOutcome::Accepted);
-        assert!(step.outcome.is_accepted());
-        assert!(step.outcome.has_proposal());
+        assert_eq!(step.outcome(), StepOutcome::Accepted);
+        assert!(step.outcome().is_accepted());
+        assert!(step.outcome().has_proposal());
         assert!(step.rejection_reason().is_none());
-        assert_eq!(step.info, Some(0.0));
-        assert_relative_eq!(step.log_prob_before, -2.0, epsilon = 1e-12);
-        assert_eq!(step.log_prob_after, Some(0.0));
-        assert_eq!(step.log_alpha, Some(2.0));
+        assert_eq!(step.info(), Some(&0.0));
+        assert_relative_eq!(step.log_prob_before(), -2.0, epsilon = 1e-12);
+        assert_eq!(step.log_prob_after(), Some(0.0));
+        assert_eq!(step.log_alpha(), Some(2.0));
         assert_eq!(chain.state, MutScalar(0.0));
         assert_eq!(chain.accepted(), 1);
         assert_eq!(chain.rejected(), 0);
@@ -2472,17 +2511,17 @@ mod tests {
             .step_delayed(&Normal, &mut proposal, &mut rng)
             .unwrap();
 
-        assert_eq!(step.outcome, StepOutcome::RejectedProposal);
-        assert!(!step.outcome.is_accepted());
-        assert!(step.outcome.has_proposal());
+        assert_eq!(step.outcome(), StepOutcome::RejectedProposal);
+        assert!(!step.outcome().is_accepted());
+        assert!(step.outcome().has_proposal());
         assert_eq!(
             step.rejection_reason(),
             Some(StepRejectionReason::RejectedProposal)
         );
-        assert_eq!(step.info, Some(100.0));
-        assert_relative_eq!(step.log_prob_before, 0.0);
-        assert_eq!(step.log_prob_after, None);
-        assert_eq!(step.log_alpha, Some(-5000.0));
+        assert_eq!(step.info(), Some(&100.0));
+        assert_relative_eq!(step.log_prob_before(), 0.0);
+        assert_eq!(step.log_prob_after(), None);
+        assert_eq!(step.log_alpha(), Some(-5000.0));
         assert_eq!(chain.state, MutScalar(0.0));
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 1);
@@ -2499,17 +2538,17 @@ mod tests {
             .step_delayed(&Normal, &mut proposal, &mut rng)
             .unwrap();
 
-        assert_eq!(step.outcome, StepOutcome::NoProposal);
-        assert!(!step.outcome.is_accepted());
-        assert!(!step.outcome.has_proposal());
+        assert_eq!(step.outcome(), StepOutcome::NoProposal);
+        assert!(!step.outcome().is_accepted());
+        assert!(!step.outcome().has_proposal());
         assert_eq!(
             step.rejection_reason(),
             Some(StepRejectionReason::NoProposal)
         );
-        assert_eq!(step.info, None);
-        assert_relative_eq!(step.log_prob_before, log_prob);
-        assert_eq!(step.log_prob_after, None);
-        assert_eq!(step.log_alpha, None);
+        assert_eq!(step.info(), None);
+        assert_relative_eq!(step.log_prob_before(), log_prob);
+        assert_eq!(step.log_prob_after(), None);
+        assert_eq!(step.log_alpha(), None);
         assert_eq!(chain.state, MutScalar(1.0));
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 1);
@@ -2525,14 +2564,14 @@ mod tests {
             .step_delayed(&Normal, &mut proposal, &mut rng)
             .unwrap();
 
-        assert_eq!(step.outcome, StepOutcome::NoProposal);
-        assert!(!step.outcome.is_accepted());
-        assert!(!step.outcome.has_proposal());
+        assert_eq!(step.outcome(), StepOutcome::NoProposal);
+        assert!(!step.outcome().is_accepted());
+        assert!(!step.outcome().has_proposal());
         assert_eq!(
             step.rejection_reason(),
             Some(StepRejectionReason::NoProposal)
         );
-        assert_eq!(step.info, Some(MoveFamily::Add));
+        assert_eq!(step.info(), Some(&MoveFamily::Add));
         assert_eq!(proposal.last_family, None);
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 1);
@@ -2836,7 +2875,7 @@ mod tests {
             .step_delayed_checked(&Normal, &mut proposal, &mut rng)
             .unwrap();
 
-        assert_eq!(step.outcome, StepOutcome::Accepted);
+        assert_eq!(step.outcome(), StepOutcome::Accepted);
         assert_eq!(chain.state, Scalar(0.0));
         assert_relative_eq!(chain.log_prob(), 0.0);
         assert_eq!(chain.accepted(), 1);

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -177,7 +177,7 @@ impl From<StepOutcome> for TraceStepOutcome {
 
 impl<I> From<&Step<I>> for TraceStepOutcome {
     fn from(step: &Step<I>) -> Self {
-        step.outcome.into()
+        step.outcome().into()
     }
 }
 
@@ -999,13 +999,7 @@ mod tests {
 
     #[test]
     fn delayed_step_reference_converts_to_trace_outcome() {
-        let step = Step {
-            outcome: StepOutcome::NoProposal,
-            info: None::<()>,
-            log_prob_before: 0.0,
-            log_prob_after: None,
-            log_alpha: None,
-        };
+        let step = Step::no_proposal(None::<()>, 0.0);
 
         assert_eq!(
             TraceStepOutcome::from(&step),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@
 //! for those streaming measurement loops.  Samplers also provide
 //! `*_with_thinning` variants to collect cloned states or measurements only
 //! every k-th completed step while still advancing the chain on every step.
+//! Parse raw positive intervals once with [`ThinningInterval::new`], then pass
+//! the proof-bearing interval to any thinned method.
 //! For workflows that choose the next step budget from the updated state, use
 //! [`Sampler::run_chunk`], [`Sampler::run_mut_chunk`], or
 //! [`Sampler::run_delayed_chunk`].  They run the next chunk on the same RNG
@@ -332,7 +334,7 @@
 //!     let mut chain = Chain::new(-1, &target).map_err(DelayedStepError::Mcmc)?;
 //!
 //!     let step = chain.step_delayed(&target, &mut proposal, &mut rng)?;
-//!     assert_eq!(step.outcome, StepOutcome::Accepted);
+//!     assert_eq!(step.outcome(), StepOutcome::Accepted);
 //!     assert_eq!(*chain.state(), 0);
 //!     Ok(())
 //! }
@@ -466,12 +468,12 @@ pub use observable::{
     Observable, ObservedStepError, ObservedStreamError, SampleBuffer, TryAccumulator, TryObservable,
 };
 pub use sampler::{
-    ObservedDelayedIntoRunResult, ObservedDelayedStep, ObservedDelayedStepResult,
-    ObservedIntoRunResult, Sampler, ThinnedObservedDelayedIntoRunResult,
-    ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningError, TryObservedDelayedIntoRunResult,
-    TryObservedDelayedRunResult, TryObservedDelayedStepResult, TryObservedIntoRunResult,
-    TryObservedMutStepResult, TryObservedRunResult, TryObservedStepResult,
-    TryThinnedObservedDelayedIntoRunResult, TryThinnedObservedIntoRunResult,
+    InvalidThinningInterval, ObservedDelayedIntoRunResult, ObservedDelayedStep,
+    ObservedDelayedStepResult, ObservedIntoRunResult, Sampler, ThinnedObservedDelayedIntoRunResult,
+    ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningInterval,
+    TryObservedDelayedIntoRunResult, TryObservedDelayedRunResult, TryObservedDelayedStepResult,
+    TryObservedIntoRunResult, TryObservedMutStepResult, TryObservedRunResult,
+    TryObservedStepResult, TryThinnedObservedDelayedIntoRunResult, TryThinnedObservedIntoRunResult,
     TryThinnedObservedRunResult,
 };
 pub use statistics::{BinningAnalysis, BinningEstimate, OnlineStats, StatisticsError};
@@ -530,11 +532,11 @@ pub use traits::{
 pub mod prelude {
     pub use crate::{
         AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, ChainId,
-        McmcError, Observable, ObservedIntoRunResult, ObservedStepError, ObservedStreamError,
-        OnlineStats, SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult,
-        ThinnedRunResult, ThinningError, Trace, TraceError, TraceRecord, TraceRecorder,
-        TraceStepOutcome, TryAccumulator, TryObservable, TryObservedIntoRunResult,
-        TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
+        InvalidThinningInterval, McmcError, Observable, ObservedIntoRunResult, ObservedStepError,
+        ObservedStreamError, OnlineStats, SampleBuffer, Sampler, StatisticsError, Target,
+        ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningInterval, Trace, TraceError,
+        TraceRecord, TraceRecorder, TraceStepOutcome, TryAccumulator, TryObservable,
+        TryObservedIntoRunResult, TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
     };
 
     /// Prelude for by-value proposals.
@@ -544,10 +546,10 @@ pub mod prelude {
     pub mod by_value {
         pub use crate::{
             AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, ChainId,
-            DiscreteProposalRatio, DiscreteProposalRatioError, McmcError, Observable,
-            ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats, Proposal,
-            SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult,
-            ThinnedRunResult, ThinningError, Trace, TraceError, TraceRecord, TraceRecorder,
+            DiscreteProposalRatio, DiscreteProposalRatioError, InvalidThinningInterval, McmcError,
+            Observable, ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats,
+            Proposal, SampleBuffer, Sampler, StatisticsError, Target, ThinnedObservedIntoRunResult,
+            ThinnedRunResult, ThinningInterval, Trace, TraceError, TraceRecord, TraceRecorder,
             TraceStepOutcome, TryAccumulator, TryObservable, TryObservedIntoRunResult,
             TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
         };
@@ -560,10 +562,10 @@ pub mod prelude {
     pub mod in_place {
         pub use crate::{
             AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, ChainId,
-            DiscreteProposalRatio, DiscreteProposalRatioError, McmcError, Observable,
-            ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats,
+            DiscreteProposalRatio, DiscreteProposalRatioError, InvalidThinningInterval, McmcError,
+            Observable, ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats,
             ProposalMut, SampleBuffer, Sampler, StatisticsError, Target,
-            ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningError, Trace, TraceError,
+            ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningInterval, Trace, TraceError,
             TraceRecord, TraceRecorder, TraceStepOutcome, TryAccumulator, TryObservable,
             TryObservedIntoRunResult, TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
         };
@@ -577,10 +579,11 @@ pub mod prelude {
         pub use crate::{
             AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, ChainId,
             DelayedProposal, DelayedStep, DelayedStepError, DiscreteProposalRatio,
-            DiscreteProposalRatioError, McmcError, Observable, ObservedDelayedIntoRunResult,
-            ObservedDelayedStep, ObservedDelayedStepResult, ObservedStepError, ObservedStreamError,
-            OnlineStats, SampleBuffer, Sampler, StatisticsError, StepOutcome, StepRejectionReason,
-            Target, ThinnedObservedDelayedIntoRunResult, ThinnedRunResult, ThinningError, Trace,
+            DiscreteProposalRatioError, InvalidThinningInterval, McmcError, Observable,
+            ObservedDelayedIntoRunResult, ObservedDelayedStep, ObservedDelayedStepResult,
+            ObservedStepError, ObservedStreamError, OnlineStats, SampleBuffer, Sampler,
+            StatisticsError, StepOutcome, StepRejectionReason, Target,
+            ThinnedObservedDelayedIntoRunResult, ThinnedRunResult, ThinningInterval, Trace,
             TraceError, TraceRecord, TraceRecorder, TraceStepOutcome, TryAccumulator,
             TryObservable, TryObservedDelayedIntoRunResult, TryThinnedObservedDelayedIntoRunResult,
             TryThinnedObservedRunResult,
@@ -619,10 +622,11 @@ mod public_api_smoke_tests {
         AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, ChainId,
         DelayedStep, DetailedBalanceBatchReport, DetailedBalanceConfig,
         DetailedBalanceDelayedTransition, DetailedBalanceDirection, DetailedBalanceError,
-        DetailedBalanceFailure, DetailedBalanceReport, DetailedBalanceState, McmcError, Observable,
-        ObservedDelayedStep, OnlineStats, Proposal, ProposalMut, SampleBuffer, Sampler,
-        StatisticsError, Step, StepOutcome, StepRejectionReason, Target, ThinningError, Trace,
-        TraceError, TraceRecord, TraceRecorder, TraceStepOutcome,
+        DetailedBalanceFailure, DetailedBalanceReport, DetailedBalanceState,
+        InvalidThinningInterval, McmcError, Observable, ObservedDelayedStep, OnlineStats, Proposal,
+        ProposalMut, SampleBuffer, Sampler, StatisticsError, Step, StepOutcome,
+        StepRejectionReason, Target, ThinningInterval, Trace, TraceError, TraceRecord,
+        TraceRecorder, TraceStepOutcome,
         prelude::{self, by_value, delayed, in_place, testing},
     };
 
@@ -721,7 +725,8 @@ mod public_api_smoke_tests {
         let _: Option<McmcError> = None;
         let _: Option<SampleBuffer<f64>> = None;
         let _: Option<Sampler<'_, f64, Smoke, Smoke, StdRng>> = None;
-        let _: Option<ThinningError<McmcError>> = None;
+        let _: Option<ThinningInterval> = None;
+        let _: Option<InvalidThinningInterval> = None;
         let _: Option<ObservedDelayedStep<(), f64>> = None;
         let _: Option<BinningAnalysis> = None;
         let _: Option<BinningEstimate> = None;

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,6 +1,6 @@
 //! Ergonomic sampling wrapper that bundles a chain with its components.
 
-use core::convert::Infallible;
+use core::{convert::Infallible, num::NonZeroUsize};
 use std::{error::Error, fmt};
 
 use rand::Rng;
@@ -49,7 +49,7 @@ pub type TryObservedDelayedIntoRunResult<P, O, A> =
     TryObservedIntoRunResult<DelayedStepError<P>, O, A>;
 
 /// Result returned by thinned sampler runs.
-pub type ThinnedRunResult<T, E> = Result<T, ThinningError<E>>;
+pub type ThinnedRunResult<T, E> = Result<T, E>;
 
 /// Result returned by thinned fallible-observation runs.
 pub type TryThinnedObservedRunResult<O, StepError, ObservationError> =
@@ -71,39 +71,100 @@ pub type ThinnedObservedDelayedIntoRunResult<P, A> =
 pub type TryThinnedObservedDelayedIntoRunResult<P, O, A> =
     TryThinnedObservedIntoRunResult<DelayedStepError<P>, O, A>;
 
-/// Error returned by thinned sampler runs.
+/// Positive interval between retained samples in a thinned run.
+///
+/// Constructing this type parses a raw `usize` once, allowing every thinned
+/// sampler method to rely on a nonzero divisor without repeating validation.
+///
+/// ```
+/// use markov_chain_monte_carlo::{InvalidThinningInterval, ThinningInterval};
+///
+/// let interval = ThinningInterval::new(4)?;
+/// assert_eq!(interval.get(), 4);
+/// assert!(ThinningInterval::new(0).is_err());
+/// # Ok::<(), InvalidThinningInterval>(())
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[must_use]
+pub struct ThinningInterval(NonZeroUsize);
+
+impl ThinningInterval {
+    /// The smallest valid thinning interval, which retains every step.
+    pub const MIN: Self = Self(NonZeroUsize::MIN);
+
+    /// Parse a raw positive thinning interval.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidThinningInterval`] when `thin_interval` is zero.
+    pub const fn new(thin_interval: usize) -> Result<Self, InvalidThinningInterval> {
+        let Some(thin_interval) = NonZeroUsize::new(thin_interval) else {
+            return Err(InvalidThinningInterval { thin_interval });
+        };
+        Ok(Self(thin_interval))
+    }
+
+    /// Return the validated raw interval.
+    #[must_use]
+    pub const fn get(self) -> usize {
+        self.0.get()
+    }
+
+    /// Add to this interval, saturating at [`usize::MAX`].
+    ///
+    /// This is primarily useful for compile-time interval constants while
+    /// preserving the nonzero invariant.
+    pub const fn saturating_add(self, amount: usize) -> Self {
+        Self(self.0.saturating_add(amount))
+    }
+}
+
+impl TryFrom<usize> for ThinningInterval {
+    type Error = InvalidThinningInterval;
+
+    fn try_from(thin_interval: usize) -> Result<Self, Self::Error> {
+        Self::new(thin_interval)
+    }
+}
+
+impl From<NonZeroUsize> for ThinningInterval {
+    fn from(thin_interval: NonZeroUsize) -> Self {
+        Self(thin_interval)
+    }
+}
+
+impl From<ThinningInterval> for NonZeroUsize {
+    fn from(thin_interval: ThinningInterval) -> Self {
+        thin_interval.0
+    }
+}
+
+/// Error returned when parsing a zero [`ThinningInterval`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum ThinningError<E> {
-    /// The requested thinning interval is invalid.
-    InvalidInterval {
-        /// The invalid interval supplied by the caller.
-        thin_interval: usize,
-    },
-    /// The underlying sampler run failed.
-    Run(E),
+pub struct InvalidThinningInterval {
+    thin_interval: usize,
 }
 
-impl<E: fmt::Display> fmt::Display for ThinningError<E> {
+impl InvalidThinningInterval {
+    /// Return the rejected raw interval.
+    #[must_use]
+    pub const fn value(self) -> usize {
+        self.thin_interval
+    }
+}
+
+impl fmt::Display for InvalidThinningInterval {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidInterval { thin_interval } => write!(
-                f,
-                "invalid thinning interval {thin_interval}: expected a value greater than zero"
-            ),
-            Self::Run(err) => write!(f, "{err}"),
-        }
+        write!(
+            f,
+            "invalid thinning interval {}: expected a value greater than zero",
+            self.thin_interval
+        )
     }
 }
 
-impl<E: Error + 'static> Error for ThinningError<E> {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::InvalidInterval { .. } => None,
-            Self::Run(err) => Some(err),
-        }
-    }
-}
+impl Error for InvalidThinningInterval {}
 
 /// Lift a step/observation error into the streaming error type.
 ///
@@ -116,18 +177,9 @@ fn stream_observed_error<S, O, A>(err: ObservedStepError<S, O>) -> ObservedStrea
     }
 }
 
-/// Validate a thinning interval supplied to a public sampler method.
-const fn validate_thin_interval<E>(thin_interval: usize) -> Result<(), ThinningError<E>> {
-    if thin_interval == 0 {
-        return Err(ThinningError::InvalidInterval { thin_interval });
-    }
-    Ok(())
-}
-
 /// Number of observations produced by observing every `thin_interval` steps.
-fn thinned_capacity<E>(steps: usize, thin_interval: usize) -> Result<usize, ThinningError<E>> {
-    validate_thin_interval(thin_interval)?;
-    Ok(steps / thin_interval)
+const fn thinned_capacity(steps: usize, thin_interval: ThinningInterval) -> usize {
+    steps / thin_interval.get()
 }
 
 /// Bundles a [`Chain`] with its target, proposal, and RNG for ergonomic
@@ -400,27 +452,15 @@ impl<S, T, P, R: ?Sized> Sampler<'_, S, T, P, R> {
         self.chain.reset_counters();
     }
 
-    /// Run the shared validate/step/modulo-gate loop for thinned methods.
-    fn run_thinning_core<E>(
-        &mut self,
-        steps: usize,
-        thin_interval: usize,
-        step_once: impl FnMut(&mut Self) -> Result<(), E>,
-        emit: impl FnMut(&Self) -> Result<(), E>,
-    ) -> ThinnedRunResult<(), E> {
-        validate_thin_interval(thin_interval)?;
-        self.run_thinning_loop(steps, thin_interval, step_once, emit)
-    }
-
     /// Collect samples from the shared thinning loop into a [`SampleBuffer`].
     fn collect_with_thinning_core<O, E>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         step_once: impl FnMut(&mut Self) -> Result<(), E>,
         mut emit: impl FnMut(&Self) -> Result<O, E>,
     ) -> ThinnedRunResult<SampleBuffer<O>, E> {
-        let mut samples = SampleBuffer::with_capacity(thinned_capacity::<E>(steps, thin_interval)?);
+        let mut samples = SampleBuffer::with_capacity(thinned_capacity(steps, thin_interval));
         self.run_thinning_loop(steps, thin_interval, step_once, |sampler| {
             samples.push(emit(sampler)?);
             Ok(())
@@ -432,14 +472,14 @@ impl<S, T, P, R: ?Sized> Sampler<'_, S, T, P, R> {
     fn run_thinning_loop<E>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         mut step_once: impl FnMut(&mut Self) -> Result<(), E>,
         mut emit: impl FnMut(&Self) -> Result<(), E>,
     ) -> ThinnedRunResult<(), E> {
         for step in 1..=steps {
-            step_once(self).map_err(ThinningError::Run)?;
-            if step % thin_interval == 0 {
-                emit(self).map_err(ThinningError::Run)?;
+            step_once(self)?;
+            if step % thin_interval.get() == 0 {
+                emit(self)?;
             }
         }
         Ok(())
@@ -701,7 +741,6 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// `thin_interval = 2` collects states after steps 2 and 4.
     ///
     /// ```
-    /// # use std::assert_matches;
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -719,26 +758,23 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ThinningError::Run)?;
+    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)?;
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// let states = sampler.run_with_thinning(5, 2)?;
+    /// let states = sampler.run_with_thinning(5, thin_interval)?;
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
-    ///
-    /// let err = sampler.run_with_thinning(1, 0).unwrap_err();
-    /// assert_matches!(err, ThinningError::InvalidInterval { thin_interval: 0 });
-    /// # Ok::<(), ThinningError<McmcError>>(())
+    /// # Ok::<(), McmcError>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] on the first step that fails.
+    /// Returns [`McmcError`] on the first step that fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn run_with_thinning(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
     ) -> ThinnedRunResult<SampleBuffer<S>, McmcError>
     where
         S: Clone,
@@ -835,7 +871,6 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// `thin_interval = 2` observes after steps 2 and 4.
     ///
     /// ```
-    /// # use std::assert_matches;
     /// use markov_chain_monte_carlo::prelude::by_value::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -851,29 +886,25 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(0, &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ThinningError::Run)?;
+    /// let chain = Chain::new(0, &Flat)?;
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)?;
     /// let mut coordinate = |state: &i32| *state;
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// let samples = sampler.run_observing_with_thinning(5, 2, &mut coordinate)?;
+    /// let samples =
+    ///     sampler.run_observing_with_thinning(5, thin_interval, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    ///
-    /// let err = sampler
-    ///     .run_observing_with_thinning(1, 0, &mut coordinate)
-    ///     .unwrap_err();
-    /// assert_matches!(err, ThinningError::InvalidInterval { thin_interval: 0 });
-    /// # Ok::<(), ThinningError<McmcError>>(())
+    /// # Ok::<(), McmcError>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] on the first step that fails.
+    /// Returns [`McmcError`] on the first step that fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn run_observing_with_thinning<O: Observable<S> + ?Sized>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
     ) -> ThinnedRunResult<SampleBuffer<O::Output>, McmcError> {
         self.collect_with_thinning_core(steps, thin_interval, Self::step, |sampler| {
@@ -964,28 +995,29 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &Flat)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// sampler.run_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
+    /// sampler.run_observing_into_with_thinning(
+    ///     5, thin_interval, &mut coordinate, &mut stats,
+    /// )?;
     /// assert_eq!(stats.count(), 2);
     /// assert_eq!(sampler.chain_ref().total_steps(), 5);
-    /// # Ok::<(), ThinningError<ObservedStreamError<McmcError, Infallible, StatisticsError>>>(())
+    /// # Ok::<(), ObservedStreamError<McmcError, Infallible, StatisticsError>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] when the underlying stream fails.
+    /// Returns [`ObservedStreamError`] when the underlying stream fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn run_observing_into_with_thinning<O, A>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
         accumulator: &mut A,
     ) -> ThinnedObservedIntoRunResult<McmcError, A::Error>
@@ -993,7 +1025,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
         O: Observable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        self.run_thinning_core(
+        self.run_thinning_loop(
             steps,
             thin_interval,
             |sampler| sampler.step().map_err(ObservedStreamError::Step),
@@ -1115,27 +1147,27 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &Flat)
-    ///     .map_err(ObservedStepError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ObservedStepError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut coordinate = |state: &i32| Ok::<i32, Infallible>(*state);
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// let samples = sampler.try_run_observing_with_thinning(5, 2, &mut coordinate)?;
+    /// let samples =
+    ///     sampler.try_run_observing_with_thinning(5, thin_interval, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), ThinningError<ObservedStepError<McmcError, Infallible>>>(())
+    /// # Ok::<(), ObservedStepError<McmcError, Infallible>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] on the first step or thinned observation
-    /// failure.
+    /// Returns [`ObservedStepError`] on the first step or thinned observation
+    /// failure. The [`ThinningInterval`] argument proves the divisor is
+    /// nonzero.
     pub fn try_run_observing_with_thinning<O: TryObservable<S> + ?Sized>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
     ) -> TryThinnedObservedRunResult<O::Output, McmcError, O::Error> {
         self.collect_with_thinning_core(
@@ -1226,27 +1258,28 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &Flat)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &i32| Ok::<f64, Infallible>(f64::from(*state));
     /// let mut stats = OnlineStats::new();
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// sampler.try_run_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
+    /// sampler.try_run_observing_into_with_thinning(
+    ///     5, thin_interval, &mut coordinate, &mut stats,
+    /// )?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), ThinningError<ObservedStreamError<McmcError, Infallible, StatisticsError>>>(())
+    /// # Ok::<(), ObservedStreamError<McmcError, Infallible, StatisticsError>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] when the underlying stream fails.
+    /// Returns [`ObservedStreamError`] when the underlying stream fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn try_run_observing_into_with_thinning<O, A>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
         accumulator: &mut A,
     ) -> TryThinnedObservedIntoRunResult<McmcError, O::Error, A::Error>
@@ -1254,7 +1287,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
         O: TryObservable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        self.run_thinning_core(
+        self.run_thinning_loop(
             steps,
             thin_interval,
             |sampler| sampler.step().map_err(ObservedStreamError::Step),
@@ -1408,7 +1441,6 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// divisible by `thin_interval`.
     ///
     /// ```
-    /// # use std::assert_matches;
     /// use markov_chain_monte_carlo::prelude::in_place::*;
     /// use rand::{Rng, SeedableRng, rngs::StdRng};
     ///
@@ -1430,26 +1462,23 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ThinningError::Run)?;
+    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)?;
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// let states = sampler.run_mut_with_thinning(5, 2)?;
+    /// let states = sampler.run_mut_with_thinning(5, thin_interval)?;
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
-    ///
-    /// let err = sampler.run_mut_with_thinning(1, 0).unwrap_err();
-    /// assert_matches!(err, ThinningError::InvalidInterval { thin_interval: 0 });
-    /// # Ok::<(), ThinningError<McmcError>>(())
+    /// # Ok::<(), McmcError>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] on the first step that fails.
+    /// Returns [`McmcError`] on the first step that fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn run_mut_with_thinning(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
     ) -> ThinnedRunResult<SampleBuffer<S>, McmcError>
     where
         S: Clone,
@@ -1575,24 +1604,25 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
-    /// let chain = Chain::new(S(0), &Flat).map_err(ThinningError::Run)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ThinningError::Run)?;
+    /// let chain = Chain::new(S(0), &Flat)?;
+    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)?;
     /// let mut coordinate = |state: &S| state.0;
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// let samples = sampler.run_mut_observing_with_thinning(5, 2, &mut coordinate)?;
+    /// let samples =
+    ///     sampler.run_mut_observing_with_thinning(5, thin_interval, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), ThinningError<McmcError>>(())
+    /// # Ok::<(), McmcError>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] on the first step that fails.
+    /// Returns [`McmcError`] on the first step that fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn run_mut_observing_with_thinning<O: Observable<S> + ?Sized>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
     ) -> ThinnedRunResult<SampleBuffer<O::Output>, McmcError> {
         self.collect_with_thinning_core(
@@ -1693,27 +1723,28 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &S| f64::from(state.0);
     /// let mut stats = OnlineStats::new();
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// sampler.run_mut_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
+    /// sampler.run_mut_observing_into_with_thinning(
+    ///     5, thin_interval, &mut coordinate, &mut stats,
+    /// )?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), ThinningError<ObservedStreamError<McmcError, Infallible, StatisticsError>>>(())
+    /// # Ok::<(), ObservedStreamError<McmcError, Infallible, StatisticsError>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] when the underlying stream fails.
+    /// Returns [`ObservedStreamError`] when the underlying stream fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn run_mut_observing_into_with_thinning<O, A>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
         accumulator: &mut A,
     ) -> ThinnedObservedIntoRunResult<McmcError, A::Error>
@@ -1721,7 +1752,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
         O: Observable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        self.run_thinning_core(
+        self.run_thinning_loop(
             steps,
             thin_interval,
             |sampler| {
@@ -1855,27 +1886,27 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat)
-    ///     .map_err(ObservedStepError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ObservedStepError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut coordinate = |state: &S| Ok::<i32, Infallible>(state.0);
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// let samples = sampler.try_run_mut_observing_with_thinning(5, 2, &mut coordinate)?;
+    /// let samples =
+    ///     sampler.try_run_mut_observing_with_thinning(5, thin_interval, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), ThinningError<ObservedStepError<McmcError, Infallible>>>(())
+    /// # Ok::<(), ObservedStepError<McmcError, Infallible>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] on the first step or thinned observation
-    /// failure.
+    /// Returns [`ObservedStepError`] on the first step or thinned observation
+    /// failure. The [`ThinningInterval`] argument proves the divisor is
+    /// nonzero.
     pub fn try_run_mut_observing_with_thinning<O: TryObservable<S> + ?Sized>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
     ) -> TryThinnedObservedRunResult<O::Output, McmcError, O::Error> {
         self.collect_with_thinning_core(
@@ -1977,27 +2008,28 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &S| Ok::<f64, Infallible>(f64::from(state.0));
     /// let mut stats = OnlineStats::new();
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// sampler.try_run_mut_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
+    /// sampler.try_run_mut_observing_into_with_thinning(
+    ///     5, thin_interval, &mut coordinate, &mut stats,
+    /// )?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), ThinningError<ObservedStreamError<McmcError, Infallible, StatisticsError>>>(())
+    /// # Ok::<(), ObservedStreamError<McmcError, Infallible, StatisticsError>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] when the underlying stream fails.
+    /// Returns [`ObservedStreamError`] when the underlying stream fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn try_run_mut_observing_into_with_thinning<O, A>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
         accumulator: &mut A,
     ) -> TryThinnedObservedIntoRunResult<McmcError, O::Error, A::Error>
@@ -2005,7 +2037,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
         O: TryObservable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        self.run_thinning_core(
+        self.run_thinning_loop(
             steps,
             thin_interval,
             |sampler| {
@@ -2084,7 +2116,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)?;
     ///
     /// let step = sampler.step_delayed()?;
-    /// assert_eq!(step.outcome, StepOutcome::Accepted);
+    /// assert_eq!(step.outcome(), StepOutcome::Accepted);
     /// assert_eq!(*sampler.chain_ref().state(), 0);
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
@@ -2163,7 +2195,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)?;
     ///
     /// let step = sampler.step_delayed_checked()?;
-    /// assert_eq!(step.outcome, StepOutcome::Accepted);
+    /// assert_eq!(step.outcome(), StepOutcome::Accepted);
     /// assert_eq!(*sampler.chain_ref().state(), 0);
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
@@ -2415,8 +2447,8 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut families = Vec::new();
     /// let continuation = sampler.run_delayed_chunk_observing(3, |step, state| {
     ///     assert!(step.rejection_reason().is_none());
-    ///     if let Some(family) = step.info {
-    ///         families.push((family, *state));
+    ///     if let Some(family) = step.info() {
+    ///         families.push((*family, *state));
     ///     }
     /// })?;
     ///
@@ -2502,28 +2534,24 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &target)
-    ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(DelayedStepError::Mcmc)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
-    ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(DelayedStepError::Mcmc)?;
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// let states = sampler.run_delayed_with_thinning(5, 2)?;
+    /// let states = sampler.run_delayed_with_thinning(5, thin_interval)?;
     /// assert_eq!(states.as_slice(), &[S(2), S(4)]);
-    ///
-    /// let err = sampler.run_delayed_with_thinning(1, 0).unwrap_err();
-    /// assert_matches!(err, ThinningError::InvalidInterval { thin_interval: 0 });
-    /// # Ok::<(), ThinningError<DelayedStepError<Infallible>>>(())
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] on the first delayed step that fails.
+    /// Returns [`DelayedStepError`] on the first delayed step that fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn run_delayed_with_thinning(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
     ) -> ThinnedRunResult<SampleBuffer<S>, DelayedStepError<P::Error>>
     where
         S: Clone,
@@ -2686,26 +2714,26 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut proposal = Increment;
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target)
-    ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(DelayedStepError::Mcmc)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
-    ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(DelayedStepError::Mcmc)?;
     /// let mut coordinate = |state: &i32| *state;
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// let samples = sampler.run_delayed_observing_with_thinning(5, 2, &mut coordinate)?;
+    /// let samples =
+    ///     sampler.run_delayed_observing_with_thinning(5, thin_interval, &mut coordinate)?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), ThinningError<DelayedStepError<Infallible>>>(())
+    /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] on the first delayed step that fails.
+    /// Returns [`DelayedStepError`] on the first delayed step that fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn run_delayed_observing_with_thinning<O: Observable<S> + ?Sized>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
     ) -> ThinnedRunResult<SampleBuffer<O::Output>, DelayedStepError<P::Error>> {
         self.collect_with_thinning_core(
@@ -2811,28 +2839,29 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
     ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &i32| f64::from(*state);
     /// let mut stats = OnlineStats::new();
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// sampler.run_delayed_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
+    /// sampler.run_delayed_observing_into_with_thinning(
+    ///     5, thin_interval, &mut coordinate, &mut stats,
+    /// )?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), ThinningError<ObservedStreamError<DelayedStepError<Infallible>, Infallible, StatisticsError>>>(())
+    /// # Ok::<(), ObservedStreamError<DelayedStepError<Infallible>, Infallible, StatisticsError>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] when the underlying stream fails.
+    /// Returns [`ObservedStreamError`] when the underlying stream fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn run_delayed_observing_into_with_thinning<O, A>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
         accumulator: &mut A,
     ) -> ThinnedObservedDelayedIntoRunResult<P::Error, A::Error>
@@ -2840,7 +2869,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
         O: Observable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        self.run_thinning_core(
+        self.run_thinning_loop(
             steps,
             thin_interval,
             |sampler| {
@@ -2987,28 +3016,29 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ObservedStepError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
     ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ObservedStepError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStepError::Step)?;
     /// let mut coordinate = |state: &i32| Ok::<i32, Infallible>(*state);
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// let samples = sampler.try_run_delayed_observing_with_thinning(5, 2, &mut coordinate)?;
+    /// let samples = sampler.try_run_delayed_observing_with_thinning(
+    ///     5, thin_interval, &mut coordinate,
+    /// )?;
     /// assert_eq!(samples.as_slice(), &[2, 4]);
-    /// # Ok::<(), ThinningError<ObservedStepError<DelayedStepError<Infallible>, Infallible>>>(())
+    /// # Ok::<(), ObservedStepError<DelayedStepError<Infallible>, Infallible>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] on the first delayed step or thinned
-    /// observation failure.
+    /// Returns [`ObservedStepError`] on the first delayed step or thinned
+    /// observation failure. The [`ThinningInterval`] argument proves the
+    /// divisor is nonzero.
     pub fn try_run_delayed_observing_with_thinning<O: TryObservable<S> + ?Sized>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
     ) -> TryThinnedObservedRunResult<O::Output, DelayedStepError<P::Error>, O::Error> {
         self.collect_with_thinning_core(
@@ -3116,28 +3146,29 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(0, &target)
     ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut sampler = Sampler::new(chain, &target, &mut proposal, &mut rng)
     ///     .map_err(DelayedStepError::Mcmc)
-    ///     .map_err(ObservedStreamError::Step)
-    ///     .map_err(ThinningError::Run)?;
+    ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &i32| Ok::<f64, Infallible>(f64::from(*state));
     /// let mut stats = OnlineStats::new();
+    /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
-    /// sampler.try_run_delayed_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)?;
+    /// sampler.try_run_delayed_observing_into_with_thinning(
+    ///     5, thin_interval, &mut coordinate, &mut stats,
+    /// )?;
     /// assert_eq!(stats.count(), 2);
-    /// # Ok::<(), ThinningError<ObservedStreamError<DelayedStepError<Infallible>, Infallible, StatisticsError>>>(())
+    /// # Ok::<(), ObservedStreamError<DelayedStepError<Infallible>, Infallible, StatisticsError>>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`ThinningError::InvalidInterval`] if `thin_interval` is zero,
-    /// or [`ThinningError::Run`] when the underlying stream fails.
+    /// Returns [`ObservedStreamError`] when the underlying stream fails. The
+    /// [`ThinningInterval`] argument proves the divisor is nonzero.
     pub fn try_run_delayed_observing_into_with_thinning<O, A>(
         &mut self,
         steps: usize,
-        thin_interval: usize,
+        thin_interval: ThinningInterval,
         observable: &mut O,
         accumulator: &mut A,
     ) -> TryThinnedObservedDelayedIntoRunResult<P::Error, O::Error, A::Error>
@@ -3145,7 +3176,7 @@ impl<S, T: Target<S>, P: DelayedProposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, 
         O: TryObservable<S> + ?Sized,
         A: TryAccumulator<O::Output> + ?Sized,
     {
-        self.run_thinning_core(
+        self.run_thinning_loop(
             steps,
             thin_interval,
             |sampler| {
@@ -3218,6 +3249,10 @@ mod tests {
     use crate::{BinningAnalysis, OnlineStats, StatisticsError, StepOutcome};
 
     // --- Shared fixtures ---
+
+    fn thin(value: usize) -> ThinningInterval {
+        ThinningInterval::new(value).unwrap()
+    }
 
     #[derive(Clone, Debug, PartialEq)]
     struct Scalar(f64);
@@ -3425,9 +3460,11 @@ mod tests {
     }
 
     #[test]
-    fn thinning_error_display_names_invalid_interval() {
-        let err: ThinningError<McmcError> = ThinningError::InvalidInterval { thin_interval: 0 };
+    fn thinning_interval_rejects_zero() {
+        let err = ThinningInterval::new(0).unwrap_err();
 
+        assert_eq!(err.value(), 0);
+        assert_eq!(ThinningInterval::try_from(0), Err(err));
         assert_eq!(
             err.to_string(),
             "invalid thinning interval 0: expected a value greater than zero"
@@ -3436,11 +3473,18 @@ mod tests {
     }
 
     #[test]
-    fn thinning_error_preserves_underlying_source() {
-        let err = ThinningError::Run(McmcError::NanLogQRatio);
+    fn thinning_interval_preserves_positive_values() {
+        let interval = ThinningInterval::new(3).unwrap();
+        let maximum = ThinningInterval::new(usize::MAX).unwrap();
+        let nonzero = NonZeroUsize::from(interval);
 
-        assert_eq!(err.to_string(), "proposal returned NaN log q-ratio");
-        assert!(Error::source(&err).is_some());
+        assert_eq!(ThinningInterval::MIN.get(), 1);
+        assert_eq!(interval.get(), 3);
+        assert_eq!(maximum.get(), usize::MAX);
+        assert_eq!(maximum.saturating_add(1), maximum);
+        assert_eq!(ThinningInterval::try_from(3), Ok(interval));
+        assert_eq!(ThinningInterval::from(nonzero), interval);
+        assert_eq!(ThinningInterval::MIN.saturating_add(2), interval);
     }
 
     // --- By-value: step and run ---
@@ -3470,7 +3514,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
 
-        let states = sampler.run_with_thinning(5, 2).unwrap();
+        let states = sampler.run_with_thinning(5, thin(2)).unwrap();
 
         assert_eq!(states.len(), 2);
         assert_eq!(sampler.chain_ref().total_steps(), 5);
@@ -3481,24 +3525,10 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
 
-        let states = sampler.run_with_thinning(3, 4).unwrap();
+        let states = sampler.run_with_thinning(3, thin(4)).unwrap();
 
         assert!(states.is_empty());
         assert_eq!(sampler.chain_ref().total_steps(), 3);
-    }
-
-    #[test]
-    fn run_with_thinning_reports_zero_interval() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
-
-        let result = sampler.run_with_thinning(5, 0);
-
-        assert_matches!(
-            result,
-            Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        );
-        assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
     #[test]
@@ -3507,9 +3537,9 @@ mod tests {
         let chain = Chain::new(Scalar(0.0), &Normal).unwrap();
         let mut sampler = sampler!(chain, &Normal, &NanLogQProposal, &mut rng);
 
-        let result = sampler.run_with_thinning(5, 2);
+        let result = sampler.run_with_thinning(5, thin(2));
 
-        assert_matches!(result, Err(ThinningError::Run(McmcError::NanLogQRatio)));
+        assert_matches!(result, Err(McmcError::NanLogQRatio));
         assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
@@ -3585,7 +3615,7 @@ mod tests {
         };
 
         let measurements = sampler
-            .run_observing_with_thinning(5, 2, &mut coordinate)
+            .run_observing_with_thinning(5, thin(2), &mut coordinate)
             .unwrap();
 
         assert_eq!(measurements.len(), 2);
@@ -3604,7 +3634,7 @@ mod tests {
         };
 
         let measurements = sampler
-            .run_observing_with_thinning(3, 4, &mut coordinate)
+            .run_observing_with_thinning(3, thin(4), &mut coordinate)
             .unwrap();
 
         assert!(measurements.is_empty());
@@ -3620,7 +3650,7 @@ mod tests {
         let mut stats = OnlineStats::new();
 
         sampler
-            .run_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)
+            .run_observing_into_with_thinning(5, thin(2), &mut coordinate, &mut stats)
             .unwrap();
 
         assert_eq!(stats.count(), 2);
@@ -3637,13 +3667,11 @@ mod tests {
             Err::<f64, _>(ObservationFailure::Failed)
         };
 
-        let result = sampler.try_run_observing_with_thinning(5, 2, &mut observable);
+        let result = sampler.try_run_observing_with_thinning(5, thin(2), &mut observable);
 
         assert_matches!(
             result,
-            Err(ThinningError::Run(ObservedStepError::Observation(
-                ObservationFailure::Failed
-            )))
+            Err(ObservedStepError::Observation(ObservationFailure::Failed))
         );
         assert_eq!(calls, 1);
         assert_eq!(sampler.chain_ref().total_steps(), 2);
@@ -3657,43 +3685,11 @@ mod tests {
         let mut stats = OnlineStats::new();
 
         sampler
-            .try_run_observing_into_with_thinning(5, 2, &mut coordinate, &mut stats)
+            .try_run_observing_into_with_thinning(5, thin(2), &mut coordinate, &mut stats)
             .unwrap();
 
         assert_eq!(stats.count(), 2);
         assert_eq!(sampler.chain_ref().total_steps(), 5);
-    }
-
-    #[test]
-    fn run_observing_with_thinning_reports_zero_interval() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
-        let mut coordinate = |state: &Scalar| state.0;
-
-        let result = sampler.run_observing_with_thinning(5, 0, &mut coordinate);
-
-        assert_matches!(
-            result,
-            Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        );
-        assert_eq!(sampler.chain_ref().total_steps(), 0);
-    }
-
-    #[test]
-    fn run_observing_into_with_thinning_reports_zero_interval() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = sampler!(scalar_chain(0.0), &Normal, &Walk { width: 1.0 }, &mut rng);
-        let mut coordinate = |state: &Scalar| state.0;
-        let mut stats = OnlineStats::new();
-
-        let result = sampler.run_observing_into_with_thinning(5, 0, &mut coordinate, &mut stats);
-
-        assert_matches!(
-            result,
-            Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        );
-        assert_eq!(stats.count(), 0);
-        assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
     #[test]
@@ -3710,13 +3706,16 @@ mod tests {
 
         // Interval 1 would emit every successful step; NanLogQProposal fails
         // the first step, proving the step error is reported before emission.
-        let result = sampler.run_observing_into_with_thinning(5, 1, &mut coordinate, &mut stats);
+        let result = sampler.run_observing_into_with_thinning(
+            5,
+            ThinningInterval::MIN,
+            &mut coordinate,
+            &mut stats,
+        );
 
         assert_matches!(
             result,
-            Err(ThinningError::Run(ObservedStreamError::Step(
-                McmcError::NanLogQRatio
-            )))
+            Err(ObservedStreamError::Step(McmcError::NanLogQRatio))
         );
         assert!(!observed);
         assert_eq!(stats.count(), 0);
@@ -3889,7 +3888,7 @@ mod tests {
             &mut rng,
         );
 
-        let states = sampler.run_mut_with_thinning(7, 3).unwrap();
+        let states = sampler.run_mut_with_thinning(7, thin(3)).unwrap();
 
         assert_eq!(states.len(), 2);
         assert_eq!(sampler.chain_ref().total_steps(), 7);
@@ -3905,29 +3904,10 @@ mod tests {
             &mut rng,
         );
 
-        let states = sampler.run_mut_with_thinning(3, 4).unwrap();
+        let states = sampler.run_mut_with_thinning(3, thin(4)).unwrap();
 
         assert!(states.is_empty());
         assert_eq!(sampler.chain_ref().total_steps(), 3);
-    }
-
-    #[test]
-    fn run_mut_with_thinning_reports_zero_interval() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = sampler!(
-            scalar_chain(0.0),
-            &Normal,
-            &MutWalk { width: 1.0 },
-            &mut rng,
-        );
-
-        let result = sampler.run_mut_with_thinning(5, 0);
-
-        assert_matches!(
-            result,
-            Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        );
-        assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
     #[test]
@@ -3976,7 +3956,7 @@ mod tests {
         };
 
         let measurements = sampler
-            .run_mut_observing_with_thinning(7, 3, &mut coordinate)
+            .run_mut_observing_with_thinning(7, thin(3), &mut coordinate)
             .unwrap();
 
         assert_eq!(measurements.len(), 2);
@@ -3997,7 +3977,7 @@ mod tests {
         let mut stats = OnlineStats::new();
 
         sampler
-            .run_mut_observing_into_with_thinning(7, 3, &mut coordinate, &mut stats)
+            .run_mut_observing_into_with_thinning(7, thin(3), &mut coordinate, &mut stats)
             .unwrap();
 
         assert_eq!(stats.count(), 2);
@@ -4019,13 +3999,11 @@ mod tests {
             Err::<f64, _>(ObservationFailure::Failed)
         };
 
-        let result = sampler.try_run_mut_observing_with_thinning(7, 3, &mut observable);
+        let result = sampler.try_run_mut_observing_with_thinning(7, thin(3), &mut observable);
 
         assert_matches!(
             result,
-            Err(ThinningError::Run(ObservedStepError::Observation(
-                ObservationFailure::Failed
-            )))
+            Err(ObservedStepError::Observation(ObservationFailure::Failed))
         );
         assert_eq!(calls, 1);
         assert_eq!(sampler.chain_ref().total_steps(), 3);
@@ -4044,31 +4022,11 @@ mod tests {
         let mut stats = OnlineStats::new();
 
         sampler
-            .try_run_mut_observing_into_with_thinning(7, 3, &mut coordinate, &mut stats)
+            .try_run_mut_observing_into_with_thinning(7, thin(3), &mut coordinate, &mut stats)
             .unwrap();
 
         assert_eq!(stats.count(), 2);
         assert_eq!(sampler.chain_ref().total_steps(), 7);
-    }
-
-    #[test]
-    fn run_mut_observing_with_thinning_reports_zero_interval() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = sampler!(
-            mut_scalar_chain(0.0),
-            &Normal,
-            &MutWalk { width: 1.0 },
-            &mut rng,
-        );
-        let mut coordinate = |state: &MutScalar| state.0;
-
-        let result = sampler.run_mut_observing_with_thinning(5, 0, &mut coordinate);
-
-        assert_matches!(
-            result,
-            Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        );
-        assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
     #[test]
@@ -4236,7 +4194,7 @@ mod tests {
 
         let step = sampler.step_delayed().unwrap();
 
-        assert_eq!(step.outcome, StepOutcome::Accepted);
+        assert_eq!(step.outcome(), StepOutcome::Accepted);
         assert_eq!(sampler.chain_ref().state(), &MutScalar(0.0));
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
@@ -4265,10 +4223,10 @@ mod tests {
         let mut observed_states = Vec::new();
         let continuation = sampler
             .run_delayed_chunk_observing(3, |step, state| {
-                outcomes.push(step.outcome);
+                outcomes.push(step.outcome());
                 assert!(step.rejection_reason().is_none());
-                if let Some(family) = step.info {
-                    families.push(family);
+                if let Some(family) = step.info() {
+                    families.push(*family);
                 }
                 observed_states.push(state.0);
             })
@@ -4321,7 +4279,7 @@ mod tests {
         let mut proposal = DelayedToZero;
         let mut sampler = sampler!(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
 
-        let states = sampler.run_delayed_with_thinning(6, 2).unwrap();
+        let states = sampler.run_delayed_with_thinning(6, thin(2)).unwrap();
 
         assert_eq!(states.as_slice(), &[Scalar(0.0), Scalar(0.0), Scalar(0.0)]);
         assert_eq!(sampler.chain_ref().total_steps(), 6);
@@ -4333,25 +4291,10 @@ mod tests {
         let mut proposal = DelayedToZero;
         let mut sampler = sampler!(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
 
-        let states = sampler.run_delayed_with_thinning(3, 4).unwrap();
+        let states = sampler.run_delayed_with_thinning(3, thin(4)).unwrap();
 
         assert!(states.is_empty());
         assert_eq!(sampler.chain_ref().total_steps(), 3);
-    }
-
-    #[test]
-    fn run_delayed_with_thinning_reports_zero_interval() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let mut proposal = DelayedToZero;
-        let mut sampler = sampler!(scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
-
-        let result = sampler.run_delayed_with_thinning(5, 0);
-
-        assert_matches!(
-            result,
-            Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        );
-        assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
     #[test]
@@ -4398,7 +4341,7 @@ mod tests {
         };
 
         let measurements = sampler
-            .run_delayed_observing_with_thinning(6, 2, &mut coordinate)
+            .run_delayed_observing_with_thinning(6, thin(2), &mut coordinate)
             .unwrap();
 
         assert_eq!(measurements.as_slice(), &[0.0; 3]);
@@ -4415,31 +4358,12 @@ mod tests {
         let mut stats = OnlineStats::new();
 
         sampler
-            .run_delayed_observing_into_with_thinning(6, 2, &mut coordinate, &mut stats)
+            .run_delayed_observing_into_with_thinning(6, thin(2), &mut coordinate, &mut stats)
             .unwrap();
 
         assert_eq!(stats.count(), 3);
         assert_eq!(stats.mean(), Some(0.0));
         assert_eq!(sampler.chain_ref().total_steps(), 6);
-    }
-
-    #[test]
-    fn run_delayed_observing_into_with_thinning_reports_zero_interval() {
-        let mut rng = StdRng::seed_from_u64(42);
-        let mut proposal = DelayedToZero;
-        let mut sampler = sampler!(mut_scalar_chain(2.0), &Normal, &mut proposal, &mut rng);
-        let mut coordinate = |state: &MutScalar| state.0;
-        let mut stats = OnlineStats::new();
-
-        let result =
-            sampler.run_delayed_observing_into_with_thinning(5, 0, &mut coordinate, &mut stats);
-
-        assert_matches!(
-            result,
-            Err(ThinningError::InvalidInterval { thin_interval: 0 })
-        );
-        assert_eq!(stats.count(), 0);
-        assert_eq!(sampler.chain_ref().total_steps(), 0);
     }
 
     #[test]
@@ -4487,13 +4411,11 @@ mod tests {
             Err::<f64, _>(ObservationFailure::Failed)
         };
 
-        let result = sampler.try_run_delayed_observing_with_thinning(6, 2, &mut observable);
+        let result = sampler.try_run_delayed_observing_with_thinning(6, thin(2), &mut observable);
 
         assert_matches!(
             result,
-            Err(ThinningError::Run(ObservedStepError::Observation(
-                ObservationFailure::Failed
-            )))
+            Err(ObservedStepError::Observation(ObservationFailure::Failed))
         );
         assert_eq!(calls, 1);
         assert_eq!(sampler.chain_ref().total_steps(), 2);
@@ -4508,7 +4430,7 @@ mod tests {
         let mut stats = OnlineStats::new();
 
         sampler
-            .try_run_delayed_observing_into_with_thinning(6, 2, &mut coordinate, &mut stats)
+            .try_run_delayed_observing_into_with_thinning(6, thin(2), &mut coordinate, &mut stats)
             .unwrap();
 
         assert_eq!(stats.count(), 3);
@@ -4637,7 +4559,7 @@ mod tests {
         let mut observed = Vec::new();
 
         let result = sampler.run_delayed_chunk_observing(3, |step, state| {
-            observed.push((step.outcome, step.info, state.0));
+            observed.push((step.outcome(), step.info().copied(), state.0));
         });
 
         assert_matches!(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -642,7 +642,7 @@ impl<S, P: ProposalMut<S> + ?Sized> ProposalMut<S> for &mut P {
 ///
 /// Implement [`no_plan_info`](Self::no_plan_info) when planning may select a
 /// move family before discovering that no concrete site exists.  [`crate::Chain`]
-/// stores that metadata in [`crate::DelayedStep::info`] even though the step is
+/// stores that metadata through [`crate::DelayedStep::info`] even though the step is
 /// counted as a rejection with no proposal.
 pub trait DelayedProposal<S> {
     /// Concrete move descriptor produced before the Metropolis-Hastings decision.
@@ -744,8 +744,8 @@ pub trait DelayedProposal<S> {
     ///
     /// let step = chain.step_delayed(&Flat, &mut proposal, &mut rng)?;
     ///
-    /// assert_eq!(step.outcome, StepOutcome::NoProposal);
-    /// assert_eq!(step.info, Some(MoveFamily::Add));
+    /// assert_eq!(step.outcome(), StepOutcome::NoProposal);
+    /// assert_eq!(step.info(), Some(&MoveFamily::Add));
     /// # Ok::<(), DelayedStepError<Infallible>>(())
     /// ```
     fn no_plan_info(&mut self) -> Option<Self::Info> {

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -82,6 +82,72 @@ pub struct DiscreteProposalRatio {
     forward_site_count: usize,
 }
 
+pub struct Sampler;
+
+impl Sampler {
+    // ruleid: mcmc.rust.thinning-interval-parameters-use-refined-type
+    pub fn run_with_thinning(&mut self, steps: usize, thin_interval: usize) {
+        let _ = (steps, thin_interval);
+    }
+
+    // ruleid: mcmc.rust.thinning-interval-parameters-use-refined-type
+    pub fn try_run_observing_with_thinning<O>(
+        &mut self,
+        steps: usize,
+        thin_interval: usize,
+        observable: &mut O,
+    ) {
+        let _ = (steps, thin_interval, observable);
+    }
+}
+
+pub struct ThinningInterval;
+
+impl Sampler {
+    // ok: mcmc.rust.thinning-interval-parameters-use-refined-type
+    pub fn run_mut_with_thinning(
+        &mut self,
+        steps: usize,
+        thin_interval: ThinningInterval,
+    ) {
+        let _ = (steps, thin_interval);
+    }
+}
+
+mod mutable_step {
+    pub struct StepOutcome;
+
+    pub struct Step<I> {
+        // ruleid: mcmc.rust.step-telemetry-fields-private
+        pub outcome: StepOutcome,
+        // ruleid: mcmc.rust.step-telemetry-fields-private
+        pub info: Option<I>,
+        // ruleid: mcmc.rust.step-telemetry-fields-private
+        pub log_prob_before: f64,
+        // ruleid: mcmc.rust.step-telemetry-fields-private
+        pub log_prob_after: Option<f64>,
+        // ruleid: mcmc.rust.step-telemetry-fields-private
+        pub log_alpha: Option<f64>,
+    }
+}
+
+mod private_step {
+    pub struct StepOutcome;
+
+    pub struct Step<I> {
+        // ok: mcmc.rust.step-telemetry-fields-private
+        outcome: StepOutcome,
+        // ok: mcmc.rust.step-telemetry-fields-private
+        info: Option<I>,
+        // ok: mcmc.rust.step-telemetry-fields-private
+        log_prob_before: f64,
+        // ok: mcmc.rust.step-telemetry-fields-private
+        log_prob_after: Option<f64>,
+        // ok: mcmc.rust.step-telemetry-fields-private
+        log_alpha: Option<f64>,
+    }
+}
+
 // ruleid: mcmc.rust.no-box-dyn-error-in-src
 fn erased_error() -> Result<(), Box<dyn Error>> {
     Ok(())


### PR DESCRIPTION
- Parse positive thinning intervals once with ThinningInterval and propagate underlying run errors directly.
- Keep Step telemetry internally consistent through private fields and read-only accessors.
- Add repository guardrails against raw thinning parameters and public telemetry fields.

Migration:
- Pass a ThinningInterval to every *_with_thinning method.
- Match the underlying method error instead of ThinningError::Run.
- Replace direct Step field access with the corresponding accessor methods.

BREAKING CHANGE: Thinned sampler methods now accept ThinningInterval and return their underlying error types, ThinningError is removed, and Step telemetry fields are private.

Closes #82