### PR TITLE
feat!: add structured in-place proposal telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ fn main() -> Result<(), McmcError> {
 ## 🧭 Choosing an API
 
 - Start with `Proposal` and `Chain::step` when state cloning is cheap.
-- Use `ProposalMut` and `Chain::step_mut` when cloning state is expensive and rollback is simple.
+- Use `ProposalMut` and `Chain::step_mut` when cloning state is expensive and rollback is simple; its `Info` metadata is returned in structured `Step`
+  telemetry for accepted, rejected, and unavailable proposals.
+- Drive `Sampler::step_mut` explicitly when every transition needs metadata. Bulk `Sampler::run_mut*` methods deliberately skip `Info` construction and
+  proposal telemetry hooks, so metadata that would be discarded is not constructed.
 - Use `DelayedProposal` and `Chain::step_delayed` when you need to plan and score a concrete move before mutating state.
 - Use `AdditiveTarget` when the target log weight is the sum of model, bias, energy, action, or externally supplied regularizer terms.
 - Use `DelayedStep` telemetry, `StepOutcome`, and `DelayedProposal::no_plan_info` when delayed proposals need domain-specific per-step records.
@@ -167,9 +170,12 @@ fn main() -> Result<(), McmcError> {
 - Use `verify_detailed_balance*` helpers in proposal tests for representative discrete transitions.
 - Use `OnlineStats` and `BinningAnalysis` when long runs should stream statistics instead of retaining every sample.
 
-When migrating from the previous thinning and delayed-telemetry APIs, replace raw thinning `usize` arguments with a parsed `ThinningInterval`, handle the
-underlying sampler or observation error directly instead of matching `ThinningError::Run`, and replace `Step` field reads with the corresponding
-`outcome()`, `info()`, `log_prob_before()`, `log_prob_after()`, and `log_alpha()` accessors.
+When migrating from the previous in-place API, add `ProposalMut::Info`, implement `info` (and optionally `no_proposal_info`), make proposal mutation hooks
+accept `&mut self`, and read the `Step` returned by `Chain::step_mut` or `Sampler::step_mut` instead of a boolean. Rejection must restore both the state and
+proposal-internal transition state. Keep telemetry hooks observational because bulk execution may skip them. For earlier thinning and
+delayed-telemetry APIs, replace raw thinning `usize` arguments with a parsed `ThinningInterval`, handle the underlying sampler or observation error directly
+instead of matching `ThinningError::Run`, and replace `Step` field reads with the corresponding `outcome()`, `info()`, `log_prob_before()`,
+`log_prob_after()`, and `log_alpha()` accessors.
 
 ## 📦 Cargo features
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ fn main() -> Result<(), McmcError> {
 
 - Start with `Proposal` and `Chain::step` when state cloning is cheap.
 - Use `ProposalMut` and `Chain::step_mut` when cloning state is expensive and rollback is simple; its `Info` metadata is returned in structured `Step`
-  telemetry for accepted, rejected, and unavailable proposals.
+  telemetry for accepted and rejected proposals. `StepOutcome::NoProposal` carries metadata only when `ProposalMut::no_proposal_info` provides it.
 - Drive `Sampler::step_mut` explicitly when every transition needs metadata. Bulk `Sampler::run_mut*` methods deliberately skip `Info` construction and
   proposal telemetry hooks, so metadata that would be discarded is not constructed.
 - Use `DelayedProposal` and `Chain::step_delayed` when you need to plan and score a concrete move before mutating state.

--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -68,8 +68,13 @@ struct SpinFlip;
 
 impl ProposalMut<SpinChain> for SpinFlip {
     type Undo = usize;
+    type Info = usize;
 
-    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+    fn propose_mut<R: Rng + ?Sized>(
+        &mut self,
+        state: &mut SpinChain,
+        rng: &mut R,
+    ) -> Option<usize> {
         if state.spins.is_empty() {
             return None;
         }
@@ -78,7 +83,11 @@ impl ProposalMut<SpinChain> for SpinFlip {
         Some(idx)
     }
 
-    fn undo(&self, state: &mut SpinChain, idx: usize) {
+    fn info(&self, _state: &SpinChain, idx: &usize) -> usize {
+        *idx
+    }
+
+    fn undo(&mut self, state: &mut SpinChain, idx: usize) {
         state.spins[idx] *= -1;
     }
 }
@@ -201,7 +210,6 @@ fn bench_chain_steps(c: &mut Criterion) {
     let flat = FlatTarget;
     let proposal = RandomWalk { width: 1.0 };
     let spin_target = Alignment { beta: 8.0 };
-    let spin_proposal = SpinFlip;
 
     c.bench_function("chain/step_by_value", |b| {
         let mut chain = scalar_chain(&target);
@@ -217,12 +225,13 @@ fn bench_chain_steps(c: &mut Criterion) {
 
     c.bench_function("chain/step_mut_accept", |b| {
         let mut chain = spin_chain(&Alignment { beta: 0.0 });
+        let mut spin_proposal = SpinFlip;
         let mut rng = StdRng::seed_from_u64(SEED);
 
         b.iter(|| {
-            black_box(
+            let _ = black_box(
                 chain
-                    .step_mut(&flat, &spin_proposal, &mut rng)
+                    .step_mut(&flat, &mut spin_proposal, &mut rng)
                     .or_abort("in-place chain step on flat target"),
             );
             black_box(chain.state().spins[0]);
@@ -231,12 +240,13 @@ fn bench_chain_steps(c: &mut Criterion) {
 
     c.bench_function("chain/step_mut_reject_rollback", |b| {
         let mut chain = spin_chain(&spin_target);
+        let mut spin_proposal = SpinFlip;
         let mut rng = StdRng::seed_from_u64(SEED);
 
         b.iter(|| {
-            black_box(
+            let _ = black_box(
                 chain
-                    .step_mut(&spin_target, &spin_proposal, &mut rng)
+                    .step_mut(&spin_target, &mut spin_proposal, &mut rng)
                     .or_abort("in-place chain step with rollback"),
             );
             black_box(chain.state().spins[0]);
@@ -297,7 +307,6 @@ fn bench_sampler_runs(c: &mut Criterion) {
     let target = Normal;
     let proposal = RandomWalk { width: 1.0 };
     let flat = FlatTarget;
-    let spin_proposal = SpinFlip;
 
     c.bench_function("sampler/run_by_value_100", |b| {
         let mut rng = StdRng::seed_from_u64(SEED);
@@ -317,7 +326,7 @@ fn bench_sampler_runs(c: &mut Criterion) {
         let mut sampler = Sampler::new(
             spin_chain(&Alignment { beta: 0.0 }),
             &flat,
-            &spin_proposal,
+            SpinFlip,
             &mut rng,
         )
         .or_abort("sampler in-place setup");

--- a/docs/proposal_validation.md
+++ b/docs/proposal_validation.md
@@ -31,18 +31,27 @@ For continuous proposals, exact endpoint hits are usually too rare for the curre
 ## In-Place Proposals
 
 Use `ProposalMut<S>` when cloning the full state is expensive. The proposal mutates state and returns an undo token that must restore the exact previous state
-on rejection.
+and any proposal-internal state that can affect later transitions on rejection.
+
+Treat `Info`, `info`, and `no_proposal_info` as telemetry only. They must not change future transition behavior: bulk `Sampler::run_mut*` methods skip these
+hooks when they do not return `Step` values. Drive `Sampler::step_mut` explicitly when every transition needs metadata.
 
 Useful checks:
 
 - Verify that `propose_mut` returning `None` instead of `Option<Undo>::Some` leaves the state unchanged.
 - Verify `undo` restores the exact previous state for every successful proposal.
+- Verify rejection also restores proposal-internal transition state.
 - Test invalid log-probability and invalid log-ratio paths.
 - Use `verify_detailed_balance_mut` on small representative states that implement `Clone + PartialEq`.
 - Use `verify_detailed_balance_mut_many` for batches of local moves.
 
-The detailed-balance helper clones endpoints so it can resample transitions from a clean state. That cloning is intentional test overhead, not a production
-sampling requirement.
+The detailed-balance helper clones endpoints so it can resample transitions from a clean state. After every concrete hypothetical proposal it calls `undo`,
+including proposals that do not match the requested destination and proposals whose density is invalid. It also consumes no-proposal telemetry. Each trial
+therefore begins from a clean endpoint and rollback-governed proposal transition state. The cloning is intentional test overhead, not a production sampling
+requirement.
+
+These diagnostics assume a fixed proposal kernel. Freeze online adaptation before calling them; proposal state outside the `undo` contract makes repeated
+transition estimates nonstationary and invalidates the detailed-balance check.
 
 ## Delayed Proposals
 

--- a/docs/scientific_basis.md
+++ b/docs/scientific_basis.md
@@ -68,7 +68,7 @@ The library enforces several local invariants:
 - Acceptance decisions are computed in log space.
 - Log-space acceptance avoids underflow in tail probabilities.
 - `NaN` and positive-infinite target log-probabilities or proposal ratios are rejected.
-- In-place proposals roll back on rejection or invalid proposed values.
+- In-place proposals roll back target state and proposal-internal transition state on rejection or invalid proposed values.
 - Delayed proposals separate planning, scoring, acceptance, and commit so mutations happen only after acceptance.
 - Sampling counters and cached log-probabilities stay synchronized through library-owned transitions.
 
@@ -86,6 +86,9 @@ The crate includes diagnostics that help users test assumptions:
 
 Detailed-balance checks are especially useful for new proposal kernels, but they remain empirical tests over selected transitions. Passing them does not
 establish irreducibility, aperiodicity, or adequate mixing.
+
+For in-place proposals, every concrete hypothetical proposal is undone before the next trial, and no-proposal telemetry is consumed. The proposal must still
+represent a fixed kernel: freeze online adaptation before validation, and keep any transition-relevant mutable state inside the `undo` contract.
 
 ## User Responsibilities
 

--- a/examples/detailed_balance.rs
+++ b/examples/detailed_balance.rs
@@ -26,14 +26,19 @@ impl Proposal<bool> for Flip {
 struct FlipMut;
 impl ProposalMut<bool> for FlipMut {
     type Undo = bool;
+    type Info = bool;
 
-    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+    fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut bool, _: &mut R) -> Option<bool> {
         let previous = *state;
         *state = !*state;
         Some(previous)
     }
 
-    fn undo(&self, state: &mut bool, token: bool) {
+    fn info(&self, state: &bool, _token: &bool) -> bool {
+        *state
+    }
+
+    fn undo(&mut self, state: &mut bool, token: bool) {
         *state = token;
     }
 }
@@ -84,7 +89,15 @@ fn main() -> Result<(), DetailedBalanceError> {
     let by_value = verify_detailed_balance(&false, &true, &target, &Flip, &mut rng, config)?;
 
     let mut rng = StdRng::seed_from_u64(42);
-    let in_place = verify_detailed_balance_mut(&false, &true, &target, &FlipMut, &mut rng, config)?;
+    let mut in_place_proposal = FlipMut;
+    let in_place = verify_detailed_balance_mut(
+        &false,
+        &true,
+        &target,
+        &mut in_place_proposal,
+        &mut rng,
+        config,
+    )?;
 
     let pairs = [(false, true), (true, false)];
     let mut rng = StdRng::seed_from_u64(42);

--- a/examples/ising_1d.rs
+++ b/examples/ising_1d.rs
@@ -128,8 +128,13 @@ struct SpinFlip;
 
 impl ProposalMut<SpinChain> for SpinFlip {
     type Undo = usize;
+    type Info = usize;
 
-    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+    fn propose_mut<R: Rng + ?Sized>(
+        &mut self,
+        state: &mut SpinChain,
+        rng: &mut R,
+    ) -> Option<usize> {
         if state.spins.is_empty() {
             return None;
         }
@@ -138,7 +143,11 @@ impl ProposalMut<SpinChain> for SpinFlip {
         Some(idx)
     }
 
-    fn undo(&self, state: &mut SpinChain, idx: usize) {
+    fn info(&self, _state: &SpinChain, idx: &usize) -> usize {
+        *idx
+    }
+
+    fn undo(&mut self, state: &mut SpinChain, idx: usize) {
         state.spins[idx] *= -1; // flipping twice = identity
     }
 }
@@ -157,9 +166,8 @@ fn main() -> Result<(), ExampleError> {
     let coupling = 1.0;
 
     let target = Ising { coupling, beta };
-    let proposal = SpinFlip;
     let chain = Chain::new(SpinChain::all_up(n_spins), &target)?;
-    let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng)?;
+    let mut sampler = Sampler::new(chain, &target, SpinFlip, &mut rng)?;
 
     println!("1-D Ising model ({n_spins} spins, β={beta}, J={coupling}, seed={seed})");
     println!(
@@ -184,16 +192,12 @@ fn main() -> Result<(), ExampleError> {
     let mut mag_sq_sum = 0.0;
     let mut trace = TraceRecorder::new(ChainId::new(0), ["energy", "magnetization"])?;
     for _ in 0..n_samples {
-        let accepted = sampler.step_mut()?;
+        let step = sampler.step_mut()?;
         let chain = sampler.chain_ref();
         let state = chain.state();
         let energy = target.energy(state);
         let m = state.magnetization();
-        trace.record(
-            chain,
-            TraceStepOutcome::from_proposal_acceptance(accepted),
-            [energy, m],
-        )?;
+        trace.record(chain, TraceStepOutcome::from(&step), [energy, m])?;
         mag_sum += m;
         mag_sq_sum += m * m;
     }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -100,7 +100,7 @@ fn check_committed_log_prob(scored: f64, committed: f64) -> Result<(), McmcError
 pub struct Step<I> {
     /// Step outcome encoded as a single invariant-bearing value.
     outcome: StepOutcome,
-    /// Proposal-specific metadata for the concrete proposal or no-plan outcome.
+    /// Proposal-specific metadata for the concrete proposal or no-proposal outcome.
     info: Option<I>,
     /// Cached log-probability before the step.
     log_prob_before: f64,
@@ -113,8 +113,8 @@ pub struct Step<I> {
 impl<I> Step<I> {
     /// Build telemetry for a no-proposal self-loop.
     ///
-    /// This keeps the [`Step`] field-level contract synchronized whenever a
-    /// delayed proposal returns `Ok(None)`.
+    /// This keeps the [`Step`] field-level contract synchronized whenever an
+    /// in-place or delayed proposal produces no concrete transition.
     pub(crate) const fn no_proposal(info: Option<I>, log_prob_before: f64) -> Self {
         Self {
             outcome: StepOutcome::NoProposal,
@@ -127,7 +127,7 @@ impl<I> Step<I> {
 
     /// Build telemetry for an accepted concrete proposal.
     ///
-    /// This records the accepted outcome together with the post-commit
+    /// This records the accepted outcome together with the post-step
     /// log-probability used by the chain cache.
     pub(crate) const fn accepted_proposal(
         info: I,
@@ -162,12 +162,12 @@ impl<I> Step<I> {
     ///
     /// The outcome and optional telemetry fields are constructed together, so
     /// callers cannot create contradictory combinations such as an accepted
-    /// step without a post-commit log-probability.
+    /// step without a post-step log-probability.
     pub const fn outcome(&self) -> StepOutcome {
         self.outcome
     }
 
-    /// Proposal-specific metadata for the concrete proposal or no-plan outcome.
+    /// Proposal-specific metadata for the concrete proposal or no-proposal outcome.
     #[must_use]
     pub const fn info(&self) -> Option<&I> {
         self.info.as_ref()
@@ -271,7 +271,7 @@ impl<I> Step<I> {
 #[non_exhaustive]
 #[must_use]
 pub enum StepOutcome {
-    /// A concrete proposal was accepted and committed.
+    /// A concrete proposal was accepted and retained.
     Accepted,
     /// A concrete proposal was produced and then rejected by the
     /// Metropolis-Hastings acceptance draw.
@@ -282,7 +282,7 @@ pub enum StepOutcome {
 }
 
 impl StepOutcome {
-    /// Whether this outcome accepted and committed a concrete proposal.
+    /// Whether this outcome accepted and retained a concrete proposal.
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::delayed::StepOutcome;
@@ -494,6 +494,80 @@ impl<E: Error + 'static> Error for DelayedStepError<E> {
     }
 }
 
+/// Select how an in-place transition reports its completed outcome.
+///
+/// The policy keeps one transition algorithm for structured single-step calls
+/// and telemetry-free bulk sampling. Implementations are statically dispatched,
+/// so the bulk path does not construct proposal metadata or a [`Step`].
+trait MutTelemetryMode<S, P: ProposalMut<S> + ?Sized> {
+    /// Proposal data retained until the acceptance decision completes.
+    type Captured;
+    /// Value returned to the caller after the transition completes.
+    type Output;
+
+    /// Complete a step for which no concrete proposal was available.
+    fn no_proposal(proposal: &mut P, log_prob_before: f64) -> Self::Output;
+
+    /// Capture data from a validated concrete proposal before possible rollback.
+    fn capture(proposal: &P, state: &S, token: &P::Undo) -> Self::Captured;
+
+    /// Complete an accepted concrete proposal.
+    fn accepted(
+        captured: Self::Captured,
+        log_prob_before: f64,
+        log_prob_after: f64,
+        log_alpha: f64,
+    ) -> Self::Output;
+
+    /// Complete a rejected concrete proposal after rollback.
+    fn rejected(captured: Self::Captured, log_prob_before: f64, log_alpha: f64) -> Self::Output;
+}
+
+/// In-place transition policy that returns full structured telemetry.
+struct CaptureMutTelemetry;
+
+impl<S, P: ProposalMut<S> + ?Sized> MutTelemetryMode<S, P> for CaptureMutTelemetry {
+    type Captured = P::Info;
+    type Output = Step<P::Info>;
+
+    fn no_proposal(proposal: &mut P, log_prob_before: f64) -> Self::Output {
+        Step::no_proposal(proposal.no_proposal_info(), log_prob_before)
+    }
+
+    fn capture(proposal: &P, state: &S, token: &P::Undo) -> Self::Captured {
+        proposal.info(state, token)
+    }
+
+    fn accepted(
+        info: Self::Captured,
+        log_prob_before: f64,
+        log_prob_after: f64,
+        log_alpha: f64,
+    ) -> Self::Output {
+        Step::accepted_proposal(info, log_prob_before, log_prob_after, log_alpha)
+    }
+
+    fn rejected(info: Self::Captured, log_prob_before: f64, log_alpha: f64) -> Self::Output {
+        Step::rejected_proposal(info, log_prob_before, log_alpha)
+    }
+}
+
+/// In-place transition policy that omits all telemetry work.
+struct DiscardMutTelemetry;
+
+impl<S, P: ProposalMut<S> + ?Sized> MutTelemetryMode<S, P> for DiscardMutTelemetry {
+    type Captured = ();
+    type Output = ();
+
+    fn no_proposal(_proposal: &mut P, _log_prob_before: f64) {}
+
+    fn capture(_proposal: &P, _state: &S, _token: &P::Undo) {}
+
+    fn accepted((): Self::Captured, _log_prob_before: f64, _log_prob_after: f64, _log_alpha: f64) {}
+
+    fn rejected((): Self::Captured, _log_prob_before: f64, _log_alpha: f64) {}
+}
+
 /// A single MCMC chain.
 #[derive(Debug)]
 #[must_use]
@@ -700,8 +774,9 @@ impl<S> Chain<S> {
     /// undo token; on rejection (or NaN error) the state is rolled back
     /// automatically.
     ///
-    /// Returns `Ok(true)` if the move was accepted, `Ok(false)` if rejected
-    /// (including when the proposal returns `None`).
+    /// Returns structured [`Step`] telemetry that distinguishes acceptance,
+    /// Metropolis-Hastings rejection, and proposal absence while preserving
+    /// proposal-specific metadata.
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::in_place::*;
@@ -713,14 +788,18 @@ impl<S> Chain<S> {
     /// # struct P;
     /// # impl ProposalMut<S> for P {
     /// #     type Undo = f64;
-    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, r: &mut R) -> Option<f64> {
+    /// #     type Info = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&mut self, s: &mut S, r: &mut R) -> Option<f64> {
     /// #         let old = s.0; s.0 += r.random_range(-1.0..1.0); Some(old)
     /// #     }
-    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// #     fn info(&self, s: &S, _: &f64) -> f64 { s.0 }
+    /// #     fn undo(&mut self, s: &mut S, old: f64) { s.0 = old; }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let mut chain = Chain::new(S(0.0), &T)?;
-    /// let accepted = chain.step_mut(&T, &P, &mut rng)?;
+    /// let mut proposal = P;
+    /// let step = chain.step_mut(&T, &mut proposal, &mut rng)?;
+    /// assert!(step.outcome().has_proposal());
     /// assert_eq!(chain.total_steps(), 1);
     /// # Ok::<(), McmcError>(())
     /// ```
@@ -733,12 +812,46 @@ impl<S> Chain<S> {
     pub fn step_mut<T: Target<S>, P: ProposalMut<S> + ?Sized, R: Rng + ?Sized>(
         &mut self,
         target: &T,
-        proposal: &P,
+        proposal: &mut P,
         rng: &mut R,
-    ) -> Result<bool, McmcError> {
+    ) -> Result<Step<P::Info>, McmcError> {
+        self.step_mut_with_mode::<CaptureMutTelemetry, T, P, R>(target, proposal, rng)
+    }
+
+    /// Perform an in-place step without constructing proposal telemetry.
+    ///
+    /// Bulk sampler methods use this path when their return type does not expose
+    /// per-step metadata. The transition mechanics are shared with [`step_mut`](Self::step_mut).
+    pub(crate) fn step_mut_without_telemetry<
+        T: Target<S>,
+        P: ProposalMut<S> + ?Sized,
+        R: Rng + ?Sized,
+    >(
+        &mut self,
+        target: &T,
+        proposal: &mut P,
+        rng: &mut R,
+    ) -> Result<(), McmcError> {
+        self.step_mut_with_mode::<DiscardMutTelemetry, T, P, R>(target, proposal, rng)
+    }
+
+    /// Execute one in-place transition with a statically selected telemetry policy.
+    fn step_mut_with_mode<
+        M: MutTelemetryMode<S, P>,
+        T: Target<S>,
+        P: ProposalMut<S> + ?Sized,
+        R: Rng + ?Sized,
+    >(
+        &mut self,
+        target: &T,
+        proposal: &mut P,
+        rng: &mut R,
+    ) -> Result<M::Output, McmcError> {
+        let log_prob_before = self.log_prob;
         let Some(token) = proposal.propose_mut(&mut self.state, rng) else {
+            let output = M::no_proposal(proposal, log_prob_before);
             self.rejected = self.rejected.saturating_add(1);
-            return Ok(false);
+            return Ok(output);
         };
 
         let log_prob_new = target.log_prob(&self.state);
@@ -754,17 +867,24 @@ impl<S> Chain<S> {
         }
 
         let log_alpha = log_prob_new - self.log_prob + log_q;
+        let captured = M::capture(proposal, &self.state, &token);
 
         let accept = accept_log_alpha(log_alpha, rng);
 
         if accept {
             self.log_prob = log_prob_new;
             self.accepted = self.accepted.saturating_add(1);
+            Ok(M::accepted(
+                captured,
+                log_prob_before,
+                log_prob_new,
+                log_alpha,
+            ))
         } else {
             proposal.undo(&mut self.state, token);
             self.rejected = self.rejected.saturating_add(1);
+            Ok(M::rejected(captured, log_prob_before, log_alpha))
         }
-        Ok(accept)
     }
 
     /// Perform a single delayed-commit Metropolis-Hastings step.
@@ -1828,8 +1948,9 @@ mod tests {
         struct InfQMutProposal;
         impl ProposalMut<MutScalar> for InfQMutProposal {
             type Undo = f64;
+            type Info = ();
             fn propose_mut<R: Rng + ?Sized>(
-                &self,
+                &mut self,
                 state: &mut MutScalar,
                 _rng: &mut R,
             ) -> Option<f64> {
@@ -1837,7 +1958,8 @@ mod tests {
                 state.0 = 0.0;
                 Some(old)
             }
-            fn undo(&self, state: &mut MutScalar, old: f64) {
+            fn info(&self, _state: &MutScalar, _old: &f64) {}
+            fn undo(&mut self, state: &mut MutScalar, old: f64) {
                 state.0 = old;
             }
             fn log_q_ratio(&self, _state: &MutScalar, _token: &f64) -> f64 {
@@ -1845,9 +1967,10 @@ mod tests {
             }
         }
         let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let mut proposal = InfQMutProposal;
         let mut rng = StdRng::seed_from_u64(42);
 
-        let result = chain.step_mut(&Normal, &InfQMutProposal, &mut rng);
+        let result = chain.step_mut(&Normal, &mut proposal, &mut rng);
         assert_matches!(result, Err(McmcError::InfiniteLogQRatio));
         assert_eq!(
             chain.state,
@@ -1869,10 +1992,10 @@ mod tests {
             }
         }
         let mut chain = Chain::new(MutScalar(1.0), &InfAtOrigin).unwrap();
-        let proposal = FixedMutProposal(0.0);
+        let mut proposal = FixedMutProposal(0.0);
         let mut rng = StdRng::seed_from_u64(42);
 
-        let result = chain.step_mut(&InfAtOrigin, &proposal, &mut rng);
+        let result = chain.step_mut(&InfAtOrigin, &mut proposal, &mut rng);
         assert_matches!(result, Err(McmcError::InfiniteProposedLogProb));
         assert_eq!(
             chain.state,
@@ -1968,12 +2091,20 @@ mod tests {
     struct FixedMutProposal(f64);
     impl ProposalMut<MutScalar> for FixedMutProposal {
         type Undo = f64; // store old value
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut MutScalar, _rng: &mut R) -> Option<f64> {
+        type Info = f64;
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut MutScalar,
+            _rng: &mut R,
+        ) -> Option<f64> {
             let old = state.0;
             state.0 = self.0;
             Some(old)
         }
-        fn undo(&self, state: &mut MutScalar, old: f64) {
+        fn info(&self, state: &MutScalar, _old: &f64) -> f64 {
+            state.0
+        }
+        fn undo(&mut self, state: &mut MutScalar, old: f64) {
             state.0 = old;
         }
     }
@@ -1982,22 +2113,67 @@ mod tests {
     struct NoMoveProposal;
     impl ProposalMut<MutScalar> for NoMoveProposal {
         type Undo = ();
-        fn propose_mut<R: Rng + ?Sized>(&self, _state: &mut MutScalar, _rng: &mut R) -> Option<()> {
+        type Info = ();
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            _state: &mut MutScalar,
+            _rng: &mut R,
+        ) -> Option<()> {
             None
         }
-        fn undo(&self, _state: &mut MutScalar, _token: ()) {}
+        fn info(&self, _state: &MutScalar, _token: &()) {}
+        fn undo(&mut self, _state: &mut MutScalar, _token: ()) {}
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum MutMoveFamily {
+        Add,
+    }
+
+    struct FamilyNoMoveProposal {
+        last_family: Option<MutMoveFamily>,
+    }
+
+    impl ProposalMut<MutScalar> for FamilyNoMoveProposal {
+        type Undo = ();
+        type Info = MutMoveFamily;
+
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            _state: &mut MutScalar,
+            _rng: &mut R,
+        ) -> Option<()> {
+            self.last_family = Some(MutMoveFamily::Add);
+            None
+        }
+
+        fn info(&self, _state: &MutScalar, _token: &()) -> Self::Info {
+            unreachable!("no proposal should not produce concrete proposal info")
+        }
+
+        fn no_proposal_info(&mut self) -> Option<Self::Info> {
+            self.last_family.take()
+        }
+
+        fn undo(&mut self, _state: &mut MutScalar, _token: ()) {}
     }
 
     /// Proposal that probes a mutation, rolls it back internally, and returns None.
     struct ProbeThenNoMoveProposal;
     impl ProposalMut<MutScalar> for ProbeThenNoMoveProposal {
         type Undo = ();
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut MutScalar, _rng: &mut R) -> Option<()> {
+        type Info = ();
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut MutScalar,
+            _rng: &mut R,
+        ) -> Option<()> {
             state.0 += 1.0;
             state.0 -= 1.0;
             None
         }
-        fn undo(&self, _state: &mut MutScalar, _token: ()) {}
+        fn info(&self, _state: &MutScalar, _token: &()) {}
+        fn undo(&mut self, _state: &mut MutScalar, _token: ()) {}
     }
 
     // --- step_mut acceptance ---
@@ -2006,12 +2182,17 @@ mod tests {
     fn step_mut_accepts_uphill() {
         // From x=2.0 (log_prob=-2) to x=0.0 (log_prob=0): always accept
         let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
-        let proposal = FixedMutProposal(0.0);
+        let mut proposal = FixedMutProposal(0.0);
         let mut rng = StdRng::seed_from_u64(42);
 
-        let accepted = chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+        let step = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
 
-        assert!(accepted, "Should accept move to higher probability");
+        assert_eq!(step.outcome(), StepOutcome::Accepted);
+        assert_eq!(step.info(), Some(&0.0));
+        assert_eq!(step.rejection_reason(), None);
+        assert_relative_eq!(step.log_prob_before(), -2.0, epsilon = 1e-12);
+        assert_eq!(step.log_prob_after(), Some(0.0));
+        assert_eq!(step.log_alpha(), Some(2.0));
         assert_eq!(chain.state, MutScalar(0.0));
         assert_eq!(chain.accepted(), 1);
         assert_eq!(chain.rejected(), 0);
@@ -2021,12 +2202,20 @@ mod tests {
     fn step_mut_rejects_downhill() {
         // From x=0.0 (log_prob=0) to x=100.0 (log_prob=-5000): virtually always reject
         let mut chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let proposal = FixedMutProposal(100.0);
+        let mut proposal = FixedMutProposal(100.0);
         let mut rng = StdRng::seed_from_u64(42);
 
-        let accepted = chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+        let step = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
 
-        assert!(!accepted, "Should reject move to much lower probability");
+        assert_eq!(step.outcome(), StepOutcome::RejectedProposal);
+        assert_eq!(step.info(), Some(&100.0));
+        assert_eq!(
+            step.rejection_reason(),
+            Some(StepRejectionReason::RejectedProposal)
+        );
+        assert_eq!(step.log_prob_before(), 0.0);
+        assert_eq!(step.log_prob_after(), None);
+        assert_eq!(step.log_alpha(), Some(-5000.0));
         // State should be rolled back to original
         assert_eq!(
             chain.state,
@@ -2043,13 +2232,37 @@ mod tests {
     fn step_mut_none_rejects() {
         let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
         let log_prob = chain.log_prob();
+        let mut proposal = NoMoveProposal;
         let mut rng = StdRng::seed_from_u64(42);
 
-        let accepted = chain.step_mut(&Normal, &NoMoveProposal, &mut rng).unwrap();
+        let step = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
 
-        assert!(!accepted, "Should return false when proposal returns None");
+        assert_eq!(step.outcome(), StepOutcome::NoProposal);
+        assert_eq!(step.info(), None);
+        assert_eq!(
+            step.rejection_reason(),
+            Some(StepRejectionReason::NoProposal)
+        );
+        assert_eq!(step.log_prob_before(), log_prob);
+        assert_eq!(step.log_prob_after(), None);
+        assert_eq!(step.log_alpha(), None);
         assert_eq!(chain.state, MutScalar(1.0), "State should be unchanged");
         assert_relative_eq!(chain.log_prob(), log_prob);
+        assert_eq!(chain.accepted(), 0);
+        assert_eq!(chain.rejected(), 1);
+    }
+
+    #[test]
+    fn step_mut_none_can_report_family_info() {
+        let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let mut proposal = FamilyNoMoveProposal { last_family: None };
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let step = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
+
+        assert_eq!(step.outcome(), StepOutcome::NoProposal);
+        assert_eq!(step.info(), Some(&MutMoveFamily::Add));
+        assert_eq!(proposal.last_family, None);
         assert_eq!(chain.accepted(), 0);
         assert_eq!(chain.rejected(), 1);
     }
@@ -2058,13 +2271,12 @@ mod tests {
     fn step_mut_none_allows_probe() {
         let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
         let log_prob = chain.log_prob();
+        let mut proposal = ProbeThenNoMoveProposal;
         let mut rng = StdRng::seed_from_u64(42);
 
-        let accepted = chain
-            .step_mut(&Normal, &ProbeThenNoMoveProposal, &mut rng)
-            .unwrap();
+        let step = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
 
-        assert!(!accepted, "Should return false when no move is produced");
+        assert_eq!(step.outcome(), StepOutcome::NoProposal);
         assert_eq!(
             chain.state,
             MutScalar(1.0),
@@ -2090,10 +2302,10 @@ mod tests {
             }
         }
         let mut chain = Chain::new(MutScalar(1.0), &NanAtOrigin).unwrap();
-        let proposal = FixedMutProposal(0.0);
+        let mut proposal = FixedMutProposal(0.0);
         let mut rng = StdRng::seed_from_u64(42);
 
-        let result = chain.step_mut(&NanAtOrigin, &proposal, &mut rng);
+        let result = chain.step_mut(&NanAtOrigin, &mut proposal, &mut rng);
         assert_matches!(result, Err(McmcError::NanProposedLogProb));
         assert_eq!(
             chain.state,
@@ -2107,8 +2319,9 @@ mod tests {
         struct NanQProposal;
         impl ProposalMut<MutScalar> for NanQProposal {
             type Undo = f64;
+            type Info = ();
             fn propose_mut<R: Rng + ?Sized>(
-                &self,
+                &mut self,
                 state: &mut MutScalar,
                 _rng: &mut R,
             ) -> Option<f64> {
@@ -2116,7 +2329,8 @@ mod tests {
                 state.0 = 0.0;
                 Some(old)
             }
-            fn undo(&self, state: &mut MutScalar, old: f64) {
+            fn info(&self, _state: &MutScalar, _old: &f64) {}
+            fn undo(&mut self, state: &mut MutScalar, old: f64) {
                 state.0 = old;
             }
             fn log_q_ratio(&self, _state: &MutScalar, _token: &f64) -> f64 {
@@ -2124,9 +2338,10 @@ mod tests {
             }
         }
         let mut chain = Chain::new(MutScalar(1.0), &Normal).unwrap();
+        let mut proposal = NanQProposal;
         let mut rng = StdRng::seed_from_u64(42);
 
-        let result = chain.step_mut(&Normal, &NanQProposal, &mut rng);
+        let result = chain.step_mut(&Normal, &mut proposal, &mut rng);
         assert_matches!(result, Err(McmcError::NanLogQRatio));
         assert_eq!(
             chain.state,
@@ -2145,8 +2360,9 @@ mod tests {
         }
         impl ProposalMut<MutScalar> for MutRandomWalk {
             type Undo = f64;
+            type Info = f64;
             fn propose_mut<R: Rng + ?Sized>(
-                &self,
+                &mut self,
                 state: &mut MutScalar,
                 rng: &mut R,
             ) -> Option<f64> {
@@ -2155,24 +2371,27 @@ mod tests {
                 state.0 += delta;
                 Some(old)
             }
-            fn undo(&self, state: &mut MutScalar, old: f64) {
+            fn info(&self, state: &MutScalar, _old: &f64) -> f64 {
+                state.0
+            }
+            fn undo(&mut self, state: &mut MutScalar, old: f64) {
                 state.0 = old;
             }
         }
 
-        let proposal = MutRandomWalk { width: 1.0 };
+        let mut proposal = MutRandomWalk { width: 1.0 };
         let steps = 100;
 
         let mut chain1 = Chain::new(MutScalar(0.0), &Normal).unwrap();
         let mut rng1 = StdRng::seed_from_u64(12345);
         for _ in 0..steps {
-            chain1.step_mut(&Normal, &proposal, &mut rng1).unwrap();
+            let _ = chain1.step_mut(&Normal, &mut proposal, &mut rng1).unwrap();
         }
 
         let mut chain2 = Chain::new(MutScalar(0.0), &Normal).unwrap();
         let mut rng2 = StdRng::seed_from_u64(12345);
         for _ in 0..steps {
-            chain2.step_mut(&Normal, &proposal, &mut rng2).unwrap();
+            let _ = chain2.step_mut(&Normal, &mut proposal, &mut rng2).unwrap();
         }
 
         assert_eq!(
@@ -2192,8 +2411,9 @@ mod tests {
         }
         impl ProposalMut<MutScalar> for MutRandomWalk {
             type Undo = f64;
+            type Info = f64;
             fn propose_mut<R: Rng + ?Sized>(
-                &self,
+                &mut self,
                 state: &mut MutScalar,
                 rng: &mut R,
             ) -> Option<f64> {
@@ -2201,25 +2421,28 @@ mod tests {
                 state.0 += rng.random_range(-self.width..self.width);
                 Some(old)
             }
-            fn undo(&self, state: &mut MutScalar, old: f64) {
+            fn info(&self, state: &MutScalar, _old: &f64) -> f64 {
+                state.0
+            }
+            fn undo(&mut self, state: &mut MutScalar, old: f64) {
                 state.0 = old;
             }
         }
 
-        let proposal = MutRandomWalk { width: 1.0 };
+        let mut proposal = MutRandomWalk { width: 1.0 };
         let mut chain = Chain::new(MutScalar(5.0), &Normal).unwrap();
         let mut rng = StdRng::seed_from_u64(42);
 
         // Burn-in
         for _ in 0..1_000 {
-            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+            let _ = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
         }
 
         // Collect samples
         let n = 10_000;
         let mut sum = 0.0;
         for _ in 0..n {
-            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+            let _ = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
             sum += chain.state.0;
         }
         let mean = sum / f64::from(n);
@@ -2240,12 +2463,12 @@ mod tests {
         // MutScalar intentionally does not derive Clone.
         // This test verifies the ProposalMut path compiles and works.
         let mut chain = Chain::new(MutScalar(5.0), &Normal).unwrap();
-        let proposal = FixedMutProposal(0.0);
+        let mut proposal = FixedMutProposal(0.0);
         let mut rng = StdRng::seed_from_u64(42);
 
         // Should accept (moving to mode)
-        let accepted = chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
-        assert!(accepted);
+        let step = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
+        assert_eq!(step.outcome(), StepOutcome::Accepted);
         assert_eq!(chain.state, MutScalar(0.0));
     }
 
@@ -3183,12 +3406,20 @@ mod tests {
     }
     impl ProposalMut<MutScalar> for AsymmetricMutProposal {
         type Undo = f64;
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut MutScalar, _rng: &mut R) -> Option<f64> {
+        type Info = f64;
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut MutScalar,
+            _rng: &mut R,
+        ) -> Option<f64> {
             let old = state.0;
             state.0 = self.target_value;
             Some(old)
         }
-        fn undo(&self, state: &mut MutScalar, old: f64) {
+        fn info(&self, state: &MutScalar, _old: &f64) -> f64 {
+            state.0
+        }
+        fn undo(&mut self, state: &mut MutScalar, old: f64) {
             state.0 = old;
         }
         fn log_q_ratio(&self, _state: &MutScalar, _token: &f64) -> f64 {
@@ -3202,12 +3433,20 @@ mod tests {
     }
     impl ProposalMut<MutScalar> for StateDependentMutProposal {
         type Undo = f64;
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut MutScalar, _rng: &mut R) -> Option<f64> {
+        type Info = f64;
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut MutScalar,
+            _rng: &mut R,
+        ) -> Option<f64> {
             let old = state.0;
             state.0 = self.target_value;
             Some(old)
         }
-        fn undo(&self, state: &mut MutScalar, old: f64) {
+        fn info(&self, state: &MutScalar, _old: &f64) -> f64 {
+            state.0
+        }
+        fn undo(&mut self, state: &mut MutScalar, old: f64) {
             state.0 = old;
         }
         fn log_q_ratio(&self, state: &MutScalar, old: &f64) -> f64 {
@@ -3259,53 +3498,47 @@ mod tests {
     fn step_mut_respects_log_q() {
         // Acceptance via step_mut with positive log_q
         let mut chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let proposal = AsymmetricMutProposal {
+        let mut proposal = AsymmetricMutProposal {
             target_value: 1.0,
             log_q: 100.0,
         };
         let mut rng = StdRng::seed_from_u64(42);
 
-        let accepted = chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
-        assert!(accepted, "Large positive log_q should force acceptance");
+        let step = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
+        assert_eq!(step.outcome(), StepOutcome::Accepted);
         assert_eq!(chain.state, MutScalar(1.0));
 
         // Rejection via step_mut with negative log_q
         let mut chain2 = Chain::new(MutScalar(2.0), &Normal).unwrap();
-        let proposal2 = AsymmetricMutProposal {
+        let mut proposal2 = AsymmetricMutProposal {
             target_value: 0.0,
             log_q: -100.0,
         };
         let mut rng2 = StdRng::seed_from_u64(42);
 
-        let accepted2 = chain2.step_mut(&Normal, &proposal2, &mut rng2).unwrap();
-        assert!(!accepted2, "Large negative log_q should force rejection");
+        let step2 = chain2.step_mut(&Normal, &mut proposal2, &mut rng2).unwrap();
+        assert_eq!(step2.outcome(), StepOutcome::RejectedProposal);
         assert_eq!(chain2.state, MutScalar(2.0));
     }
 
     #[test]
     fn step_mut_log_q_sees_old_and_new() {
         let mut chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
-        let proposal = StateDependentMutProposal { target_value: 0.0 };
+        let mut proposal = StateDependentMutProposal { target_value: 0.0 };
         let mut rng = StdRng::seed_from_u64(42);
 
-        let accepted = chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+        let step = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
 
-        assert!(
-            accepted,
-            "old - new log q-ratio should contribute to acceptance"
-        );
+        assert_eq!(step.outcome(), StepOutcome::Accepted);
         assert_eq!(chain.state, MutScalar(0.0));
 
         let mut chain2 = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let proposal2 = StateDependentMutProposal { target_value: 2.0 };
+        let mut proposal2 = StateDependentMutProposal { target_value: 2.0 };
         let mut rng2 = StdRng::seed_from_u64(42);
 
-        let accepted2 = chain2.step_mut(&Normal, &proposal2, &mut rng2).unwrap();
+        let step2 = chain2.step_mut(&Normal, &mut proposal2, &mut rng2).unwrap();
 
-        assert!(
-            !accepted2,
-            "new state and old-state undo token should both affect log q-ratio"
-        );
+        assert_eq!(step2.outcome(), StepOutcome::RejectedProposal);
         assert_eq!(chain2.state, MutScalar(0.0));
     }
 
@@ -3397,15 +3630,14 @@ mod tests {
         }
 
         let mut chain = Chain::new(MutScalar(0.0), &AlwaysNegInf).unwrap();
-        let proposal = FixedMutProposal(1.0);
+        let mut proposal = FixedMutProposal(1.0);
         let mut rng = StdRng::seed_from_u64(42);
 
-        let accepted = chain.step_mut(&AlwaysNegInf, &proposal, &mut rng).unwrap();
+        let step = chain
+            .step_mut(&AlwaysNegInf, &mut proposal, &mut rng)
+            .unwrap();
 
-        assert!(
-            !accepted,
-            "Should reject when both states have -inf log_prob"
-        );
+        assert_eq!(step.outcome(), StepOutcome::RejectedProposal);
         assert_eq!(
             chain.state,
             MutScalar(0.0),

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -866,7 +866,7 @@ impl<S> Chain<S> {
             return Err(err);
         }
 
-        let log_alpha = log_prob_new - self.log_prob + log_q;
+        let log_alpha = log_prob_new - log_prob_before + log_q;
         let captured = M::capture(proposal, &self.state, &token);
 
         let accept = accept_log_alpha(log_alpha, rng);

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -13,7 +13,7 @@
 //! information:
 //!
 //! - In-place stepping ([`Chain::step_mut`](crate::Chain::step_mut) and
-//!   [`Sampler::step_mut`](crate::Sampler::step_mut)) returns a [`Step`] with
+//!   [`Sampler::step_mut`](crate::Sampler::step_mut) returns a [`Step`] with
 //!   proposal metadata and an exact [`StepOutcome`].
 //! - Delayed stepping ([`Chain::step_delayed`](crate::Chain::step_delayed) and
 //!   [`Sampler::step_delayed`](crate::Sampler::step_delayed)) returns the same

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -13,11 +13,12 @@
 //! information:
 //!
 //! - In-place stepping ([`Chain::step_mut`](crate::Chain::step_mut) and
-//!   [`Sampler::step_mut`](crate::Sampler::step_mut)) returns `bool`; convert
-//!   it with [`TraceStepOutcome::from_proposal_acceptance`].
+//!   [`Sampler::step_mut`](crate::Sampler::step_mut)) returns a [`Step`] with
+//!   proposal metadata and an exact [`StepOutcome`].
 //! - Delayed stepping ([`Chain::step_delayed`](crate::Chain::step_delayed) and
-//!   [`Sampler::step_delayed`](crate::Sampler::step_delayed)) returns a
-//!   [`Step`]/[`StepOutcome`]; convert it with the [`From`] implementations on
+//!   [`Sampler::step_delayed`](crate::Sampler::step_delayed)) returns the same
+//!   [`Step`]/[`StepOutcome`] telemetry shape.
+//! - Convert either structured step with the [`From`] implementations on
 //!   [`TraceStepOutcome`].
 //! - By-value stepping ([`Chain::step`](crate::Chain::step) and
 //!   [`Sampler::step`](crate::Sampler::step)) returns `Result<(), _>` with no
@@ -128,10 +129,10 @@ impl TraceStepOutcome {
 
     /// Convert a concrete proposal's boolean acceptance result.
     ///
-    /// This is the natural adapter for [`crate::Chain::step_mut`] and
-    /// [`crate::Sampler::step_mut`] when the caller knows the in-place proposal
-    /// produced a concrete move.  A `false` value is recorded as
-    /// [`Self::rejected_proposal`], not [`Self::no_proposal`].
+    /// Use [`From<&crate::Step<_>>`](Self) for crate-produced structured step
+    /// telemetry. This adapter is for external sources that expose only a
+    /// concrete proposal's boolean acceptance result. A `false` value is
+    /// recorded as [`Self::rejected_proposal`], not [`Self::no_proposal`].
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::TraceStepOutcome;
@@ -152,7 +153,7 @@ impl TraceStepOutcome {
         }
     }
 
-    /// Whether the step accepted and committed a concrete proposal.
+    /// Whether the step accepted and retained a concrete proposal.
     #[must_use]
     pub const fn is_accepted(self) -> bool {
         self.accepted

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,9 @@
 //!
 //! For state spaces where cloning is expensive, use [`ProposalMut`] with
 //! [`Chain::step_mut`].  The proposal mutates the state in place and returns
-//! a small undo token for rollback on rejection:
+//! a small undo token for rollback on rejection. Each completed step returns
+//! [`Step`] telemetry containing the proposal's [`ProposalMut::Info`], outcome,
+//! and acceptance numerics:
 //!
 //! ```
 //! use markov_chain_monte_carlo::prelude::in_place::*;
@@ -230,13 +232,15 @@
 //! struct SpinFlip;
 //! impl ProposalMut<SpinChain> for SpinFlip {
 //!     type Undo = usize;
-//!     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
+//!     type Info = usize;
+//!     fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut SpinChain, rng: &mut R) -> Option<usize> {
 //!         if state.spins.is_empty() { return None; }
 //!         let idx = rng.random_range(0..state.spins.len());
 //!         state.spins[idx] *= -1;
 //!         Some(idx)
 //!     }
-//!     fn undo(&self, state: &mut SpinChain, idx: usize) {
+//!     fn info(&self, _state: &SpinChain, idx: &usize) -> usize { *idx }
+//!     fn undo(&mut self, state: &mut SpinChain, idx: usize) {
 //!         state.spins[idx] *= -1;  // flipping twice = identity
 //!     }
 //! }
@@ -245,9 +249,10 @@
 //!     let mut rng = StdRng::seed_from_u64(42);
 //!     let state = SpinChain { spins: vec![1; 20] };
 //!     let mut chain = Chain::new(state, &Ising)?;
+//!     let mut proposal = SpinFlip;
 //!
 //!     for _ in 0..1000 {
-//!         chain.step_mut(&Ising, &SpinFlip, &mut rng)?;
+//!         let _ = chain.step_mut(&Ising, &mut proposal, &mut rng)?;
 //!     }
 //!
 //!     assert!(chain.acceptance_rate() > 0.0);
@@ -469,12 +474,12 @@ pub use observable::{
 };
 pub use sampler::{
     InvalidThinningInterval, ObservedDelayedIntoRunResult, ObservedDelayedStep,
-    ObservedDelayedStepResult, ObservedIntoRunResult, Sampler, ThinnedObservedDelayedIntoRunResult,
-    ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningInterval,
-    TryObservedDelayedIntoRunResult, TryObservedDelayedRunResult, TryObservedDelayedStepResult,
-    TryObservedIntoRunResult, TryObservedMutStepResult, TryObservedRunResult,
-    TryObservedStepResult, TryThinnedObservedDelayedIntoRunResult, TryThinnedObservedIntoRunResult,
-    TryThinnedObservedRunResult,
+    ObservedDelayedStepResult, ObservedIntoRunResult, ObservedMutStep, Sampler,
+    ThinnedObservedDelayedIntoRunResult, ThinnedObservedIntoRunResult, ThinnedRunResult,
+    ThinningInterval, TryObservedDelayedIntoRunResult, TryObservedDelayedRunResult,
+    TryObservedDelayedStepResult, TryObservedIntoRunResult, TryObservedMutStepResult,
+    TryObservedRunResult, TryObservedStepResult, TryThinnedObservedDelayedIntoRunResult,
+    TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
 };
 pub use statistics::{BinningAnalysis, BinningEstimate, OnlineStats, StatisticsError};
 pub use testing::{
@@ -557,17 +562,19 @@ pub mod prelude {
 
     /// Prelude for in-place proposals with rollback.
     ///
-    /// This imports the shared sampling types plus [`crate::ProposalMut`], without
-    /// importing the by-value or delayed proposal traits.
+    /// This imports the shared sampling types, [`crate::ProposalMut`], and
+    /// structured [`crate::Step`] telemetry without importing the by-value or
+    /// delayed proposal traits.
     pub mod in_place {
         pub use crate::{
             AdditiveTarget, BinningAnalysis, BinningEstimate, Chain, ChainCheckpoint, ChainId,
             DiscreteProposalRatio, DiscreteProposalRatioError, InvalidThinningInterval, McmcError,
-            Observable, ObservedIntoRunResult, ObservedStepError, ObservedStreamError, OnlineStats,
-            ProposalMut, SampleBuffer, Sampler, StatisticsError, Target,
-            ThinnedObservedIntoRunResult, ThinnedRunResult, ThinningInterval, Trace, TraceError,
-            TraceRecord, TraceRecorder, TraceStepOutcome, TryAccumulator, TryObservable,
-            TryObservedIntoRunResult, TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
+            Observable, ObservedIntoRunResult, ObservedMutStep, ObservedStepError,
+            ObservedStreamError, OnlineStats, ProposalMut, SampleBuffer, Sampler, StatisticsError,
+            Step, StepOutcome, StepRejectionReason, Target, ThinnedObservedIntoRunResult,
+            ThinnedRunResult, ThinningInterval, Trace, TraceError, TraceRecord, TraceRecorder,
+            TraceStepOutcome, TryAccumulator, TryObservable, TryObservedIntoRunResult,
+            TryObservedMutStepResult, TryThinnedObservedIntoRunResult, TryThinnedObservedRunResult,
         };
     }
 
@@ -623,10 +630,10 @@ mod public_api_smoke_tests {
         DelayedStep, DetailedBalanceBatchReport, DetailedBalanceConfig,
         DetailedBalanceDelayedTransition, DetailedBalanceDirection, DetailedBalanceError,
         DetailedBalanceFailure, DetailedBalanceReport, DetailedBalanceState,
-        InvalidThinningInterval, McmcError, Observable, ObservedDelayedStep, OnlineStats, Proposal,
-        ProposalMut, SampleBuffer, Sampler, StatisticsError, Step, StepOutcome,
-        StepRejectionReason, Target, ThinningInterval, Trace, TraceError, TraceRecord,
-        TraceRecorder, TraceStepOutcome,
+        InvalidThinningInterval, McmcError, Observable, ObservedDelayedStep, ObservedMutStep,
+        OnlineStats, Proposal, ProposalMut, SampleBuffer, Sampler, StatisticsError, Step,
+        StepOutcome, StepRejectionReason, Target, ThinningInterval, Trace, TraceError, TraceRecord,
+        TraceRecorder, TraceStepOutcome, TryObservedMutStepResult,
         prelude::{self, by_value, delayed, in_place, testing},
     };
 
@@ -647,12 +654,15 @@ mod public_api_smoke_tests {
 
     impl ProposalMut<f64> for Smoke {
         type Undo = ();
+        type Info = ();
 
-        fn propose_mut<R: Rng + ?Sized>(&self, _: &mut f64, _: &mut R) -> Option<Self::Undo> {
+        fn propose_mut<R: Rng + ?Sized>(&mut self, _: &mut f64, _: &mut R) -> Option<Self::Undo> {
             Some(())
         }
 
-        fn undo(&self, _: &mut f64, (): Self::Undo) {}
+        fn info(&self, _: &f64, _token: &Self::Undo) {}
+
+        fn undo(&mut self, _: &mut f64, (): Self::Undo) {}
     }
 
     impl delayed::DelayedProposal<f64> for Smoke {
@@ -728,6 +738,8 @@ mod public_api_smoke_tests {
         let _: Option<ThinningInterval> = None;
         let _: Option<InvalidThinningInterval> = None;
         let _: Option<ObservedDelayedStep<(), f64>> = None;
+        let _: Option<ObservedMutStep<(), f64>> = None;
+        let _: Option<TryObservedMutStepResult<(), f64, Infallible>> = None;
         let _: Option<BinningAnalysis> = None;
         let _: Option<BinningEstimate> = None;
         let _: Option<OnlineStats> = None;
@@ -766,6 +778,11 @@ mod public_api_smoke_tests {
         let _: Option<in_place::TraceRecord> = None;
         let _: Option<in_place::TraceRecorder> = None;
         let _: Option<in_place::TraceStepOutcome> = None;
+        let _: Option<in_place::Step<()>> = None;
+        let _: Option<in_place::StepOutcome> = None;
+        let _: Option<in_place::StepRejectionReason> = None;
+        let _: Option<in_place::ObservedMutStep<(), f64>> = None;
+        let _: Option<in_place::TryObservedMutStepResult<(), f64, Infallible>> = None;
         let _: Option<in_place::DiscreteProposalRatio> = None;
         let _: Option<in_place::DiscreteProposalRatioError> = None;
         let _: Option<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,8 @@
 //! }
 //! ```
 //!
+//! For bulk in-place sampling, use [`Sampler::run_mut`] instead.
+//!
 //! # Delayed commit proposals
 //!
 //! Use [`DelayedProposal`] with [`Chain::step_delayed`] when a proposal can

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -3408,6 +3408,28 @@ mod tests {
         }
     }
 
+    impl ProposalMut<Scalar> for CountingInfoProposal {
+        type Undo = f64;
+        type Info = f64;
+
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut Scalar,
+            _rng: &mut R,
+        ) -> Option<f64> {
+            Some(state.0)
+        }
+
+        fn info(&self, state: &Scalar, _token: &f64) -> f64 {
+            self.info_calls.set(self.info_calls.get() + 1);
+            state.0
+        }
+
+        fn undo(&mut self, state: &mut Scalar, token: f64) {
+            state.0 = token;
+        }
+    }
+
     #[derive(Default)]
     struct CountingNoProposalInfo {
         no_proposal_info_calls: usize,
@@ -4055,12 +4077,21 @@ mod tests {
     #[test]
     fn run_mut_with_thinning_collects_every_kth_state() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = sampler!(scalar_chain(0.0), &Normal, MutWalk { width: 1.0 }, &mut rng,);
+        let mut sampler = sampler!(
+            scalar_chain(0.0),
+            &Normal,
+            CountingInfoProposal::default(),
+            &mut rng,
+        );
 
         let states = sampler.run_mut_with_thinning(7, thin(3)).unwrap();
 
         assert_eq!(states.len(), 2);
         assert_eq!(sampler.chain_ref().total_steps(), 7);
+        assert_eq!(sampler.proposal_ref().info_calls.get(), 0);
+
+        let _step = sampler.step_mut().unwrap();
+        assert_eq!(sampler.proposal_ref().info_calls.get(), 1);
     }
 
     #[test]

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -7,12 +7,15 @@ use rand::Rng;
 
 use crate::{
     Chain, ChainCheckpoint, DelayedProposal, DelayedStep, DelayedStepError, McmcError, Observable,
-    ObservedStepError, ObservedStreamError, Proposal, ProposalMut, SampleBuffer, Target,
+    ObservedStepError, ObservedStreamError, Proposal, ProposalMut, SampleBuffer, Step, Target,
     TryAccumulator, TryObservable,
 };
 
 /// Delayed-step telemetry paired with a measurement from the resulting state.
 pub type ObservedDelayedStep<I, O> = (DelayedStep<I>, O);
+
+/// In-place step telemetry paired with a measurement from the resulting state.
+pub type ObservedMutStep<I, O> = (Step<I>, O);
 
 /// Result returned by delayed observing steps.
 pub type ObservedDelayedStepResult<I, O, E> =
@@ -22,7 +25,8 @@ pub type ObservedDelayedStepResult<I, O, E> =
 pub type TryObservedStepResult<O, E> = Result<O, ObservedStepError<McmcError, E>>;
 
 /// Result returned by fallible in-place observing steps.
-pub type TryObservedMutStepResult<O, E> = Result<(bool, O), ObservedStepError<McmcError, E>>;
+pub type TryObservedMutStepResult<I, O, E> =
+    Result<ObservedMutStep<I, O>, ObservedStepError<McmcError, E>>;
 
 /// Result returned by fallible by-value or in-place observing runs.
 pub type TryObservedRunResult<O, E> = Result<SampleBuffer<O>, ObservedStepError<McmcError, E>>;
@@ -1308,8 +1312,8 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
 impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R> {
     /// Perform a single in-place Metropolis–Hastings step with rollback.
     ///
-    /// Delegates to [`Chain::step_mut`].  Returns `Ok(true)` if accepted,
-    /// `Ok(false)` if rejected.
+    /// Delegates to [`Chain::step_mut`] and returns structured telemetry for
+    /// the completed step.
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::in_place::*;
@@ -1321,15 +1325,18 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # struct P;
     /// # impl ProposalMut<S> for P {
     /// #     type Undo = f64;
-    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, r: &mut R) -> Option<f64> {
+    /// #     type Info = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&mut self, s: &mut S, r: &mut R) -> Option<f64> {
     /// #         let old = s.0; s.0 += r.random_range(-1.0..1.0); Some(old)
     /// #     }
-    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// #     fn info(&self, s: &S, _: &f64) -> f64 { s.0 }
+    /// #     fn undo(&mut self, s: &mut S, old: f64) { s.0 = old; }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
-    /// let accepted = sampler.step_mut()?;
+    /// let mut sampler = Sampler::new(chain, &T, P, &mut rng)?;
+    /// let step = sampler.step_mut()?;
+    /// assert!(step.outcome().has_proposal());
     /// assert_eq!(sampler.chain_ref().total_steps(), 1);
     /// # Ok::<(), McmcError>(())
     /// ```
@@ -1338,13 +1345,22 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ///
     /// Returns [`McmcError`] on NaN or +∞ log-probability or NaN log q-ratio
     /// (state is rolled back before the error is returned).
-    pub fn step_mut(&mut self) -> Result<bool, McmcError> {
-        self.chain.step_mut(self.target, &self.proposal, self.rng)
+    pub fn step_mut(&mut self) -> Result<Step<P::Info>, McmcError> {
+        self.chain
+            .step_mut(self.target, &mut self.proposal, self.rng)
+    }
+
+    /// Perform one in-place transition without constructing step telemetry.
+    fn step_mut_without_telemetry(&mut self) -> Result<(), McmcError> {
+        self.chain
+            .step_mut_without_telemetry(self.target, &mut self.proposal, self.rng)
     }
 
     /// Run `steps` in-place Metropolis–Hastings steps.
     ///
-    /// Stops and returns the first error encountered.
+    /// Stops and returns the first error encountered. This bulk path does not
+    /// call [`ProposalMut::info`] or [`ProposalMut::no_proposal_info`]; call
+    /// [`step_mut`](Self::step_mut) directly when per-step telemetry is needed.
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::in_place::*;
@@ -1360,14 +1376,16 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # struct Flip;
     /// # impl ProposalMut<Spins> for Flip {
     /// #     type Undo = usize;
-    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut Spins, r: &mut R) -> Option<usize> {
+    /// #     type Info = usize;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&mut self, s: &mut Spins, r: &mut R) -> Option<usize> {
     /// #         let i = r.random_range(0..s.0.len()); s.0[i] *= -1; Some(i)
     /// #     }
-    /// #     fn undo(&self, s: &mut Spins, i: usize) { s.0[i] *= -1; }
+    /// #     fn info(&self, _: &Spins, i: &usize) -> usize { *i }
+    /// #     fn undo(&mut self, s: &mut Spins, i: usize) { s.0[i] *= -1; }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(Spins(vec![1; 20]), &Ising)?;
-    /// let mut sampler = Sampler::new(chain, &Ising, &Flip, &mut rng)?;
+    /// let mut sampler = Sampler::new(chain, &Ising, Flip, &mut rng)?;
     ///
     /// sampler.run_mut(1000)?;
     /// assert_eq!(sampler.chain_ref().total_steps(), 1000);
@@ -1379,7 +1397,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// Returns [`McmcError`] on the first step that fails.
     pub fn run_mut(&mut self, steps: usize) -> Result<(), McmcError> {
         for _ in 0..steps {
-            self.step_mut()?;
+            self.step_mut_without_telemetry()?;
         }
         Ok(())
     }
@@ -1403,21 +1421,24 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// struct Increment;
     /// impl ProposalMut<S> for Increment {
     ///     type Undo = i32;
+    ///     type Info = i32;
     ///
-    ///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, _: &mut R) -> Option<i32> {
+    ///     fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut S, _: &mut R) -> Option<i32> {
     ///         let old = state.0;
     ///         state.0 += 1;
     ///         Some(old)
     ///     }
     ///
-    ///     fn undo(&self, state: &mut S, old: i32) {
+    ///     fn info(&self, state: &S, _: &i32) -> i32 { state.0 }
+    ///
+    ///     fn undo(&mut self, state: &mut S, old: i32) {
     ///         state.0 = old;
     ///     }
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)?;
+    /// let mut sampler = Sampler::new(chain, &Flat, Increment, &mut rng)?;
     ///
     /// let continuation = sampler.run_mut_chunk(3)?;
     /// assert_eq!(continuation.state().0, 3);
@@ -1453,17 +1474,19 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// struct Increment;
     /// impl ProposalMut<S> for Increment {
     ///     type Undo = i32;
-    ///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, _: &mut R) -> Option<i32> {
+    ///     type Info = i32;
+    ///     fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut S, _: &mut R) -> Option<i32> {
     ///         let old = state.0;
     ///         state.0 += 1;
     ///         Some(old)
     ///     }
-    ///     fn undo(&self, state: &mut S, old: i32) { state.0 = old; }
+    ///     fn info(&self, state: &S, _: &i32) -> i32 { state.0 }
+    ///     fn undo(&mut self, state: &mut S, old: i32) { state.0 = old; }
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)?;
+    /// let mut sampler = Sampler::new(chain, &Flat, Increment, &mut rng)?;
     /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
     /// let states = sampler.run_mut_with_thinning(5, thin_interval)?;
@@ -1486,17 +1509,14 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
         self.collect_with_thinning_core(
             steps,
             thin_interval,
-            |sampler| {
-                sampler.step_mut()?;
-                Ok(())
-            },
+            Sampler::step_mut_without_telemetry,
             |sampler| Ok(sampler.chain.state().clone()),
         )
     }
 
     /// Perform one in-place step and observe the resulting chain state.
     ///
-    /// Returns the step acceptance flag together with the measurement.
+    /// Returns structured step telemetry together with the measurement.
     ///
     /// ```
     /// use markov_chain_monte_carlo::prelude::in_place::*;
@@ -1508,17 +1528,20 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # struct P;
     /// # impl ProposalMut<S> for P {
     /// #     type Undo = f64;
-    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #     type Info = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&mut self, s: &mut S, _r: &mut R) -> Option<f64> {
     /// #         let old = s.0; s.0 += 1.0; Some(old)
     /// #     }
-    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// #     fn info(&self, s: &S, _: &f64) -> f64 { s.0 }
+    /// #     fn undo(&mut self, s: &mut S, old: f64) { s.0 = old; }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
+    /// let mut sampler = Sampler::new(chain, &T, P, &mut rng)?;
     /// let mut coordinate = |state: &S| state.0;
     ///
-    /// let (_accepted, sample) = sampler.step_mut_observing(&mut coordinate)?;
+    /// let (step, sample) = sampler.step_mut_observing(&mut coordinate)?;
+    /// assert!(step.outcome().has_proposal());
     /// assert!(sample >= 0.0);
     /// # Ok::<(), McmcError>(())
     /// ```
@@ -1530,9 +1553,9 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     pub fn step_mut_observing<O: Observable<S> + ?Sized>(
         &mut self,
         observable: &mut O,
-    ) -> Result<(bool, O::Output), McmcError> {
-        let accepted = self.step_mut()?;
-        Ok((accepted, observable.observe(self.chain.state())))
+    ) -> Result<ObservedMutStep<P::Info, O::Output>, McmcError> {
+        let step = self.step_mut()?;
+        Ok((step, observable.observe(self.chain.state())))
     }
 
     /// Run in-place steps and collect one observation after each step.
@@ -1547,14 +1570,16 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # struct P;
     /// # impl ProposalMut<S> for P {
     /// #     type Undo = f64;
-    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #     type Info = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&mut self, s: &mut S, _r: &mut R) -> Option<f64> {
     /// #         let old = s.0; s.0 += 1.0; Some(old)
     /// #     }
-    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// #     fn info(&self, s: &S, _: &f64) -> f64 { s.0 }
+    /// #     fn undo(&mut self, s: &mut S, old: f64) { s.0 = old; }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)?;
+    /// let mut sampler = Sampler::new(chain, &T, P, &mut rng)?;
     /// let mut coordinate = |state: &S| state.0;
     ///
     /// let samples = sampler.run_mut_observing(16, &mut coordinate)?;
@@ -1572,8 +1597,8 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ) -> Result<SampleBuffer<O::Output>, McmcError> {
         let mut samples = SampleBuffer::with_capacity(steps);
         for _ in 0..steps {
-            let (_, sample) = self.step_mut_observing(observable)?;
-            samples.push(sample);
+            self.step_mut_without_telemetry()?;
+            samples.push(observable.observe(self.chain.state()));
         }
         Ok(samples)
     }
@@ -1595,17 +1620,19 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// struct Increment;
     /// impl ProposalMut<S> for Increment {
     ///     type Undo = i32;
-    ///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, _: &mut R) -> Option<i32> {
+    ///     type Info = i32;
+    ///     fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut S, _: &mut R) -> Option<i32> {
     ///         let old = state.0;
     ///         state.0 += 1;
     ///         Some(old)
     ///     }
-    ///     fn undo(&self, state: &mut S, old: i32) { state.0 = old; }
+    ///     fn info(&self, state: &S, _: &i32) -> i32 { state.0 }
+    ///     fn undo(&mut self, state: &mut S, old: i32) { state.0 = old; }
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)?;
+    /// let mut sampler = Sampler::new(chain, &Flat, Increment, &mut rng)?;
     /// let mut coordinate = |state: &S| state.0;
     /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
     ///
@@ -1628,10 +1655,7 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
         self.collect_with_thinning_core(
             steps,
             thin_interval,
-            |sampler| {
-                sampler.step_mut()?;
-                Ok(())
-            },
+            Sampler::step_mut_without_telemetry,
             |sampler| Ok(observable.observe(sampler.chain.state())),
         )
     }
@@ -1652,14 +1676,16 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # struct P;
     /// # impl ProposalMut<S> for P {
     /// #     type Undo = f64;
-    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #     type Info = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&mut self, s: &mut S, _r: &mut R) -> Option<f64> {
     /// #         let old = s.0; s.0 += 1.0; Some(old)
     /// #     }
-    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// #     fn info(&self, s: &S, _: &f64) -> f64 { s.0 }
+    /// #     fn undo(&mut self, s: &mut S, old: f64) { s.0 = old; }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    /// let mut sampler = Sampler::new(chain, &T, P, &mut rng)
     ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &S| state.0;
     /// let mut bins = BinningAnalysis::new();
@@ -1685,9 +1711,9 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
         A: TryAccumulator<O::Output> + ?Sized,
     {
         for _ in 0..steps {
-            let (_, sample) = self
-                .step_mut_observing(observable)
+            self.step_mut_without_telemetry()
                 .map_err(ObservedStreamError::Step)?;
+            let sample = observable.observe(self.chain.state());
             accumulator
                 .try_push(sample)
                 .map_err(ObservedStreamError::Accumulation)?;
@@ -1713,18 +1739,20 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// struct Increment;
     /// impl ProposalMut<S> for Increment {
     ///     type Undo = i32;
-    ///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, _: &mut R) -> Option<i32> {
+    ///     type Info = i32;
+    ///     fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut S, _: &mut R) -> Option<i32> {
     ///         let old = state.0;
     ///         state.0 += 1;
     ///         Some(old)
     ///     }
-    ///     fn undo(&self, state: &mut S, old: i32) { state.0 = old; }
+    ///     fn info(&self, state: &S, _: &i32) -> i32 { state.0 }
+    ///     fn undo(&mut self, state: &mut S, old: i32) { state.0 = old; }
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat)
     ///     .map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    /// let mut sampler = Sampler::new(chain, &Flat, Increment, &mut rng)
     ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &S| f64::from(state.0);
     /// let mut stats = OnlineStats::new();
@@ -1756,8 +1784,9 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
             steps,
             thin_interval,
             |sampler| {
-                sampler.step_mut().map_err(ObservedStreamError::Step)?;
-                Ok(())
+                sampler
+                    .step_mut_without_telemetry()
+                    .map_err(ObservedStreamError::Step)
             },
             |sampler| {
                 accumulator
@@ -1779,20 +1808,23 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # struct P;
     /// # impl ProposalMut<S> for P {
     /// #     type Undo = f64;
-    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #     type Info = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&mut self, s: &mut S, _r: &mut R) -> Option<f64> {
     /// #         let old = s.0; s.0 += 1.0; Some(old)
     /// #     }
-    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// #     fn info(&self, s: &S, _: &f64) -> f64 { s.0 }
+    /// #     fn undo(&mut self, s: &mut S, old: f64) { s.0 = old; }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    /// let mut sampler = Sampler::new(chain, &T, P, &mut rng)
     ///     .map_err(ObservedStepError::Step)?;
     /// let mut finite = |state: &S| {
     ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
     /// };
     ///
-    /// let (_accepted, sample) = sampler.try_step_mut_observing(&mut finite)?;
+    /// let (step, sample) = sampler.try_step_mut_observing(&mut finite)?;
+    /// assert!(step.outcome().has_proposal());
     /// assert!(sample.is_finite());
     /// # Ok::<(), ObservedStepError<McmcError, &'static str>>(())
     /// ```
@@ -1804,12 +1836,12 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     pub fn try_step_mut_observing<O: TryObservable<S> + ?Sized>(
         &mut self,
         observable: &mut O,
-    ) -> TryObservedMutStepResult<O::Output, O::Error> {
-        let accepted = self.step_mut().map_err(ObservedStepError::Step)?;
+    ) -> TryObservedMutStepResult<P::Info, O::Output, O::Error> {
+        let step = self.step_mut().map_err(ObservedStepError::Step)?;
         let sample = observable
             .try_observe(self.chain.state())
             .map_err(ObservedStepError::Observation)?;
-        Ok((accepted, sample))
+        Ok((step, sample))
     }
 
     /// Run in-place steps and collect fallible observations.
@@ -1824,14 +1856,16 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # struct P;
     /// # impl ProposalMut<S> for P {
     /// #     type Undo = f64;
-    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #     type Info = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&mut self, s: &mut S, _r: &mut R) -> Option<f64> {
     /// #         let old = s.0; s.0 += 1.0; Some(old)
     /// #     }
-    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// #     fn info(&self, s: &S, _: &f64) -> f64 { s.0 }
+    /// #     fn undo(&mut self, s: &mut S, old: f64) { s.0 = old; }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    /// let mut sampler = Sampler::new(chain, &T, P, &mut rng)
     ///     .map_err(ObservedStepError::Step)?;
     /// let mut finite = |state: &S| {
     ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
@@ -1852,7 +1886,11 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     ) -> TryObservedRunResult<O::Output, O::Error> {
         let mut samples = SampleBuffer::with_capacity(steps);
         for _ in 0..steps {
-            let (_, sample) = self.try_step_mut_observing(observable)?;
+            self.step_mut_without_telemetry()
+                .map_err(ObservedStepError::Step)?;
+            let sample = observable
+                .try_observe(self.chain.state())
+                .map_err(ObservedStepError::Observation)?;
             samples.push(sample);
         }
         Ok(samples)
@@ -1876,18 +1914,20 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// struct Increment;
     /// impl ProposalMut<S> for Increment {
     ///     type Undo = i32;
-    ///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, _: &mut R) -> Option<i32> {
+    ///     type Info = i32;
+    ///     fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut S, _: &mut R) -> Option<i32> {
     ///         let old = state.0;
     ///         state.0 += 1;
     ///         Some(old)
     ///     }
-    ///     fn undo(&self, state: &mut S, old: i32) { state.0 = old; }
+    ///     fn info(&self, state: &S, _: &i32) -> i32 { state.0 }
+    ///     fn undo(&mut self, state: &mut S, old: i32) { state.0 = old; }
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat)
     ///     .map_err(ObservedStepError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    /// let mut sampler = Sampler::new(chain, &Flat, Increment, &mut rng)
     ///     .map_err(ObservedStepError::Step)?;
     /// let mut coordinate = |state: &S| Ok::<i32, Infallible>(state.0);
     /// let thin_interval = ThinningInterval::MIN.saturating_add(1);
@@ -1913,8 +1953,9 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
             steps,
             thin_interval,
             |sampler| {
-                sampler.step_mut().map_err(ObservedStepError::Step)?;
-                Ok(())
+                sampler
+                    .step_mut_without_telemetry()
+                    .map_err(ObservedStepError::Step)
             },
             |sampler| {
                 observable
@@ -1936,14 +1977,16 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// # struct P;
     /// # impl ProposalMut<S> for P {
     /// #     type Undo = f64;
-    /// #     fn propose_mut<R: Rng + ?Sized>(&self, s: &mut S, _r: &mut R) -> Option<f64> {
+    /// #     type Info = f64;
+    /// #     fn propose_mut<R: Rng + ?Sized>(&mut self, s: &mut S, _r: &mut R) -> Option<f64> {
     /// #         let old = s.0; s.0 += 1.0; Some(old)
     /// #     }
-    /// #     fn undo(&self, s: &mut S, old: f64) { s.0 = old; }
+    /// #     fn info(&self, s: &S, _: &f64) -> f64 { s.0 }
+    /// #     fn undo(&mut self, s: &mut S, old: f64) { s.0 = old; }
     /// # }
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0.0), &T).map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &T, &P, &mut rng)
+    /// let mut sampler = Sampler::new(chain, &T, P, &mut rng)
     ///     .map_err(ObservedStreamError::Step)?;
     /// let mut finite = |state: &S| {
     ///     if state.0.is_finite() { Ok(state.0) } else { Err("non-finite") }
@@ -1970,9 +2013,11 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
         A: TryAccumulator<O::Output> + ?Sized,
     {
         for _ in 0..steps {
-            let (_, sample) = self
-                .try_step_mut_observing(observable)
-                .map_err(stream_observed_error)?;
+            self.step_mut_without_telemetry()
+                .map_err(ObservedStreamError::Step)?;
+            let sample = observable
+                .try_observe(self.chain.state())
+                .map_err(ObservedStreamError::Observation)?;
             accumulator
                 .try_push(sample)
                 .map_err(ObservedStreamError::Accumulation)?;
@@ -1998,18 +2043,20 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
     /// struct Increment;
     /// impl ProposalMut<S> for Increment {
     ///     type Undo = i32;
-    ///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, _: &mut R) -> Option<i32> {
+    ///     type Info = i32;
+    ///     fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut S, _: &mut R) -> Option<i32> {
     ///         let old = state.0;
     ///         state.0 += 1;
     ///         Some(old)
     ///     }
-    ///     fn undo(&self, state: &mut S, old: i32) { state.0 = old; }
+    ///     fn info(&self, state: &S, _: &i32) -> i32 { state.0 }
+    ///     fn undo(&mut self, state: &mut S, old: i32) { state.0 = old; }
     /// }
     ///
     /// let mut rng = StdRng::seed_from_u64(42);
     /// let chain = Chain::new(S(0), &Flat)
     ///     .map_err(ObservedStreamError::Step)?;
-    /// let mut sampler = Sampler::new(chain, &Flat, &Increment, &mut rng)
+    /// let mut sampler = Sampler::new(chain, &Flat, Increment, &mut rng)
     ///     .map_err(ObservedStreamError::Step)?;
     /// let mut coordinate = |state: &S| Ok::<f64, Infallible>(f64::from(state.0));
     /// let mut stats = OnlineStats::new();
@@ -2041,8 +2088,9 @@ impl<S, T: Target<S>, P: ProposalMut<S>, R: Rng + ?Sized> Sampler<'_, S, T, P, R
             steps,
             thin_interval,
             |sampler| {
-                sampler.step_mut().map_err(ObservedStreamError::Step)?;
-                Ok(())
+                sampler
+                    .step_mut_without_telemetry()
+                    .map_err(ObservedStreamError::Step)
             },
             |sampler| {
                 let sample = observable
@@ -3240,7 +3288,7 @@ impl<S, T: Target<S>, P: Proposal<S>, R: Rng + ?Sized> Iterator for Sampler<'_, 
 #[cfg(test)]
 mod tests {
     use core::convert::Infallible;
-    use std::assert_matches;
+    use std::{assert_matches, cell::Cell};
 
     use approx::assert_relative_eq;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
@@ -3299,26 +3347,92 @@ mod tests {
     }
     impl ProposalMut<MutScalar> for MutWalk {
         type Undo = f64;
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut MutScalar, rng: &mut R) -> Option<f64> {
+        type Info = f64;
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut MutScalar,
+            rng: &mut R,
+        ) -> Option<f64> {
             let old = state.0;
             state.0 += rng.random_range(-self.width..self.width);
             Some(old)
         }
-        fn undo(&self, state: &mut MutScalar, old: f64) {
+        fn info(&self, state: &MutScalar, _old: &f64) -> f64 {
+            state.0
+        }
+        fn undo(&mut self, state: &mut MutScalar, old: f64) {
             state.0 = old;
         }
     }
 
     impl ProposalMut<Scalar> for MutWalk {
         type Undo = f64;
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut Scalar, rng: &mut R) -> Option<f64> {
+        type Info = f64;
+        fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut Scalar, rng: &mut R) -> Option<f64> {
             let old = state.0;
             state.0 += rng.random_range(-self.width..self.width);
             Some(old)
         }
-        fn undo(&self, state: &mut Scalar, old: f64) {
+        fn info(&self, state: &Scalar, _old: &f64) -> f64 {
+            state.0
+        }
+        fn undo(&mut self, state: &mut Scalar, old: f64) {
             state.0 = old;
         }
+    }
+
+    #[derive(Default)]
+    struct CountingInfoProposal {
+        info_calls: Cell<usize>,
+    }
+
+    impl ProposalMut<MutScalar> for CountingInfoProposal {
+        type Undo = f64;
+        type Info = f64;
+
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut MutScalar,
+            _rng: &mut R,
+        ) -> Option<f64> {
+            Some(state.0)
+        }
+
+        fn info(&self, state: &MutScalar, _token: &f64) -> f64 {
+            self.info_calls.set(self.info_calls.get() + 1);
+            state.0
+        }
+
+        fn undo(&mut self, state: &mut MutScalar, token: f64) {
+            state.0 = token;
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingNoProposalInfo {
+        no_proposal_info_calls: usize,
+    }
+
+    impl ProposalMut<MutScalar> for CountingNoProposalInfo {
+        type Undo = ();
+        type Info = ();
+
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            _state: &mut MutScalar,
+            _rng: &mut R,
+        ) -> Option<()> {
+            None
+        }
+
+        fn info(&self, _state: &MutScalar, _token: &()) {}
+
+        fn no_proposal_info(&mut self) -> Option<()> {
+            self.no_proposal_info_calls += 1;
+            Some(())
+        }
+
+        fn undo(&mut self, _state: &mut MutScalar, _token: ()) {}
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3862,9 +3976,9 @@ mod tests {
     fn step_mut_advances_chain() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, MutWalk { width: 1.0 }, &mut rng);
 
-        sampler.step_mut().unwrap();
+        let _ = sampler.step_mut().unwrap();
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
 
@@ -3872,21 +3986,76 @@ mod tests {
     fn run_mut_n_steps() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, MutWalk { width: 1.0 }, &mut rng);
 
         sampler.run_mut(500).unwrap();
         assert_eq!(sampler.chain_ref().total_steps(), 500);
     }
 
     #[test]
+    fn bulk_mut_runs_skip_concrete_proposal_telemetry() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut sampler = sampler!(chain, &Normal, CountingInfoProposal::default(), &mut rng);
+        let mut coordinate = |state: &MutScalar| state.0;
+        let mut try_coordinate = |state: &MutScalar| Ok::<f64, Infallible>(state.0);
+        let mut observed = Vec::new();
+        let mut try_observed = Vec::new();
+        let thin_interval = ThinningInterval::MIN;
+
+        sampler.run_mut(4).unwrap();
+        let _samples = sampler.run_mut_observing(4, &mut coordinate).unwrap();
+        let _thinned_samples = sampler
+            .run_mut_observing_with_thinning(2, thin_interval, &mut coordinate)
+            .unwrap();
+        sampler
+            .run_mut_observing_into(2, &mut coordinate, &mut observed)
+            .unwrap();
+        sampler
+            .run_mut_observing_into_with_thinning(2, thin_interval, &mut coordinate, &mut observed)
+            .unwrap();
+        let _try_samples = sampler
+            .try_run_mut_observing(2, &mut try_coordinate)
+            .unwrap();
+        let _try_thinned_samples = sampler
+            .try_run_mut_observing_with_thinning(2, thin_interval, &mut try_coordinate)
+            .unwrap();
+        sampler
+            .try_run_mut_observing_into(2, &mut try_coordinate, &mut try_observed)
+            .unwrap();
+        sampler
+            .try_run_mut_observing_into_with_thinning(
+                2,
+                thin_interval,
+                &mut try_coordinate,
+                &mut try_observed,
+            )
+            .unwrap();
+
+        assert_eq!(sampler.proposal_ref().info_calls.get(), 0);
+        let step = sampler.step_mut().unwrap();
+        assert_eq!(step.outcome(), StepOutcome::Accepted);
+        assert_eq!(sampler.proposal_ref().info_calls.get(), 1);
+    }
+
+    #[test]
+    fn bulk_mut_runs_skip_no_proposal_telemetry() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
+        let mut sampler = sampler!(chain, &Normal, CountingNoProposalInfo::default(), &mut rng,);
+
+        sampler.run_mut(8).unwrap();
+
+        assert_eq!(sampler.proposal_ref().no_proposal_info_calls, 0);
+        let step = sampler.step_mut().unwrap();
+        assert_eq!(step.outcome(), StepOutcome::NoProposal);
+        assert_eq!(sampler.proposal_ref().no_proposal_info_calls, 1);
+    }
+
+    #[test]
     fn run_mut_with_thinning_collects_every_kth_state() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = sampler!(
-            scalar_chain(0.0),
-            &Normal,
-            &MutWalk { width: 1.0 },
-            &mut rng,
-        );
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, MutWalk { width: 1.0 }, &mut rng,);
 
         let states = sampler.run_mut_with_thinning(7, thin(3)).unwrap();
 
@@ -3897,12 +4066,7 @@ mod tests {
     #[test]
     fn run_mut_with_thinning_skips_collection_when_interval_exceeds_steps() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut sampler = sampler!(
-            scalar_chain(0.0),
-            &Normal,
-            &MutWalk { width: 1.0 },
-            &mut rng,
-        );
+        let mut sampler = sampler!(scalar_chain(0.0), &Normal, MutWalk { width: 1.0 }, &mut rng,);
 
         let states = sampler.run_mut_with_thinning(3, thin(4)).unwrap();
 
@@ -3914,7 +4078,7 @@ mod tests {
     fn run_mut_observing_collects() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, MutWalk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &MutScalar| state.0;
 
         let measurements = sampler.run_mut_observing(25, &mut coordinate).unwrap();
@@ -3927,7 +4091,7 @@ mod tests {
     fn run_mut_observing_into_streams_to_binning_analysis() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, MutWalk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &MutScalar| state.0;
         let mut bins = BinningAnalysis::new();
 
@@ -3946,7 +4110,7 @@ mod tests {
         let mut sampler = sampler!(
             mut_scalar_chain(0.0),
             &Normal,
-            &MutWalk { width: 1.0 },
+            MutWalk { width: 1.0 },
             &mut rng,
         );
         let mut calls = 0;
@@ -3970,7 +4134,7 @@ mod tests {
         let mut sampler = sampler!(
             mut_scalar_chain(0.0),
             &Normal,
-            &MutWalk { width: 1.0 },
+            MutWalk { width: 1.0 },
             &mut rng,
         );
         let mut coordinate = |state: &MutScalar| state.0;
@@ -3990,7 +4154,7 @@ mod tests {
         let mut sampler = sampler!(
             mut_scalar_chain(0.0),
             &Normal,
-            &MutWalk { width: 1.0 },
+            MutWalk { width: 1.0 },
             &mut rng,
         );
         let mut calls = 0;
@@ -4015,7 +4179,7 @@ mod tests {
         let mut sampler = sampler!(
             mut_scalar_chain(0.0),
             &Normal,
-            &MutWalk { width: 1.0 },
+            MutWalk { width: 1.0 },
             &mut rng,
         );
         let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
@@ -4033,11 +4197,12 @@ mod tests {
     fn try_step_mut_observing_collects() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(2.0), &Normal).unwrap();
-        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, MutWalk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
 
-        let (_accepted, sample) = sampler.try_step_mut_observing(&mut coordinate).unwrap();
+        let (step, sample) = sampler.try_step_mut_observing(&mut coordinate).unwrap();
 
+        assert!(step.outcome().has_proposal());
         assert!(sample.is_finite());
         assert_eq!(sampler.chain_ref().total_steps(), 1);
     }
@@ -4046,7 +4211,7 @@ mod tests {
     fn try_run_mut_observing_errors() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, MutWalk { width: 1.0 }, &mut rng);
         let mut observable = |_state: &MutScalar| Err::<f64, _>(ObservationFailure::Failed);
 
         let result = sampler.try_run_mut_observing(1, &mut observable);
@@ -4062,7 +4227,7 @@ mod tests {
     fn try_run_mut_observing_collects_successes() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, MutWalk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
 
         let measurements = sampler.try_run_mut_observing(5, &mut coordinate).unwrap();
@@ -4076,7 +4241,7 @@ mod tests {
     fn try_run_mut_observing_into_streams_successes() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, MutWalk { width: 1.0 }, &mut rng);
         let mut coordinate = |state: &MutScalar| Ok::<f64, ObservationFailure>(state.0);
         let mut stats = OnlineStats::new();
 
@@ -4092,7 +4257,7 @@ mod tests {
     fn try_run_mut_observing_into_reports_accumulation_error() {
         let mut rng = StdRng::seed_from_u64(42);
         let chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
-        let mut sampler = sampler!(chain, &Normal, &MutWalk { width: 1.0 }, &mut rng);
+        let mut sampler = sampler!(chain, &Normal, MutWalk { width: 1.0 }, &mut rng);
         let mut invalid = |_state: &MutScalar| Ok::<f64, ObservationFailure>(f64::INFINITY);
         let mut stats = OnlineStats::new();
 
@@ -4625,20 +4790,20 @@ mod tests {
 
     #[test]
     fn sampler_mut_matches_raw_chain() {
-        let proposal = MutWalk { width: 1.0 };
+        let mut proposal = MutWalk { width: 1.0 };
         let steps = 100;
 
         // Raw chain
         let mut chain = Chain::new(MutScalar(0.0), &Normal).unwrap();
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..steps {
-            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+            let _ = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
         }
 
         // Sampler
         let chain2 = Chain::new(MutScalar(0.0), &Normal).unwrap();
         let mut rng2 = StdRng::seed_from_u64(42);
-        let mut sampler = sampler!(chain2, &Normal, &proposal, &mut rng2);
+        let mut sampler = sampler!(chain2, &Normal, MutWalk { width: 1.0 }, &mut rng2);
         sampler.run_mut(steps).unwrap();
 
         assert_eq!(chain.state, *sampler.chain_ref().state());

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -773,24 +773,28 @@ where
 /// struct Flip;
 /// impl ProposalMut<bool> for Flip {
 ///     type Undo = bool;
+///     type Info = bool;
 ///
-///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+///     fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut bool, _: &mut R) -> Option<bool> {
 ///         let old = *state;
 ///         *state = !*state;
 ///         Some(old)
 ///     }
 ///
-///     fn undo(&self, state: &mut bool, token: bool) {
+///     fn info(&self, state: &bool, _token: &bool) -> bool { *state }
+///
+///     fn undo(&mut self, state: &mut bool, token: bool) {
 ///         *state = token;
 ///     }
 /// }
 ///
 /// let mut rng = StdRng::seed_from_u64(42);
+/// let mut proposal = Flip;
 /// let report = verify_detailed_balance_mut(
 ///     &false,
 ///     &true,
 ///     &Flat,
-///     &Flip,
+///     &mut proposal,
 ///     &mut rng,
 ///     DetailedBalanceConfig::new(128, 1e-12, 1)?,
 /// )?;
@@ -809,7 +813,7 @@ pub fn verify_detailed_balance_mut<S, T, P, R>(
     current: &S,
     proposed: &S,
     target: &T,
-    proposal: &P,
+    proposal: &mut P,
     rng: &mut R,
     config: DetailedBalanceConfig,
 ) -> Result<DetailedBalanceReport, DetailedBalanceError>
@@ -838,24 +842,28 @@ where
 /// struct Flip;
 /// impl ProposalMut<bool> for Flip {
 ///     type Undo = bool;
+///     type Info = bool;
 ///
-///     fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+///     fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut bool, _: &mut R) -> Option<bool> {
 ///         let old = *state;
 ///         *state = !*state;
 ///         Some(old)
 ///     }
 ///
-///     fn undo(&self, state: &mut bool, token: bool) {
+///     fn info(&self, state: &bool, _token: &bool) -> bool { *state }
+///
+///     fn undo(&mut self, state: &mut bool, token: bool) {
 ///         *state = token;
 ///     }
 /// }
 ///
 /// let pairs = [(false, true), (true, false)];
 /// let mut rng = StdRng::seed_from_u64(42);
+/// let mut proposal = Flip;
 /// let batch = verify_detailed_balance_mut_many(
 ///     pairs.iter().map(|(current, proposed)| (current, proposed)),
 ///     &Flat,
-///     &Flip,
+///     &mut proposal,
 ///     &mut rng,
 ///     DetailedBalanceConfig::new(128, 1e-12, 1)?,
 /// );
@@ -869,7 +877,7 @@ where
 pub fn verify_detailed_balance_mut_many<'a, S, T, P, R, I>(
     pairs: I,
     target: &T,
-    proposal: &P,
+    proposal: &mut P,
     rng: &mut R,
     config: DetailedBalanceConfig,
 ) -> DetailedBalanceBatchReport
@@ -1168,7 +1176,7 @@ fn verify_detailed_balance_mut_unchecked<S, T, P, R>(
     current: &S,
     proposed: &S,
     target: &T,
-    proposal: &P,
+    proposal: &mut P,
     rng: &mut R,
     config: DetailedBalanceConfig,
 ) -> Result<DetailedBalanceReport, DetailedBalanceError>
@@ -1415,11 +1423,15 @@ where
 
 /// Sample an in-place proposal from cloned endpoints and score each exact hit
 /// with the proposal's undo-token log ratio.
+///
+/// Every concrete proposal is hypothetical, so it is undone after scoring and
+/// before any evaluation error is propagated. This restores both the cloned
+/// endpoint and proposal-internal transition state between trials.
 fn estimate_mut_transition<S, T, P, R>(
     from: &S,
     to: &S,
     target: &T,
-    proposal: &P,
+    proposal: &mut P,
     rng: &mut R,
     request: TransitionRequest,
 ) -> Result<TransitionEstimate, DetailedBalanceError>
@@ -1433,16 +1445,27 @@ where
     for _ in 0..request.samples {
         let mut candidate = from.clone();
         let Some(token) = proposal.propose_mut(&mut candidate, rng) else {
+            let _ = proposal.no_proposal_info();
             continue;
         };
-        if candidate.eq(to) {
+
+        let result = (|| -> Result<Option<f64>, DetailedBalanceError> {
+            if !candidate.eq(to) {
+                return Ok(None);
+            }
+
             let proposed_log_prob = target.log_prob(&candidate);
             check_log_prob(DetailedBalanceState::Proposed, proposed_log_prob)?;
             let log_q_ratio = proposal.log_q_ratio(&candidate, &token);
             check_log_q_ratio(request.direction, log_q_ratio)?;
-            estimate.push(acceptance_probability(
+            Ok(Some(acceptance_probability(
                 proposed_log_prob - request.from_log_prob + log_q_ratio,
-            ));
+            )))
+        })();
+
+        proposal.undo(&mut candidate, token);
+        if let Some(weight) = result? {
+            estimate.push(weight);
         }
     }
     Ok(estimate)
@@ -1676,32 +1699,51 @@ mod tests {
         }
     }
 
-    struct FlipMut;
+    #[derive(Default)]
+    struct FlipMut {
+        pending: bool,
+        undo_calls: usize,
+    }
+
     impl ProposalMut<bool> for FlipMut {
         type Undo = bool;
+        type Info = bool;
 
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+        fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut bool, _: &mut R) -> Option<bool> {
+            assert!(!self.pending, "previous hypothetical move was not undone");
+            self.pending = true;
             let old = *state;
             *state = !*state;
             Some(old)
         }
 
-        fn undo(&self, state: &mut bool, token: bool) {
+        fn info(&self, state: &bool, _token: &bool) -> bool {
+            *state
+        }
+
+        fn undo(&mut self, state: &mut bool, token: bool) {
             *state = token;
+            self.pending = false;
+            self.undo_calls += 1;
         }
     }
 
     struct BadLogQMut;
     impl ProposalMut<bool> for BadLogQMut {
         type Undo = bool;
+        type Info = bool;
 
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+        fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut bool, _: &mut R) -> Option<bool> {
             let old = *state;
             *state = !*state;
             Some(old)
         }
 
-        fn undo(&self, state: &mut bool, token: bool) {
+        fn info(&self, state: &bool, _token: &bool) -> bool {
+            *state
+        }
+
+        fn undo(&mut self, state: &mut bool, token: bool) {
             *state = token;
         }
 
@@ -1710,18 +1752,32 @@ mod tests {
         }
     }
 
-    struct InfiniteLogQMut;
+    #[derive(Default)]
+    struct InfiniteLogQMut {
+        pending: bool,
+        undo_calls: usize,
+    }
+
     impl ProposalMut<bool> for InfiniteLogQMut {
         type Undo = bool;
+        type Info = bool;
 
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut bool, _: &mut R) -> Option<bool> {
+        fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut bool, _: &mut R) -> Option<bool> {
+            assert!(!self.pending, "previous hypothetical move was not undone");
+            self.pending = true;
             let old = *state;
             *state = !*state;
             Some(old)
         }
 
-        fn undo(&self, state: &mut bool, token: bool) {
+        fn info(&self, state: &bool, _token: &bool) -> bool {
+            *state
+        }
+
+        fn undo(&mut self, state: &mut bool, token: bool) {
             *state = token;
+            self.pending = false;
+            self.undo_calls += 1;
         }
 
         fn log_q_ratio(&self, _: &bool, _: &bool) -> f64 {
@@ -1729,15 +1785,33 @@ mod tests {
         }
     }
 
-    struct NoMoveMut;
+    #[derive(Default)]
+    struct NoMoveMut {
+        pending_info: bool,
+        no_proposal_info_calls: usize,
+    }
+
     impl ProposalMut<bool> for NoMoveMut {
         type Undo = bool;
+        type Info = bool;
 
-        fn propose_mut<R: Rng + ?Sized>(&self, _: &mut bool, _: &mut R) -> Option<bool> {
+        fn propose_mut<R: Rng + ?Sized>(&mut self, _: &mut bool, _: &mut R) -> Option<bool> {
+            self.pending_info = true;
             None
         }
 
-        fn undo(&self, state: &mut bool, token: bool) {
+        fn info(&self, state: &bool, _token: &bool) -> bool {
+            *state
+        }
+
+        fn no_proposal_info(&mut self) -> Option<bool> {
+            let info = self.pending_info.then_some(false);
+            self.pending_info = false;
+            self.no_proposal_info_calls += 1;
+            info
+        }
+
+        fn undo(&mut self, state: &mut bool, token: bool) {
             *state = token;
         }
     }
@@ -2286,11 +2360,12 @@ mod tests {
     #[test]
     fn verifies_mutable_two_state_transition() {
         let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = FlipMut::default();
         let report = verify_detailed_balance_mut(
             &false,
             &true,
             &TwoStateTarget,
-            &FlipMut,
+            &mut proposal,
             &mut rng,
             small_config(),
         )
@@ -2299,6 +2374,8 @@ mod tests {
         assert_eq!(report.forward_hits, 128);
         assert_eq!(report.reverse_hits, 128);
         assert!(report.is_within_tolerance(1e-12));
+        assert!(!proposal.pending);
+        assert_eq!(proposal.undo_calls, 256);
     }
 
     #[test]
@@ -2409,11 +2486,12 @@ mod tests {
     #[test]
     fn mutable_rejects_bad_log_q_ratio() {
         let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = BadLogQMut;
         let err = verify_detailed_balance_mut(
             &false,
             &true,
             &TwoStateTarget,
-            &BadLogQMut,
+            &mut proposal,
             &mut rng,
             small_config(),
         )
@@ -2553,11 +2631,12 @@ mod tests {
             } if log_q_ratio.is_infinite() && log_q_ratio.is_sign_positive()
         );
 
+        let mut proposal = InfiniteLogQMut::default();
         let err = verify_detailed_balance_mut(
             &false,
             &true,
             &TwoStateTarget,
-            &InfiniteLogQMut,
+            &mut proposal,
             &mut rng,
             small_config(),
         )
@@ -2569,6 +2648,8 @@ mod tests {
                 log_q_ratio,
             } if log_q_ratio.is_infinite() && log_q_ratio.is_sign_positive()
         );
+        assert!(!proposal.pending);
+        assert_eq!(proposal.undo_calls, 1);
 
         let mut proposal = InfiniteLogQDelayed;
         let err = verify_detailed_balance_delayed(
@@ -2613,11 +2694,12 @@ mod tests {
     #[test]
     fn none_proposals_report_insufficient_hits() {
         let mut rng = StdRng::seed_from_u64(42);
+        let mut proposal = NoMoveMut::default();
         let err = verify_detailed_balance_mut(
             &false,
             &true,
             &TwoStateTarget,
-            &NoMoveMut,
+            &mut proposal,
             &mut rng,
             small_config(),
         )
@@ -2630,6 +2712,8 @@ mod tests {
                 min_hits: 1,
             }
         );
+        assert!(!proposal.pending_info);
+        assert_eq!(proposal.no_proposal_info_calls, 256);
 
         let mut proposal = NoPlanDelayed;
         let err = verify_detailed_balance_delayed(
@@ -2798,10 +2882,11 @@ mod tests {
     fn mutable_batch_reports_all_failures() {
         let mut rng = StdRng::seed_from_u64(42);
         let pairs = [(false, true), (true, false)];
+        let mut proposal = BadLogQMut;
         let batch = verify_detailed_balance_mut_many(
             pairs.iter().map(|(current, proposed)| (current, proposed)),
             &TwoStateTarget,
-            &BadLogQMut,
+            &mut proposal,
             &mut rng,
             small_config(),
         );

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -586,7 +586,10 @@ pub trait ProposalMut<S> {
     /// return it here without an external side channel. Any mutation performed
     /// here must be limited to consuming telemetry-only scratch storage and
     /// must not affect future transitions. Bulk sampler methods do not call
-    /// this hook when they discard per-step telemetry.
+    /// this hook when they discard per-step telemetry. Scratch retained across
+    /// [`propose_mut`](Self::propose_mut) calls must therefore remain bounded
+    /// even when this hook is never invoked, for example by using a fixed-size
+    /// or single-overwritten slot.
     fn no_proposal_info(&mut self) -> Option<Self::Info> {
         None
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -543,9 +543,16 @@ impl<S, P: Proposal<S> + ?Sized> Proposal<S> for &mut P {
 ///
 /// * [`Undo`](ProposalMut::Undo) — a small token that captures
 ///   exactly what is needed to reverse a move.
+/// * [`Info`](ProposalMut::Info) — user-facing metadata returned with the
+///   completed step.
 pub trait ProposalMut<S> {
     /// Token that records how to reverse a proposed move.
     type Undo;
+    /// User-facing metadata returned in structured step telemetry.
+    ///
+    /// Bulk sampler methods whose return type does not include a [`crate::Step`]
+    /// do not construct this metadata.
+    type Info;
 
     /// Mutate `state` in place, returning `Some(undo_token)` on success
     /// or `None` if no valid move could be found.
@@ -554,11 +561,42 @@ pub trait ProposalMut<S> {
     /// proposal mutates state before discovering that the move is invalid, it
     /// must undo those changes before returning `None`.  Once `Some(token)` is
     /// returned, [`undo`](ProposalMut::undo) must be able to restore the exact
-    /// prior state.
-    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, rng: &mut R) -> Option<Self::Undo>;
+    /// prior state and any proposal-internal transition state changed by the
+    /// attempt. Returning `None` must likewise leave transition-relevant
+    /// proposal state unchanged; telemetry-only scratch may remain for
+    /// [`no_proposal_info`](Self::no_proposal_info) to consume.
+    fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut S, rng: &mut R) -> Option<Self::Undo>;
+
+    /// Produce telemetry metadata for a concrete in-place proposal.
+    ///
+    /// `state` is the already-mutated proposed state and `token` is the undo
+    /// token returned by [`propose_mut`](Self::propose_mut). This hook runs
+    /// after the proposed log-probability and proposal ratio have been
+    /// validated, but before a rejected move is undone.
+    ///
+    /// This hook is observational: it must not change target state or proposal
+    /// state that affects future transitions. Bulk sampler methods do not call
+    /// it when they discard per-step telemetry.
+    fn info(&self, state: &S, token: &Self::Undo) -> Self::Info;
+
+    /// Produce telemetry metadata when no concrete proposal was available.
+    ///
+    /// The default returns no metadata. Stateful proposals may record a move
+    /// family or search outcome during [`propose_mut`](Self::propose_mut) and
+    /// return it here without an external side channel. Any mutation performed
+    /// here must be limited to consuming telemetry-only scratch storage and
+    /// must not affect future transitions. Bulk sampler methods do not call
+    /// this hook when they discard per-step telemetry.
+    fn no_proposal_info(&mut self) -> Option<Self::Info> {
+        None
+    }
 
     /// Reverse a previously applied move using its undo token.
-    fn undo(&self, state: &mut S, token: Self::Undo);
+    ///
+    /// Implementations must also restore proposal-internal transition state
+    /// associated with the attempted move. Telemetry-only scratch storage need
+    /// not be restored because it cannot affect future transitions.
+    fn undo(&mut self, state: &mut S, token: Self::Undo);
 
     /// Log proposal ratio for the in-place move.
     ///
@@ -574,30 +612,23 @@ pub trait ProposalMut<S> {
     }
 }
 
-impl<S, P: ProposalMut<S> + ?Sized> ProposalMut<S> for &P {
-    type Undo = P::Undo;
-
-    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, rng: &mut R) -> Option<Self::Undo> {
-        (**self).propose_mut(state, rng)
-    }
-
-    fn undo(&self, state: &mut S, token: Self::Undo) {
-        (**self).undo(state, token);
-    }
-
-    fn log_q_ratio(&self, state: &S, token: &Self::Undo) -> f64 {
-        (**self).log_q_ratio(state, token)
-    }
-}
-
 impl<S, P: ProposalMut<S> + ?Sized> ProposalMut<S> for &mut P {
     type Undo = P::Undo;
+    type Info = P::Info;
 
-    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut S, rng: &mut R) -> Option<Self::Undo> {
+    fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut S, rng: &mut R) -> Option<Self::Undo> {
         (**self).propose_mut(state, rng)
     }
 
-    fn undo(&self, state: &mut S, token: Self::Undo) {
+    fn info(&self, state: &S, token: &Self::Undo) -> Self::Info {
+        (**self).info(state, token)
+    }
+
+    fn no_proposal_info(&mut self) -> Option<Self::Info> {
+        (**self).no_proposal_info()
+    }
+
+    fn undo(&mut self, state: &mut S, token: Self::Undo) {
         (**self).undo(state, token);
     }
 
@@ -893,12 +924,20 @@ mod tests {
     struct SymmetricMutProposal;
     impl ProposalMut<Scalar> for SymmetricMutProposal {
         type Undo = f64;
-        fn propose_mut<R: Rng + ?Sized>(&self, state: &mut Scalar, _rng: &mut R) -> Option<f64> {
+        type Info = f64;
+        fn propose_mut<R: Rng + ?Sized>(
+            &mut self,
+            state: &mut Scalar,
+            _rng: &mut R,
+        ) -> Option<f64> {
             let old = state.0;
             state.0 += 1.0;
             Some(old)
         }
-        fn undo(&self, state: &mut Scalar, old: f64) {
+        fn info(&self, state: &Scalar, _old: &f64) -> f64 {
+            state.0
+        }
+        fn undo(&mut self, state: &mut Scalar, old: f64) {
             state.0 = old;
         }
         // log_q_ratio intentionally not overridden — uses default
@@ -938,16 +977,16 @@ mod tests {
     }
 
     #[test]
-    fn shared_mut_proposal_forwards() {
-        let proposal = SymmetricMutProposal;
-        let shared = &proposal;
+    fn owned_mut_proposal_works() {
+        let mut proposal = SymmetricMutProposal;
         let mut state = Scalar(2.0);
-        let token = shared.propose_mut(&mut state, &mut rng()).unwrap();
+        let token = proposal.propose_mut(&mut state, &mut rng()).unwrap();
 
         assert_relative_eq!(state.0, 3.0);
-        assert_relative_eq!(shared.log_q_ratio(&state, &token), 0.0);
+        assert_relative_eq!(proposal.info(&state, &token), 3.0);
+        assert_relative_eq!(proposal.log_q_ratio(&state, &token), 0.0);
 
-        shared.undo(&mut state, token);
+        proposal.undo(&mut state, token);
         assert_relative_eq!(state.0, 2.0);
     }
 

--- a/tests/proptest_chain.rs
+++ b/tests/proptest_chain.rs
@@ -46,12 +46,16 @@ struct MutWalk {
 }
 impl ProposalMut<Scalar> for MutWalk {
     type Undo = f64;
-    fn propose_mut<R: Rng + ?Sized>(&self, state: &mut Scalar, rng: &mut R) -> Option<f64> {
+    type Info = f64;
+    fn propose_mut<R: Rng + ?Sized>(&mut self, state: &mut Scalar, rng: &mut R) -> Option<f64> {
         let old = state.0;
         state.0 += rng.random_range(-self.width..self.width);
         Some(old)
     }
-    fn undo(&self, state: &mut Scalar, old: f64) {
+    fn info(&self, state: &Scalar, _old: &f64) -> f64 {
+        state.0
+    }
+    fn undo(&mut self, state: &mut Scalar, old: f64) {
         state.0 = old;
     }
 }
@@ -114,11 +118,11 @@ proptest! {
         seed in any::<u64>(),
     ) {
         let mut chain = Chain::new(Scalar(initial), &Normal).unwrap();
-        let proposal = MutWalk { width };
+        let mut proposal = MutWalk { width };
         let mut rng = StdRng::seed_from_u64(seed);
 
         for _ in 0..steps {
-            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+            let _ = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
         }
 
         let expected = Normal.log_prob(chain.state());
@@ -164,7 +168,7 @@ proptest! {
         seed in any::<u64>(),
     ) {
         let clone_proposal = CloneWalk { width };
-        let mut_proposal = MutWalk { width };
+        let mut mut_proposal = MutWalk { width };
 
         let mut chain_clone = Chain::new(Scalar(initial), &Normal).unwrap();
         let mut rng_clone = StdRng::seed_from_u64(seed);
@@ -174,7 +178,9 @@ proptest! {
 
         for _ in 0..steps {
             chain_clone.step(&Normal, &clone_proposal, &mut rng_clone).unwrap();
-            chain_mut.step_mut(&Normal, &mut_proposal, &mut rng_mut).unwrap();
+            let _ = chain_mut
+                .step_mut(&Normal, &mut mut_proposal, &mut rng_mut)
+                .unwrap();
         }
 
         prop_assert_eq!(
@@ -237,11 +243,11 @@ proptest! {
         seed in any::<u64>(),
     ) {
         let mut chain = Chain::new(Scalar(initial), &Normal).unwrap();
-        let proposal = MutWalk { width };
+        let mut proposal = MutWalk { width };
         let mut rng = StdRng::seed_from_u64(seed);
 
         for _ in 0..steps {
-            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+            let _ = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
         }
 
         prop_assert_eq!(
@@ -363,19 +369,19 @@ proptest! {
         steps in 1u32..500,
         seed in any::<u64>(),
     ) {
-        let proposal = MutWalk { width };
+        let mut proposal = MutWalk { width };
 
         // Raw chain
         let mut chain = Chain::new(Scalar(initial), &Normal).unwrap();
         let mut rng = StdRng::seed_from_u64(seed);
         for _ in 0..steps {
-            chain.step_mut(&Normal, &proposal, &mut rng).unwrap();
+            let _ = chain.step_mut(&Normal, &mut proposal, &mut rng).unwrap();
         }
 
         // Sampler
         let chain2 = Chain::new(Scalar(initial), &Normal).unwrap();
         let mut rng2 = StdRng::seed_from_u64(seed);
-        let mut sampler = Sampler::new(chain2, &Normal, &proposal, &mut rng2).unwrap();
+        let mut sampler = Sampler::new(chain2, &Normal, MutWalk { width }, &mut rng2).unwrap();
         sampler.run_mut(steps as usize).unwrap();
 
         prop_assert_eq!(chain.state(), sampler.chain_ref().state());
@@ -393,21 +399,30 @@ proptest! {
         split in 0u32..500,
         seed in any::<u64>(),
     ) {
-        let proposal = MutWalk { width };
         let steps = steps as usize;
         let first = split as usize % (steps + 1);
         let second = steps - first;
 
         let one_shot_chain = Chain::new(Scalar(initial), &Normal).unwrap();
         let mut one_shot_rng = StdRng::seed_from_u64(seed);
-        let mut one_shot =
-            Sampler::new(one_shot_chain, &Normal, &proposal, &mut one_shot_rng).unwrap();
+        let mut one_shot = Sampler::new(
+            one_shot_chain,
+            &Normal,
+            MutWalk { width },
+            &mut one_shot_rng,
+        )
+        .unwrap();
         one_shot.run_mut(steps).unwrap();
 
         let chunked_chain = Chain::new(Scalar(initial), &Normal).unwrap();
         let mut chunked_rng = StdRng::seed_from_u64(seed);
-        let mut chunked =
-            Sampler::new(chunked_chain, &Normal, &proposal, &mut chunked_rng).unwrap();
+        let mut chunked = Sampler::new(
+            chunked_chain,
+            &Normal,
+            MutWalk { width },
+            &mut chunked_rng,
+        )
+        .unwrap();
 
         let first_total_steps = {
             let continuation = chunked.run_mut_chunk(first).unwrap();


### PR DESCRIPTION
- Return invariant-bearing `Step<Info>` metadata from in-place single-step APIs.
- Support stateful proposal hooks with rollback of transition-relevant proposal state.
- Skip discarded telemetry construction throughout bulk sampling.
- Keep mutable detailed-balance trials rollback-safe and document fixed-kernel requirements.

BREAKING CHANGE: `ProposalMut` now requires an `Info` type and mutable proposal hooks. In-place `step_mut` APIs return `Step<Info>` instead of `bool`, and shared `&P` forwarding is removed in favor of owned proposals or `&mut P`.

Closes #103