### PR TITLE
feat: add release performance benchmarking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
 
           cargo_nextest_version="$(resolve_version cargo_nextest_version)"
           dprint_version="$(resolve_version dprint_version)"
+          python_version="$(resolve_version python_version)"
           rumdl_version="$(resolve_version rumdl_version)"
           taplo_version="$(resolve_version taplo_version)"
           typos_version="$(resolve_version typos_version)"
@@ -98,6 +99,7 @@ jobs:
           {
             echo "CARGO_NEXTEST_VERSION=$cargo_nextest_version"
             echo "DPRINT_VERSION=$dprint_version"
+            echo "PYTHON_VERSION=$python_version"
             echo "RUMDL_VERSION=$rumdl_version"
             echo "TAPLO_VERSION=$taplo_version"
             echo "TYPOS_VERSION=$typos_version"
@@ -108,7 +110,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.14"
+          python-version: ${{ steps.tool_versions.outputs.PYTHON_VERSION }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -67,6 +67,8 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          set -euo pipefail
+
           python - <<'PY'
           import json
           import os
@@ -143,6 +145,7 @@ jobs:
 
       - name: Attach baseline to GitHub Release
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_ASSET: ${{ needs.release-baseline.outputs.release-asset }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -1,0 +1,161 @@
+name: Release Benchmarks
+
+# Publish durable Criterion baselines for every GitHub Release. Release jobs do
+# not restore or save dependency caches because the resulting archive is a
+# long-lived comparison input rather than a development-speed optimization.
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: release-benchmarks-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  release-baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      release-asset: ${{ steps.package-baseline.outputs.asset }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+
+      - name: Set up just
+        uses: ./.github/actions/setup-just
+
+      - name: Export Python version
+        id: python_version
+        shell: bash
+        run: |
+          set -euo pipefail
+          python_version="$(just --evaluate python_version)"
+          if [[ -z "$python_version" ]]; then
+            echo "::error::Resolved empty python_version from justfile" >&2
+            exit 1
+          fi
+          echo "value=$python_version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ steps.python_version.outputs.value }}
+
+      - name: Save release Criterion baseline
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: just bench-save-baseline "$RELEASE_TAG"
+
+      - name: Record release benchmark metadata
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import platform
+          import subprocess
+          import tomllib
+          from pathlib import Path
+
+          lock = tomllib.loads(Path("Cargo.lock").read_text(encoding="utf-8"))
+          criterion_versions = [
+              package["version"]
+              for package in lock["package"]
+              if package.get("name") == "criterion"
+          ]
+          if len(criterion_versions) != 1:
+              raise SystemExit("expected exactly one Criterion package in Cargo.lock")
+
+          metadata = {
+              "schema": 1,
+              "tag": os.environ["RELEASE_TAG"],
+              "commit": subprocess.run(
+                  ["git", "--no-pager", "rev-parse", "HEAD"],
+                  check=True,
+                  capture_output=True,
+                  encoding="utf-8",
+              ).stdout.strip(),
+              "operating_system": platform.platform(),
+              "architecture": platform.machine(),
+              "rustc": subprocess.run(
+                  ["rustc", "--version"],
+                  check=True,
+                  capture_output=True,
+                  encoding="utf-8",
+              ).stdout.strip(),
+              "criterion_version": criterion_versions[0],
+          }
+          Path("target/criterion/.mcmc-release-metadata.json").write_text(
+              json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Package release Criterion baseline
+        id: package-baseline
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          asset="markov-chain-monte-carlo-${RELEASE_TAG}-criterion-baseline.tar.gz"
+          tar -C target -czf "$asset" criterion
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+
+      - name: Upload temporary baseline artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bench-baseline-${{ github.event.release.tag_name }}
+          path: ${{ steps.package-baseline.outputs.asset }}
+          retention-days: 30
+          if-no-files-found: error
+
+  publish-baseline:
+    needs: release-baseline
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Download release baseline
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bench-baseline-${{ github.event.release.tag_name }}
+
+      - name: Attach baseline to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ASSET: ${{ needs.release-baseline.outputs.release-asset }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" "$RELEASE_ASSET" --clobber
+
+      - name: Release baseline summary
+        env:
+          RELEASE_ASSET: ${{ needs.release-baseline.outputs.release-asset }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "### Release Benchmark Baseline"
+            echo ""
+            echo "Uploaded release asset: \`$RELEASE_ASSET\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ The repository's docs have overlapping topics but distinct roles. When in doubt,
   claim, and how to reproduce local checks.
 - **`docs/scientific_basis.md`** — Metropolis–Hastings contract and scope discussion that expands the README scientific-basis summary.
 - **`docs/proposal_validation.md`** — proposal-author testing patterns and `verify_detailed_balance*` usage.
+- **`docs/BENCHMARKING.md`** — benchmark command contracts, release-signal scope, durable release assets, comparison limits, and report promotion.
 - **`docs/roadmap.md`** — planned feature work.
 - **`docs/dev/rust.md`** — Rust toolchain notes and tooling deep-dive.
 - **`docs/RELEASING.md`** — release procedure (also referenced from `## Publishing note` below).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,8 @@ architectural placement question.
 ### Just Command Runner
 
 This project uses [Just] as the primary task automation tool. The justfile defines every dev workflow.
+Run bare `just` for the curated workflow guide and `just --list` for the complete grouped recipe reference. Public recipes are documented, grouped, and kept
+in lexicographic source order so both views remain easy to scan.
 
 **Essential Just commands:**
 
@@ -346,6 +348,7 @@ RUSTDOCFLAGS="-D warnings" cargo doc       # fail on rustdoc warnings
 Long-form discussion lives under `docs/`. Update these alongside code changes that affect them.
 
 - [`docs/code_organization.md`](docs/code_organization.md) — per-module "where does new code go?" guidance for `src/*.rs`
+- [`docs/BENCHMARKING.md`](docs/BENCHMARKING.md) — local regression checks, release comparisons, durable assets, and report promotion
 - [`docs/reviewer_guide.md`](docs/reviewer_guide.md) — short reading path for scientific and engineering reviewers
 - [`docs/scientific_basis.md`](docs/scientific_basis.md) — Metropolis–Hastings contract and scope discussion that expands the README scientific-basis summary
 - [`docs/proposal_validation.md`](docs/proposal_validation.md) — proposal-author testing patterns and `verify_detailed_balance*` usage
@@ -358,10 +361,17 @@ Long-form discussion lives under `docs/`. Update these alongside code changes th
 Benchmarks live in [`benches/`](benches/) and use [Criterion](https://docs.rs/criterion).
 
 ```bash
-just bench           # run all benchmarks
-just bench-compile   # compile benchmark harness without measuring
+just bench-latest           # run the fixed-seed release-signal set
+just bench-latest-vs-last   # rerun and compare with the saved local baseline
+just performance-local      # compare the current tree with the latest stable release
+just bench                  # run all benchmarks for broader profiling
+just bench-compile          # compile benchmark harness without measuring
 cargo bench --bench stepping <filter>   # run a subset
 ```
+
+Use `just bench-save-last` before the first `bench-latest-vs-last` run. Release maintainers use `just performance-release` to update the curated report and
+`just performance-github-assets` for comparisons that consume durable release artifacts without local measurements. See
+[`docs/BENCHMARKING.md`](docs/BENCHMARKING.md) for the command contracts and interpretation limits.
 
 Performance guidelines:
 

--- a/benches/stepping.rs
+++ b/benches/stepping.rs
@@ -4,6 +4,7 @@ use core::{convert::Infallible, fmt};
 use std::hint::black_box;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use markov_chain_monte_carlo::StepOutcome;
 use markov_chain_monte_carlo::prelude::by_value::Proposal;
 use markov_chain_monte_carlo::prelude::delayed::DelayedProposal;
 use markov_chain_monte_carlo::prelude::in_place::ProposalMut;
@@ -211,46 +212,82 @@ fn bench_chain_steps(c: &mut Criterion) {
     let proposal = RandomWalk { width: 1.0 };
     let spin_target = Alignment { beta: 8.0 };
 
-    c.bench_function("chain/step_by_value", |b| {
-        let mut chain = scalar_chain(&target);
-        let mut rng = StdRng::seed_from_u64(SEED);
-
-        b.iter(|| {
-            chain
-                .step(&target, &proposal, &mut rng)
-                .or_abort("chain step by value");
-            black_box(chain.state().0);
-        });
-    });
-
-    c.bench_function("chain/step_mut_accept", |b| {
+    {
         let mut chain = spin_chain(&Alignment { beta: 0.0 });
         let mut spin_proposal = SpinFlip;
         let mut rng = StdRng::seed_from_u64(SEED);
+        let outcome = chain
+            .step_mut(&flat, &mut spin_proposal, &mut rng)
+            .or_abort("verify in-place acceptance benchmark")
+            .outcome();
+        assert_eq!(outcome, StepOutcome::Accepted);
+    }
 
-        b.iter(|| {
-            let _ = black_box(
-                chain
-                    .step_mut(&flat, &mut spin_proposal, &mut rng)
-                    .or_abort("in-place chain step on flat target"),
-            );
-            black_box(chain.state().spins[0]);
-        });
-    });
-
-    c.bench_function("chain/step_mut_reject_rollback", |b| {
+    {
         let mut chain = spin_chain(&spin_target);
         let mut spin_proposal = SpinFlip;
         let mut rng = StdRng::seed_from_u64(SEED);
+        let outcome = chain
+            .step_mut(&spin_target, &mut spin_proposal, &mut rng)
+            .or_abort("verify in-place rollback benchmark")
+            .outcome();
+        assert_eq!(outcome, StepOutcome::RejectedProposal);
+        assert!(chain.state().spins.iter().all(|&spin| spin == 1));
+    }
 
-        b.iter(|| {
-            let _ = black_box(
+    c.bench_function("chain/step_by_value", |b| {
+        b.iter_batched(
+            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
+            |(mut chain, mut rng)| {
                 chain
-                    .step_mut(&spin_target, &mut spin_proposal, &mut rng)
-                    .or_abort("in-place chain step with rollback"),
-            );
-            black_box(chain.state().spins[0]);
-        });
+                    .step(&target, &proposal, &mut rng)
+                    .or_abort("chain step by value");
+                black_box(chain.state().0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("chain/step_mut_accept", |b| {
+        b.iter_batched(
+            || {
+                (
+                    spin_chain(&Alignment { beta: 0.0 }),
+                    SpinFlip,
+                    StdRng::seed_from_u64(SEED),
+                )
+            },
+            |(mut chain, mut spin_proposal, mut rng)| {
+                let _ = black_box(
+                    chain
+                        .step_mut(&flat, &mut spin_proposal, &mut rng)
+                        .or_abort("in-place chain step on flat target"),
+                );
+                black_box(chain.state().spins[0]);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("chain/step_mut_reject_rollback", |b| {
+        b.iter_batched(
+            || {
+                (
+                    spin_chain(&spin_target),
+                    SpinFlip,
+                    StdRng::seed_from_u64(SEED),
+                )
+            },
+            |(mut chain, mut spin_proposal, mut rng)| {
+                let _ = black_box(
+                    chain
+                        .step_mut(&spin_target, &mut spin_proposal, &mut rng)
+                        .or_abort("in-place chain step with rollback"),
+                );
+                black_box(chain.state().spins[0]);
+            },
+            BatchSize::SmallInput,
+        );
     });
 }
 
@@ -259,46 +296,97 @@ fn bench_delayed_steps(c: &mut Criterion) {
     let normal = Normal;
     let flat = FlatTarget;
 
-    c.bench_function("chain/step_delayed_accept_commit", |b| {
+    {
         let mut chain = scalar_chain(&flat);
         let mut proposal = DelayedWalk { delta: 1.0 };
         let mut rng = StdRng::seed_from_u64(SEED);
+        let outcome = chain
+            .step_delayed(&flat, &mut proposal, &mut rng)
+            .or_abort("verify delayed acceptance benchmark")
+            .outcome();
+        assert_eq!(outcome, StepOutcome::Accepted);
+    }
 
-        b.iter(|| {
-            let step = chain
-                .step_delayed(&flat, &mut proposal, &mut rng)
-                .or_abort("delayed accepted chain step");
-            black_box(step.outcome().is_accepted());
-            black_box(chain.state().0);
-        });
-    });
-
-    c.bench_function("chain/step_delayed_reject_plan", |b| {
+    {
         let mut chain = scalar_chain(&normal);
         let mut proposal = DelayedWalk { delta: 100.0 };
         let mut rng = StdRng::seed_from_u64(SEED);
+        let outcome = chain
+            .step_delayed(&normal, &mut proposal, &mut rng)
+            .or_abort("verify delayed rejection benchmark")
+            .outcome();
+        assert_eq!(outcome, StepOutcome::RejectedProposal);
+    }
 
-        b.iter(|| {
-            let step = chain
-                .step_delayed(&normal, &mut proposal, &mut rng)
-                .or_abort("delayed rejected chain step");
-            black_box(step.outcome().is_accepted());
-            black_box(chain.state().0);
-        });
-    });
-
-    c.bench_function("chain/step_delayed_no_plan", |b| {
+    {
         let mut chain = scalar_chain(&normal);
         let mut proposal = NoDelayedPlan;
         let mut rng = StdRng::seed_from_u64(SEED);
+        let outcome = chain
+            .step_delayed(&normal, &mut proposal, &mut rng)
+            .or_abort("verify delayed no-plan benchmark")
+            .outcome();
+        assert_eq!(outcome, StepOutcome::NoProposal);
+    }
 
-        b.iter(|| {
-            let step = chain
-                .step_delayed(&normal, &mut proposal, &mut rng)
-                .or_abort("delayed no-plan chain step");
-            black_box(step.outcome().has_proposal());
-            black_box(chain.rejected());
-        });
+    c.bench_function("chain/step_delayed_accept_commit", |b| {
+        b.iter_batched(
+            || {
+                (
+                    scalar_chain(&flat),
+                    DelayedWalk { delta: 1.0 },
+                    StdRng::seed_from_u64(SEED),
+                )
+            },
+            |(mut chain, mut proposal, mut rng)| {
+                let step = chain
+                    .step_delayed(&flat, &mut proposal, &mut rng)
+                    .or_abort("delayed accepted chain step");
+                let _ = black_box(step.outcome());
+                black_box(chain.state().0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("chain/step_delayed_reject_plan", |b| {
+        b.iter_batched(
+            || {
+                (
+                    scalar_chain(&normal),
+                    DelayedWalk { delta: 100.0 },
+                    StdRng::seed_from_u64(SEED),
+                )
+            },
+            |(mut chain, mut proposal, mut rng)| {
+                let step = chain
+                    .step_delayed(&normal, &mut proposal, &mut rng)
+                    .or_abort("delayed rejected chain step");
+                let _ = black_box(step.outcome());
+                black_box(chain.state().0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("chain/step_delayed_no_plan", |b| {
+        b.iter_batched(
+            || {
+                (
+                    scalar_chain(&normal),
+                    NoDelayedPlan,
+                    StdRng::seed_from_u64(SEED),
+                )
+            },
+            |(mut chain, mut proposal, mut rng)| {
+                let step = chain
+                    .step_delayed(&normal, &mut proposal, &mut rng)
+                    .or_abort("delayed no-plan chain step");
+                let _ = black_box(step.outcome());
+                black_box(chain.rejected());
+            },
+            BatchSize::SmallInput,
+        );
     });
 }
 
@@ -309,48 +397,59 @@ fn bench_sampler_runs(c: &mut Criterion) {
     let flat = FlatTarget;
 
     c.bench_function("sampler/run_by_value_100", |b| {
-        let mut rng = StdRng::seed_from_u64(SEED);
-        let mut sampler = Sampler::new(scalar_chain(&target), &target, &proposal, &mut rng)
-            .or_abort("sampler by-value setup");
-
-        b.iter(|| {
-            sampler
-                .run(black_box(BULK_STEPS))
-                .or_abort("sampler by-value bulk run");
-            black_box(sampler.chain_ref().state().0);
-        });
+        b.iter_batched(
+            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
+            |(chain, mut rng)| {
+                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng)
+                    .or_abort("sampler by-value setup");
+                sampler
+                    .run(black_box(BULK_STEPS))
+                    .or_abort("sampler by-value bulk run");
+                black_box(sampler.chain_ref().state().0);
+            },
+            BatchSize::SmallInput,
+        );
     });
 
     c.bench_function("sampler/run_mut_100", |b| {
-        let mut rng = StdRng::seed_from_u64(SEED);
-        let mut sampler = Sampler::new(
-            spin_chain(&Alignment { beta: 0.0 }),
-            &flat,
-            SpinFlip,
-            &mut rng,
-        )
-        .or_abort("sampler in-place setup");
-
-        b.iter(|| {
-            sampler
-                .run_mut(black_box(BULK_STEPS))
-                .or_abort("sampler in-place bulk run");
-            black_box(sampler.chain_ref().state().spins[0]);
-        });
+        b.iter_batched(
+            || {
+                (
+                    spin_chain(&Alignment { beta: 0.0 }),
+                    StdRng::seed_from_u64(SEED),
+                )
+            },
+            |(chain, mut rng)| {
+                let mut sampler = Sampler::new(chain, &flat, SpinFlip, &mut rng)
+                    .or_abort("sampler in-place setup");
+                sampler
+                    .run_mut(black_box(BULK_STEPS))
+                    .or_abort("sampler in-place bulk run");
+                black_box(sampler.chain_ref().state().spins[0]);
+            },
+            BatchSize::SmallInput,
+        );
     });
 
     c.bench_function("sampler/run_delayed_100", |b| {
-        let mut delayed = DelayedWalk { delta: 1.0 };
-        let mut rng = StdRng::seed_from_u64(SEED);
-        let mut sampler = Sampler::new(scalar_chain(&flat), &flat, &mut delayed, &mut rng)
-            .or_abort("sampler delayed setup");
-
-        b.iter(|| {
-            sampler
-                .run_delayed(black_box(BULK_STEPS))
-                .or_abort("sampler delayed bulk run");
-            black_box(sampler.chain_ref().state().0);
-        });
+        b.iter_batched(
+            || {
+                (
+                    scalar_chain(&flat),
+                    DelayedWalk { delta: 1.0 },
+                    StdRng::seed_from_u64(SEED),
+                )
+            },
+            |(chain, mut delayed, mut rng)| {
+                let mut sampler = Sampler::new(chain, &flat, &mut delayed, &mut rng)
+                    .or_abort("sampler delayed setup");
+                sampler
+                    .run_delayed(black_box(BULK_STEPS))
+                    .or_abort("sampler delayed bulk run");
+                black_box(sampler.chain_ref().state().0);
+            },
+            BatchSize::SmallInput,
+        );
     });
 }
 
@@ -360,17 +459,19 @@ fn bench_observing(c: &mut Criterion) {
     let proposal = RandomWalk { width: 1.0 };
 
     c.bench_function("observing/run_observing_buffer_100", |b| {
-        let mut rng = StdRng::seed_from_u64(SEED);
-        let mut sampler = Sampler::new(scalar_chain(&target), &target, &proposal, &mut rng)
-            .or_abort("observing buffer sampler setup");
-        let mut square = |state: &Scalar| state.0 * state.0;
-
-        b.iter(|| {
-            let observations = sampler
-                .run_observing(black_box(BULK_STEPS), &mut square)
-                .or_abort("observing buffer run");
-            black_box(observations.as_slice());
-        });
+        b.iter_batched(
+            || (scalar_chain(&target), StdRng::seed_from_u64(SEED)),
+            |(chain, mut rng)| {
+                let mut sampler = Sampler::new(chain, &target, &proposal, &mut rng)
+                    .or_abort("observing buffer sampler setup");
+                let mut square = |state: &Scalar| state.0 * state.0;
+                let observations = sampler
+                    .run_observing(black_box(BULK_STEPS), &mut square)
+                    .or_abort("observing buffer run");
+                black_box(observations.as_slice());
+            },
+            BatchSize::SmallInput,
+        );
     });
 
     c.bench_function("observing/manual_online_sum_100", |b| {

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -1,0 +1,143 @@
+# Benchmarking
+
+The Criterion suite protects stable, public MCMC workflows and separates three jobs: quick local regression checks, release-to-release evidence, and broader
+profiling. Benchmark results are empirical and machine-dependent; they are not correctness tests or universal performance guarantees.
+
+## Command Guide
+
+| Command | Purpose | Output |
+|:--------|:--------|:-------|
+| `just bench-latest` | Run the fixed-seed release-signal suite on the current tree | `target/criterion/` |
+| `just bench-latest-vs-last` | Measure the current tree and compare it with the saved `last` baseline | `target/bench-reports/performance.md` |
+| `just bench-compare [baseline]` | Render existing measurements against `last` or an explicit saved baseline | `target/bench-reports/performance.md` |
+| `just bench-save-baseline <tag>` | Measure and save a named local Criterion baseline | `target/criterion/**/<tag>/` |
+| `just bench-save-last` | Save the conventional local `last` baseline | `target/criterion/**/last/` |
+| `just performance-local` | Compare the current working tree with the latest stable published release in isolated worktrees | `target/bench-reports/performance.md` |
+| `just performance-github-assets` | Compare the two latest durable GitHub Release benchmark assets without running Cargo | `target/bench-reports/github-assets-performance.md` |
+| `just performance-release` | Generate and promote the release comparison, archiving the previous curated report | `docs/PERFORMANCE.md` and `docs/archive/performance/` |
+| `just bench` | Run the full current Criterion harness for profiling or exploration | `target/criterion/` |
+
+`just bench-compare <baseline>`, `just performance-github-assets <current-tag> <baseline-tag>`, and
+`just performance-release <current-tag> <baseline-tag>` accept explicit baselines or release pairs. Both tags must be supplied together.
+
+## Release-Signal Workloads
+
+`benches/stepping.rs` uses fixed seeds and public APIs. The release-signal set covers:
+
+- by-value stepping and in-place acceptance/rollback paths;
+- delayed-proposal accepted, rejected, and no-plan paths;
+- fixed 100-step `Sampler` runs for by-value, in-place, and delayed proposals;
+- buffered observation, manual online accumulation, `OnlineStats`, and `BinningAnalysis`.
+
+The harness measures transition and observation overhead, not distribution convergence. Fixture setup that establishes valid chain state occurs outside the
+timed operation where Criterion's batching API permits it. Every measured iteration starts from the same chain state and `StdRng` seed, and the harness
+checks that benchmarks named for accepted, rejected, rollback, or no-plan paths actually enter that path before timing. Timing samples remain empirical and
+will vary with the host and surrounding load.
+
+## Local Saved Baselines
+
+Use a saved baseline for iteration on one machine:
+
+```bash
+just bench-save-last
+
+# Make a change, then rerun the release signal and render the comparison.
+just bench-latest-vs-last
+```
+
+For a named checkpoint:
+
+```bash
+just bench-save-baseline before-observer-change
+just bench-latest
+just bench-compare before-observer-change
+```
+
+Criterion baselines below `target/` are local scratch data. Do not commit them or treat measurements from different machines as a controlled comparison.
+
+## Current Tree Versus a Published Release
+
+```bash
+just performance-local
+```
+
+This command resolves the latest stable published GitHub Release, creates detached temporary worktrees for that tag and the current `HEAD`, applies the current
+tracked diff and untracked files to the current worktree, and runs `stepping` in both. Each revision uses its own checked-in benchmark harness; the report
+compares benchmark names present in both revisions and lists current-only or baseline-only rows as coverage notes. Temporary worktrees are removed after the
+report is copied to `target/bench-reports/performance.md`.
+
+Before 1.0, public APIs and benchmark harnesses may change in any release. A stable benchmark name means the workload remains intentionally comparable;
+renamed, added, or removed workflows appear as coverage notes rather than forced comparisons. Coverage gaps are expected evidence of surface evolution, not
+performance regressions. If a workload's meaning changes materially, give it a new benchmark name instead of comparing unlike operations.
+
+This is the preferred pre-PR regression check because both measurements run on the same host while keeping build products and source trees isolated.
+
+## GitHub Release Assets
+
+The `Release Benchmarks` workflow runs when a GitHub Release is published. It saves the release tag as a Criterion baseline and attaches
+`markov-chain-monte-carlo-<tag>-criterion-baseline.tar.gz` to the release. The workflow also uploads a 30-day Actions artifact for diagnostics; only the
+GitHub Release attachment is the durable historical baseline. Each archive records the release tag and commit, runner operating system and architecture,
+rustc version, and Criterion version beside the measurement data.
+
+Compare the latest two assets without local measurements:
+
+```bash
+just performance-github-assets
+```
+
+Repair or regenerate a particular historical comparison with:
+
+```bash
+just performance-github-assets v0.6.0 v0.5.0
+```
+
+Releases published before the `Release Benchmarks` workflow was introduced are not backfilled. Asset-to-asset comparisons therefore become available after
+two releases have been published with the workflow. The asset comparison fails clearly when either archive or requested Criterion sample is absent. Archives
+are checked for traversal and link entries before extraction.
+
+This rollout is prospective. The first post-rollout release creates the initial durable asset; the second creates the first complete historical pair and is
+the point at which the end-to-end asset workflow can be considered adopted. For example, if the first assets are `v0.4.1` and `v0.4.2`, the first durable
+comparison is `v0.4.2` against `v0.4.1`. Pre-1.0 API changes remain allowed: changed workloads should receive new benchmark names and appear as coverage
+changes rather than being forced into invalid comparisons.
+
+GitHub-hosted runner hardware can vary between releases. Historical asset reports are useful release records, but a same-host local comparison is stronger
+evidence for attributing a change to the code.
+
+## Curated Release Report
+
+During release preparation, after the package version is final:
+
+```bash
+just performance-release
+```
+
+The command reads the current tag from `Cargo.toml`. If that version is not published, it compares the patched working tree against the latest stable release;
+if it is already published, the repair path measures that exact release tag against the preceding stable release. It writes `docs/PERFORMANCE.md`, archives
+the previous curated pair under `docs/archive/performance/<current>-vs-<baseline>.md`, and refreshes the archive index. Existing archive files are never
+overwritten.
+
+For an explicit repair path:
+
+```bash
+just performance-release v0.6.0 v0.5.0
+```
+
+Review the report's release pair, comparable-row coverage, and environment before committing it. The Markdown report records Criterion medians and marginal
+confidence intervals plus the source commits, toolchains, Criterion versions, and host identity available for the selected mode. Interval separation is
+described as a relation, not as a paired statistical-significance claim.
+
+The repository intentionally starts the curated history prospectively. Earlier releases remain usable as same-host local baselines, but are not represented
+as durable assets or retrospective committed reports. A release-preparation report may therefore exist before two durable assets do; that local report does
+not substitute for verifying the first asset-to-asset pair after the second post-rollout release.
+
+## Broader Profiling
+
+`just bench` currently runs the same fixed-seed harness without selecting a release baseline. Filter Criterion benchmarks when investigating one path:
+
+```bash
+cargo bench --locked --bench stepping chain/step_mut
+cargo bench --locked --bench stepping observing/
+```
+
+Use a profiler when the question is where time or allocations are spent. Release comparisons answer whether a stable workload changed; they do not identify
+the cause.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -86,7 +86,23 @@ Review version references:
 git grep -nE '\bv?[0-9]+\.[0-9]+\.[0-9]+\b' -- README.md docs/ Cargo.toml Cargo.lock CITATION.cff pyproject.toml uv.lock CHANGELOG.md
 ```
 
-### 4. Validate locally
+### 4. Update the release performance comparison
+
+After finalizing the package version, generate the curated release-to-release report:
+
+```bash
+just performance-release
+```
+
+Review `docs/PERFORMANCE.md` and any newly archived report under `docs/archive/performance/`. The default command reads the current tag from `Cargo.toml`. An
+unpublished current version measures the patched working tree against the latest stable release; an already-published current version measures that tag against
+the preceding stable release. Use `just performance-release <current-tag> <baseline-tag>` only for an explicit repair.
+
+For a same-host development comparison that does not modify committed docs, use `just performance-local`. To compare durable assets from two already-published
+releases without running Cargo locally, use `just performance-github-assets` or pass an explicit release pair. See
+[`docs/BENCHMARKING.md`](BENCHMARKING.md) for the full command contracts and measurement limits.
+
+### 5. Validate locally
 
 Run the normal release validation gates:
 
@@ -100,7 +116,7 @@ just publish-check
 output validation, YAML, TOML, Markdown, spelling, GitHub Actions, and Semgrep checks. `just publish-check` validates crates.io metadata and runs
 `cargo publish --locked --allow-dirty --dry-run`.
 
-### 5. Commit, push, and open the PR
+### 6. Commit, push, and open the PR
 
 Review the diff carefully:
 
@@ -136,6 +152,12 @@ Create the GitHub release:
 ```bash
 gh release create "$TAG" --title "$TAG" --notes-from-tag
 ```
+
+The `Release Benchmarks` workflow then saves the `stepping` Criterion suite and attaches
+`markov-chain-monte-carlo-$TAG-criterion-baseline.tar.gz` to the GitHub Release. Verify the release attachment exists; the workflow's 30-day Actions artifact is
+diagnostic only and is not the durable baseline. Historical releases are not backfilled; `performance-github-assets` requires two releases published through
+this workflow. During the prospective rollout, the first post-rollout release establishes the initial asset. After the second, run
+`just performance-github-assets` and verify the resulting pair before treating the release-benchmark adoption as complete.
 
 Publish to crates.io:
 

--- a/docs/archive/performance/README.md
+++ b/docs/archive/performance/README.md
@@ -1,0 +1,5 @@
+# Archived Performance Reports
+
+Older curated release-to-release benchmark comparisons are archived here. The latest curated report is written to `docs/PERFORMANCE.md`.
+
+- No archived performance reports yet.

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -33,6 +33,7 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 │       ├── codeql.yml
 │       ├── dependabot-auto-merge.yml
 │       ├── rust-clippy.yml
+│       ├── release-benchmarks.yml
 │       ├── semgrep-sarif.yml
 │       └── zizmor.yml
 ├── .gitignore
@@ -53,7 +54,11 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 ├── cliff.toml
 ├── clippy.toml
 ├── docs/
+│   ├── BENCHMARKING.md
 │   ├── RELEASING.md
+│   ├── archive/
+│   │   └── performance/
+│   │       └── README.md
 │   ├── assets/
 │   │   └── ising_energy_trace.png
 │   ├── code_organization.md
@@ -80,13 +85,18 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 ├── rustfmt.toml
 ├── scripts/
 │   ├── README.md
+│   ├── archive_performance.py
+│   ├── bench_compare.py
 │   ├── check_notebooks.py
 │   ├── postprocess_changelog.py
 │   ├── subprocess_utils.py
 │   ├── tag_release.py
 │   └── tests/
 │       ├── __init__.py
+│       ├── test_archive_performance.py
+│       ├── test_bench_compare.py
 │       ├── test_check_notebooks.py
+│       ├── test_justfile_discoverability.py
 │       ├── test_postprocess_changelog.py
 │       ├── test_subprocess_utils.py
 │       └── test_tag_release.py
@@ -140,9 +150,10 @@ This tree reflects the tracked files in a fresh GitHub checkout. Update it whene
 - `notebooks/` — notebook consumers for example-generated artifacts such as exported diagnostic traces.
 - `tests/` — integration tests, property-based tests named `tests/proptest_*.rs`, and project-rule tests including Semgrep fixtures under `tests/semgrep/`.
 - `benches/` — Criterion benchmarks for stepping, sampler loops, and observing overhead.
-- `docs/` — topic guides that support the public API documentation without duplicating README or crate-level contract material.
+- `docs/` — topic guides, release benchmark methodology and archives, and release procedures that support the public API documentation without duplicating
+  README or crate-level contract material. `docs/PERFORMANCE.md` is added when the first curated report is promoted.
 - `docs/assets/` — tracked images and other documentation media referenced from README or topic guides.
-- `scripts/` — Python helpers for notebook checks, changelog post-processing, and release tagging.
+- `scripts/` — Python helpers for benchmark comparison and report promotion, notebook checks, changelog post-processing, and release tagging.
 - Root configuration files (`Cargo.toml`, `rust-toolchain.toml`, `justfile`, `semgrep.yaml`, `dprint.json`, `rumdl.toml`, `cliff.toml`, `typos.toml`,
   `.config/nextest.toml`) — build, validation, formatting, release, and project-rule configuration.
 
@@ -271,8 +282,9 @@ Notebook files live in `notebooks/` and should consume generated artifacts rathe
 
 ## Benchmarks
 
-Benchmarks live in `benches/` and use Criterion. Keep them deterministic and focused on library invariants rather than distribution convergence. The stepping
-suite covers by-value, in-place rollback, delayed accepted/rejected/no plan, sampler bulk loops, and observing overhead.
+Benchmarks live in `benches/` and use Criterion. Keep their inputs reproducible with fixed seeds and per-iteration state resets, and focus them on library
+invariants rather than distribution convergence. The stepping suite covers by-value, in-place rollback, delayed accepted/rejected/no plan, sampler bulk loops,
+and observing overhead.
 
 ## See also
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -146,10 +146,18 @@ intentional in-place cleanup before committing.
 
 ## Benchmarks
 
-Benchmarks use Criterion and are intentionally deterministic. Run all benchmarks with:
+Benchmarks use Criterion with fixed seeds and reset each timed workload to the same starting state. Run all benchmarks with:
 
 ```bash
 just bench
+```
+
+For the release-signal, saved-baseline, isolated-worktree, GitHub Release asset, and curated-report workflows, see
+[`docs/BENCHMARKING.md`](../BENCHMARKING.md). The shortest local regression loop is:
+
+```bash
+just bench-save-last
+just bench-latest-vs-last
 ```
 
 The full CI simulation (`just ci`) compiles benchmark harnesses with `just bench-compile`, but it does not run Criterion measurements. Benchmark harness
@@ -162,6 +170,9 @@ The initial `benches/stepping.rs` suite protects core transition costs:
 - delayed `Chain::step_delayed` accepted, rejected, and no-plan paths
 - bulk `Sampler` run loops
 - observing with `SampleBuffer` versus manual online accumulation
+
+The observing group also covers `OnlineStats` and `BinningAnalysis`. Release reports compare only benchmark names present in both revisions and identify
+unmatched rows explicitly.
 
 ## Coverage
 

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ clippy_sarif_version := "0.8.0"
 dprint_version := "0.55.2"
 git_cliff_version := "2.13.1"
 just_version := "1.57.0"
+python_version := "3.14"
 rumdl_version := "0.2.48"
 sarif_fmt_version := "0.8.0"
 taplo_version := "0.10.0"
@@ -161,32 +162,61 @@ _ensure-zizmor:
     fi
 
 # GitHub Actions workflow validation
+[group('validation')]
 action-lint: _ensure-actionlint
     #!/usr/bin/env bash
     set -euo pipefail
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '.github/workflows/*.yml' '.github/workflows/*.yaml')
+    done < <(git ls-files -co --exclude-standard -z '.github/workflows/*.yml' '.github/workflows/*.yaml')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 uv run --locked actionlint
     else
         echo "No workflow files found to lint."
     fi
 
-# Benchmarks
+# Run the Criterion benchmark suite.
+[group('benchmarks and performance')]
 bench:
     cargo bench --locked --bench stepping
 
+# Render existing Criterion measurements against an explicit saved baseline.
+[group('benchmarks and performance')]
+bench-compare baseline="last": python-sync
+    uv run --locked bench-compare {{ quote(baseline) }}
+
 # Compile benchmark harnesses without running Criterion measurements.
+[group('benchmarks and performance')]
 bench-compile:
     cargo bench --locked --all-features --no-run
 
-# Build
+# Run the fixed-seed MCMC release-signal benchmark set.
+[group('benchmarks and performance')]
+bench-latest: bench
+
+# Run latest measurements and compare them with a saved Criterion baseline.
+[group('benchmarks and performance')]
+bench-latest-vs-last baseline="last": bench-latest python-sync
+    uv run --locked bench-compare {{ quote(baseline) }}
+
+# Save the complete MCMC release-signal set under a Criterion baseline name.
+[group('benchmarks and performance')]
+bench-save-baseline tag:
+    cargo bench --locked --bench stepping -- --save-baseline {{ quote(tag) }}
+
+# Save the current release signal under the conventional local `last` name.
+[group('benchmarks and performance')]
+bench-save-last:
+    just bench-save-baseline last
+
+# Build the library.
+[group('build and setup')]
 build:
     cargo build --locked
 
 # Changelog generation (git-cliff + post-processing)
+[group('release')]
 changelog: _ensure-git-cliff python-sync
     #!/usr/bin/env bash
     set -euo pipefail
@@ -194,6 +224,7 @@ changelog: _ensure-git-cliff python-sync
     uv run --locked postprocess-changelog
 
 # Regenerate CHANGELOG.md for a release tag before the tag exists
+[group('release')]
 changelog-unreleased version: _ensure-git-cliff python-sync
     #!/usr/bin/env bash
     set -euo pipefail
@@ -201,54 +232,66 @@ changelog-unreleased version: _ensure-git-cliff python-sync
     uv run --locked postprocess-changelog
 
 # Non-mutating validation gate
+[group('workflows')]
 check: check-rust check-repository-tooling
     @echo "✅ Checks complete!"
 
 # Fast compile check (no binary produced)
+[group('build and setup')]
 check-fast:
     cargo check --locked
 
 # Repository tooling that does not need to be repeated across operating systems.
-check-repository-tooling: python-check notebook-lint validate-json yaml-check action-lint zizmor toml-fmt-check toml-lint markdown-check spell-check semgrep semgrep-test
+[group('validation')]
+check-repository-tooling: python-check notebook-lint validate-json yaml-check action-lint zizmor justfile-fmt-check toml-fmt-check toml-lint markdown-check spell-check semgrep semgrep-test
     @echo "✅ Repository tooling checks complete!"
 
 # Rust validation that is meaningful for source portability and user-facing API correctness.
+[group('validation')]
 check-rust: fmt-check clippy
     @echo "✅ Rust checks complete!"
 
-# CI simulation: flat union of GitHub-equivalent focused validators.
 # Runnable Rust unit and integration tests share one release-profile nextest pass;
 # rustdoc doctests remain separate because nextest does not execute them.
-ci: action-lint zizmor markdown-check spell-check validate-json toml-fmt-check toml-lint yaml-check python-check test-python semgrep semgrep-test notebook-check fmt-check clippy doc test-rust-ci test-doc bench-compile validate-examples
+# Run the flat union of GitHub-equivalent validators and tests.
+[group('workflows')]
+ci: action-lint zizmor justfile-fmt-check markdown-check spell-check validate-json toml-fmt-check toml-lint yaml-check python-check test-python semgrep semgrep-test notebook-check fmt-check clippy doc test-rust-ci test-doc bench-compile validate-examples
     @echo "🎯 CI checks complete!"
 
 # CI subset for macOS and Windows portability confidence.
+[group('workflows')]
 ci-portability: check-fast test-rust-ci test-doc validate-examples
     @echo "✅ Portability CI checks complete!"
 
 # CI subset for repository tooling and support-script tests.
+[group('workflows')]
 ci-repository-tooling: check-repository-tooling test-python
     @echo "✅ Repository tooling CI checks complete!"
 
 # CI subset for Rust correctness.
+[group('workflows')]
 ci-rust: check-rust doc test-rust-ci test-doc validate-examples
     @echo "✅ Rust CI checks complete!"
 
 # Clean build artifacts
+[group('build and setup')]
 clean:
     cargo clean
     rm -rf target/llvm-cov
     rm -rf coverage
 
 # Core library Clippy linting used by the default validation gates.
+[group('validation')]
 clippy:
     CARGO_BUILD_WARNINGS=deny cargo clippy --locked --workspace --all-features --lib -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo -A clippy::multiple_crate_versions
 
 # Optional broad Clippy sweep; tests, examples, and benches have focused validators in CI.
+[group('validation')]
 clippy-all-targets:
     CARGO_BUILD_WARNINGS=deny cargo clippy --locked --workspace --all-features --all-targets -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo -A clippy::multiple_crate_versions
 
 # Coverage analysis for local development (HTML output)
+[group('tests and coverage')]
 coverage: _ensure-cargo-llvm-cov
     #!/usr/bin/env bash
     set -euo pipefail
@@ -258,6 +301,7 @@ coverage: _ensure-cargo-llvm-cov
     echo "Coverage report generated: target/llvm-cov/html/index.html"
 
 # Coverage analysis for CI (XML output for codecov)
+[group('tests and coverage')]
 coverage-ci: _ensure-cargo-llvm-cov
     #!/usr/bin/env bash
     set -euo pipefail
@@ -265,18 +309,23 @@ coverage-ci: _ensure-cargo-llvm-cov
     mkdir -p coverage
     cargo llvm-cov {{ _coverage_base_args }} --cobertura --output-path coverage/cobertura.xml
 
-# Default recipe shows available commands
-default:
-    @just --list
+# Show curated workflows when Just is invoked without a recipe.
+[default]
+[private]
+default: help-workflows
 
-# Documentation
+# Build rustdoc for the library.
+[group('validation')]
 doc:
     cargo doc --locked --no-deps --document-private-items
 
 # Run one example by name, e.g. `just example ising_1d`.
+[group('tests and coverage')]
 example name:
     cargo run --locked --example "{{ name }}"
 
+# Build and run every Rust example.
+[group('tests and coverage')]
 examples: _build-examples
     #!/usr/bin/env bash
     set -euo pipefail
@@ -289,17 +338,22 @@ examples: _build-examples
     done
 
 # Fix (mutating): apply formatters
-fix: fmt markdown-fix yaml-fix python-fix toml-fix
+[group('workflows')]
+fix: fmt justfile-fmt markdown-fix yaml-fix python-fix toml-fix
     @echo "✅ Fixes applied!"
 
-# Rust formatting
+# Format Rust source files.
+[group('validation')]
 fmt:
     cargo fmt --all
 
-# Rust format check
+# Check Rust source formatting without modifying files.
+[group('validation')]
 fmt-check:
     cargo fmt --all -- --check
 
+# Show the curated entry points for common repository workflows.
+[group('workflows')]
 help-workflows:
     @echo "Common Just workflows:"
     @echo "  just check          # Run lint/validators (non-mutating)"
@@ -320,6 +374,7 @@ help-workflows:
     @echo "  just lint-config    # JSON, TOML, YAML, GitHub Actions, and Actions security checks"
     @echo "  just lint-docs      # Markdown and spelling checks"
     @echo "  just python-check   # Ruff + Ty checks for Python tooling"
+    @echo "  just justfile-fmt-check # Validate canonical Justfile formatting"
     @echo "  just notebook-lint  # Validate JSON, output hygiene, and extracted Python"
     @echo "  just notebook-check # Lint all notebooks and execute the fast notebook set"
     @echo "  just notebook-check-slow # Include explicitly configured heavy notebooks"
@@ -330,21 +385,50 @@ help-workflows:
     @echo "  just test-rust      # Broad release Rust tests + doctests"
     @echo "  just test-all       # Broad Rust + Python tooling tests"
     @echo "  just bench          # Run Criterion benchmarks"
+    @echo "  just bench-latest   # Run the fixed-seed release-signal set"
+    @echo "  just bench-latest-vs-last # Measure and compare against the saved 'last' baseline"
+    @echo "  just bench-compare [baseline] # Render existing measurements against a baseline"
+    @echo "  just bench-save-baseline <tag> # Save a named local Criterion baseline"
+    @echo "  just bench-save-last # Save the conventional local 'last' baseline"
     @echo "  just bench-compile  # Compile benchmarks without measuring"
+    @echo "  just performance-local # Compare the current tree with the latest stable release"
+    @echo "  just performance-github-assets # Compare durable GitHub Release assets"
+    @echo "  just performance-release # Promote/archive the release-to-release report"
     @echo "  just coverage       # Generate and open HTML coverage report"
     @echo "  just coverage-ci    # Generate Cobertura XML coverage report"
     @echo "  just example <name> # Run one example, e.g. just example ising_1d"
     @echo "  just examples       # Run all examples"
+    @echo ""
+    @echo "Use 'just --list' for the complete grouped recipe reference."
+
+# Format the Just command layer canonically.
+[group('validation')]
+justfile-fmt:
+    just --fmt
+
+# Check Justfile formatting without modifying it.
+[group('validation')]
+justfile-fmt-check:
+    just --fmt --check
 
 # All linting: code + documentation + configuration
+[group('validation')]
 lint: lint-code lint-docs lint-config
 
+# Check Rust, Python, and repository-owned Semgrep rules.
+[group('validation')]
 lint-code: fmt-check clippy python-check semgrep semgrep-test
 
-lint-config: validate-json toml-fmt-check toml-lint yaml-check action-lint zizmor
+# Check JSON, TOML, YAML, GitHub Actions, and Just configuration.
+[group('validation')]
+lint-config: validate-json toml-fmt-check toml-lint yaml-check action-lint zizmor justfile-fmt-check
 
+# Check Markdown and spelling.
+[group('validation')]
 lint-docs: markdown-check spell-check
 
+# Check Markdown formatting and lint rules.
+[group('validation')]
 markdown-check: _ensure-rumdl
     #!/usr/bin/env bash
     set -euo pipefail
@@ -354,13 +438,15 @@ markdown-check: _ensure-rumdl
             CHANGELOG.md) continue ;;
         esac
         files+=("$file")
-    done < <(git ls-files -z '*.md')
+    done < <(git ls-files -co --exclude-standard -z '*.md')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 -n100 rumdl check
     else
         echo "No Markdown files found to check."
     fi
 
+# Apply Markdown formatting and lint fixes.
+[group('validation')]
 markdown-fix: _ensure-rumdl
     #!/usr/bin/env bash
     set -euo pipefail
@@ -370,24 +456,34 @@ markdown-fix: _ensure-rumdl
             CHANGELOG.md) continue ;;
         esac
         files+=("$file")
-    done < <(git ls-files -z '*.md')
+    done < <(git ls-files -co --exclude-standard -z '*.md')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 -n100 rumdl check --fix
     else
         echo "No Markdown files found to format."
     fi
 
+# Alias for the canonical Markdown check.
+[group('validation')]
 markdown-lint: markdown-check
 
+# Lint and execute the configured fast notebook set.
+[group('notebooks')]
 notebook-check: notebook-lint notebook-execute-fast
     @echo "📓 Fast notebook checks complete!"
 
+# Lint and execute the configured fast and slow notebook sets.
+[group('notebooks')]
 notebook-check-slow: notebook-check notebook-execute-slow
     @echo "📓 Slow notebook checks complete!"
 
+# Clear outputs from every source notebook explicitly.
+[group('notebooks')]
 notebook-clear-outputs-all: notebook-sync
     uv run --locked --group dev --group notebook check-notebooks clear --repo-root .
 
+# Execute the configured fast notebook set headlessly.
+[group('notebooks')]
 notebook-execute-fast: notebook-sync
     #!/usr/bin/env bash
     set -euo pipefail
@@ -395,6 +491,8 @@ notebook-execute-fast: notebook-sync
     notebooks=( {{ fast_notebooks }} )
     MPLBACKEND=Agg uv run --locked --group dev --group notebook check-notebooks execute "${notebooks[@]}" --repo-root . --output-dir target/notebooks
 
+# Execute the explicitly configured slow notebook set headlessly.
+[group('notebooks')]
 notebook-execute-slow: _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
@@ -405,13 +503,57 @@ notebook-execute-slow: _ensure-uv
     fi
     MPLBACKEND=Agg uv run --locked --group dev --group notebook check-notebooks execute "${notebooks[@]}" --repo-root . --output-dir target/notebooks --timeout 1800
 
+# Validate source notebook structure and extracted Python without execution.
+[group('notebooks')]
 notebook-lint: _ensure-uv
     uv run --locked --group dev --group notebook check-notebooks lint --repo-root .
 
+# Synchronize the notebook-capable Python environment.
+[group('notebooks')]
 notebook-sync: _ensure-uv
     uv sync --locked --group dev --group notebook
 
+# Compare stored GitHub Release benchmark assets without local benchmark runs.
+[group('benchmarks and performance')]
+performance-github-assets current_tag="" baseline_tag="": python-sync
+    #!/usr/bin/env bash
+    set -euo pipefail
+    current_tag={{ quote(current_tag) }}
+    baseline_tag={{ quote(baseline_tag) }}
+    if [[ -n "$current_tag" || -n "$baseline_tag" ]]; then
+        if [[ -z "$current_tag" || -z "$baseline_tag" ]]; then
+            echo "current_tag and baseline_tag must be provided together" >&2
+            exit 2
+        fi
+        uv run --locked archive-performance "$current_tag" "$baseline_tag" --github-assets --output target/bench-reports/github-assets-performance.md
+    else
+        uv run --locked archive-performance --published-latest --github-assets --output target/bench-reports/github-assets-performance.md
+    fi
+
+# Compare the current tree with the latest stable published release locally.
+[group('benchmarks and performance')]
+performance-local: python-sync
+    uv run --locked archive-performance --current-vs-latest --output target/bench-reports/performance.md
+
+# Generate a release-to-release report, promote it, and archive the previous report.
+[group('benchmarks and performance')]
+performance-release current_tag="" baseline_tag="": python-sync
+    #!/usr/bin/env bash
+    set -euo pipefail
+    current_tag={{ quote(current_tag) }}
+    baseline_tag={{ quote(baseline_tag) }}
+    if [[ -n "$current_tag" || -n "$baseline_tag" ]]; then
+        if [[ -z "$current_tag" || -z "$baseline_tag" ]]; then
+            echo "current_tag and baseline_tag must be provided together" >&2
+            exit 2
+        fi
+        uv run --locked archive-performance "$current_tag" "$baseline_tag" --promote
+    else
+        uv run --locked archive-performance --infer-release --promote
+    fi
+
 # Pre-publish validation: checks crates.io metadata rules that cargo publish --dry-run does NOT catch
+[group('release')]
 publish-check: _ensure-jq
     #!/usr/bin/env bash
     set -euo pipefail
@@ -473,26 +615,52 @@ publish-check: _ensure-jq
     echo ""
     echo "✅ Publish check passed!"
 
+# Check Python support scripts with Ruff and Ty.
+[group('validation')]
 python-check: python-typecheck
     uv run --locked ruff format --check scripts/
     uv run --locked ruff check scripts/
 
+# Apply Ruff fixes and formatting to Python support scripts.
+[group('validation')]
 python-fix: python-sync
     uv run --locked ruff check scripts/ --fix
     uv run --locked ruff format scripts/
 
+# Alias for the canonical Python check.
+[group('validation')]
 python-lint: python-check
 
+# Synchronize the development Python environment.
+[group('build and setup')]
 python-sync: _ensure-uv
     uv sync --locked --group dev
 
+# Type-check Python support scripts with Ty.
+[group('validation')]
 python-typecheck: python-sync
     uv run --locked ty check scripts/
 
 # Repository-owned Semgrep rules for project-specific diagnostics.
+[group('validation')]
 semgrep: _ensure-uv
-    uv run --locked semgrep --metrics off --error --strict --timeout 30 --config semgrep.yaml .
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=()
+    while IFS= read -r -d '' file; do
+        case "$file" in
+            tests/semgrep/*) continue ;;
+        esac
+        files+=("$file")
+    done < <(git ls-files -co --exclude-standard -z)
+    if [ "${#files[@]}" -gt 0 ]; then
+        uv run --locked semgrep --metrics off --error --strict --timeout 30 --config semgrep.yaml "${files[@]}"
+    else
+        echo "No tracked or untracked repository files found to scan."
+    fi
 
+# Validate repository-owned Semgrep rules against annotated fixtures.
+[group('validation')]
 semgrep-test: _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
@@ -540,8 +708,12 @@ semgrep-test: _ensure-uv
     expect_semgrep_count 2 mcmc.docs.check-before-fix-command-order docs/check_fix_order.md
     uv run --locked semgrep scan --metrics off --test --strict --config ../../semgrep.yaml scripts/tests/python_exceptions.py
 
+# Install or verify the complete development environment.
+[group('build and setup')]
 setup: setup-tools
 
+# Install or synchronize external development tools.
+[group('build and setup')]
 setup-tools: _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
@@ -626,51 +798,70 @@ setup-tools: _ensure-uv
     echo ""
     echo "✅ Tooling setup complete."
 
+# Check repository spelling.
+[group('validation')]
 spell-check: _ensure-typos
     typos --config typos.toml --force-exclude .
 
 # Create an annotated git tag from the CHANGELOG.md section for the given version
+[group('release')]
 tag version: python-sync
     uv run --locked tag-release {{ version }}
 
 # Recreate an existing tag from the CHANGELOG.md section for the given version
+[group('release')]
 tag-force version: python-sync
     uv run --locked tag-release {{ version }} --force
 
 # Focused local Rust buckets: unit tests plus rustdoc doctests.
+[group('tests and coverage')]
 test: test-unit test-doc
 
 # Broad Rust correctness plus Python tooling tests.
+[group('tests and coverage')]
 test-all: test-rust test-python
     @echo "✅ All tests passed"
 
+# Run rustdoc doctests.
+[group('tests and coverage')]
 test-doc:
     cargo test --locked --doc --verbose
 
 # Integration tests
+[group('tests and coverage')]
 test-integration: _ensure-cargo-nextest
     cargo nextest run --locked --test '*' --verbose
 
-# Focused library unit tests for changed-surface validation.
-test-unit: _ensure-cargo-nextest
-    cargo nextest run --locked --lib --verbose
-
 # Backward-compatible alias for the former recipe name.
+[group('tests and coverage')]
 test-lib: test-unit
 
-# Broad release-profile Rust CI bucket: lib unit and integration tests together.
-test-rust-ci: _ensure-cargo-nextest
-    cargo nextest run --locked --release --profile ci --lib --tests --verbose
-
-# Broad Rust test workflow; doctests remain a separate cargo-test bucket.
-test-rust: test-rust-ci test-doc
-    @echo "✅ Rust tests passed"
-
+# Run Python support-script tests.
+[group('tests and coverage')]
 test-python: python-sync
     uv run --locked pytest -q
 
+# Broad Rust test workflow; doctests remain a separate cargo-test bucket.
+[group('tests and coverage')]
+test-rust: test-rust-ci test-doc
+    @echo "✅ Rust tests passed"
+
+# Broad release-profile Rust CI bucket: lib unit and integration tests together.
+[group('tests and coverage')]
+test-rust-ci: _ensure-cargo-nextest
+    cargo nextest run --locked --release --profile ci --lib --tests --verbose
+
+# Focused library unit tests for changed-surface validation.
+[group('tests and coverage')]
+test-unit: _ensure-cargo-nextest
+    cargo nextest run --locked --lib --verbose
+
+# Apply canonical TOML formatting.
+[group('validation')]
 toml-fix: toml-fmt
 
+# Format tracked TOML files.
+[group('validation')]
 toml-fmt: _ensure-taplo
     #!/usr/bin/env bash
     set -euo pipefail
@@ -684,6 +875,8 @@ toml-fmt: _ensure-taplo
         echo "No TOML files found to format."
     fi
 
+# Check tracked TOML formatting without modifying files.
+[group('validation')]
 toml-fmt-check: _ensure-taplo
     #!/usr/bin/env bash
     set -euo pipefail
@@ -697,6 +890,8 @@ toml-fmt-check: _ensure-taplo
         echo "No TOML files found to check."
     fi
 
+# Lint tracked TOML files.
+[group('validation')]
 toml-lint: _ensure-taplo
     #!/usr/bin/env bash
     set -euo pipefail
@@ -711,6 +906,7 @@ toml-lint: _ensure-taplo
     fi
 
 # Validate example output (seeded, deterministic)
+[group('tests and coverage')]
 validate-examples: _build-examples
     #!/usr/bin/env bash
     set -euo pipefail
@@ -743,6 +939,8 @@ validate-examples: _build-examples
     validate_example delayed_chunked_telemetry "Per-step telemetry" "Delayed chunked telemetry complete"
     validate_example additive_target_bias "AdditiveTarget bias example" "observed P(true)"
 
+# Validate tracked JSON files.
+[group('validation')]
 validate-json: _ensure-jq
     #!/usr/bin/env bash
     set -euo pipefail
@@ -757,6 +955,7 @@ validate-json: _ensure-jq
     fi
 
 # YAML formatting check
+[group('validation')]
 yaml-check: _ensure-dprint
     #!/usr/bin/env bash
     set -euo pipefail
@@ -771,6 +970,7 @@ yaml-check: _ensure-dprint
     fi
 
 # YAML formatting
+[group('validation')]
 yaml-fix: _ensure-dprint
     #!/usr/bin/env bash
     set -euo pipefail
@@ -784,8 +984,11 @@ yaml-fix: _ensure-dprint
         echo "No YAML files found to format."
     fi
 
+# Alias for the canonical YAML check.
+[group('validation')]
 yaml-lint: yaml-check
 
 # GitHub Actions security analysis
+[group('validation')]
 zizmor: _ensure-zizmor
     zizmor .github

--- a/justfile
+++ b/justfile
@@ -169,7 +169,7 @@ action-lint: _ensure-actionlint
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -co --exclude-standard -z '.github/workflows/*.yml' '.github/workflows/*.yaml')
+    done < <(git ls-files -co --exclude-standard -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 uv run --locked actionlint
     else
@@ -438,7 +438,7 @@ markdown-check: _ensure-rumdl
             CHANGELOG.md) continue ;;
         esac
         files+=("$file")
-    done < <(git ls-files -co --exclude-standard -z '*.md')
+    done < <(git ls-files -co --exclude-standard -z -- '*.md')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 -n100 rumdl check
     else
@@ -456,7 +456,7 @@ markdown-fix: _ensure-rumdl
             CHANGELOG.md) continue ;;
         esac
         files+=("$file")
-    done < <(git ls-files -co --exclude-standard -z '*.md')
+    done < <(git ls-files -co --exclude-standard -z -- '*.md')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 -n100 rumdl check --fix
     else
@@ -652,7 +652,7 @@ semgrep: _ensure-uv
             tests/semgrep/*) continue ;;
         esac
         files+=("$file")
-    done < <(git ls-files -co --exclude-standard -z)
+    done < <(git ls-files -co --exclude-standard -z --)
     if [ "${#files[@]}" -gt 0 ]; then
         uv run --locked semgrep --metrics off --error --strict --timeout 30 --config semgrep.yaml "${files[@]}"
     else
@@ -868,7 +868,7 @@ toml-fmt: _ensure-taplo
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.toml')
+    done < <(git ls-files -co --exclude-standard -z -- '*.toml')
     if [ "${#files[@]}" -gt 0 ]; then
         taplo fmt "${files[@]}"
     else
@@ -883,7 +883,7 @@ toml-fmt-check: _ensure-taplo
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.toml')
+    done < <(git ls-files -co --exclude-standard -z -- '*.toml')
     if [ "${#files[@]}" -gt 0 ]; then
         taplo fmt --check "${files[@]}"
     else
@@ -898,7 +898,7 @@ toml-lint: _ensure-taplo
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.toml')
+    done < <(git ls-files -co --exclude-standard -z -- '*.toml')
     if [ "${#files[@]}" -gt 0 ]; then
         taplo lint "${files[@]}"
     else
@@ -947,7 +947,7 @@ validate-json: _ensure-jq
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.json')
+    done < <(git ls-files -co --exclude-standard -z -- '*.json')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 -n1 jq empty
     else
@@ -962,7 +962,7 @@ yaml-check: _ensure-dprint
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.yml' '*.yaml')
+    done < <(git ls-files -co --exclude-standard -z -- '*.yml' '*.yaml')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 dprint check
     else
@@ -977,7 +977,7 @@ yaml-fix: _ensure-dprint
     files=()
     while IFS= read -r -d '' file; do
         files+=("$file")
-    done < <(git ls-files -z '*.yml' '*.yaml')
+    done < <(git ls-files -co --exclude-standard -z -- '*.yml' '*.yaml')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 dprint fmt
     else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,15 @@ dependencies = [  ]
 "Bug Tracker" = "https://github.com/acgetchell/markov-chain-monte-carlo/issues"
 
 [project.scripts]
+archive-performance = "archive_performance:main"
+bench-compare = "bench_compare:main"
 check-notebooks = "check_notebooks:main"
 postprocess-changelog = "postprocess_changelog:main"
 tag-release = "tag_release:main"
 
 [tool.setuptools]
 package-dir = { "" = "scripts" }
-py-modules = [ "check_notebooks", "postprocess_changelog", "subprocess_utils", "tag_release" ]
+py-modules = [ "archive_performance", "bench_compare", "check_notebooks", "postprocess_changelog", "subprocess_utils", "tag_release" ]
 
 [dependency-groups]
 dev = [
@@ -86,6 +88,8 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = [
+    "archive_performance",
+    "bench_compare",
     "check_notebooks",
     "postprocess_changelog",
     "subprocess_utils",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,8 +12,10 @@ just performance-release [current-tag baseline-tag]
 ```
 
 `bench-compare` discovers Criterion samples below `target/criterion`, compares `new` with a saved baseline, and writes Markdown under
-`target/bench-reports/`. `archive-performance` resolves published release pairs, runs isolated local worktrees or downloads durable GitHub Release assets,
-and safely promotes one curated report into `docs/PERFORMANCE.md` while preserving prior pairs under `docs/archive/performance/`.
+`target/bench-reports/`. For current-working-tree comparisons, `archive-performance` resolves the latest stable release and measures both revisions in isolated
+worktrees. GitHub Release comparisons resolve two published tags and consume their durable assets without local measurements. Release-promotion runs infer or
+accept a release pair, measure it in isolated worktrees, and safely promote one curated report into `docs/PERFORMANCE.md` while preserving prior pairs under
+`docs/archive/performance/`.
 
 The benchmark command contracts and interpretation limits live in [`docs/BENCHMARKING.md`](../docs/BENCHMARKING.md).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,21 @@
 
 Python utilities used by local repository workflows.
 
+## Benchmark Reports
+
+```bash
+just bench-compare [baseline]
+just performance-local
+just performance-github-assets [current-tag baseline-tag]
+just performance-release [current-tag baseline-tag]
+```
+
+`bench-compare` discovers Criterion samples below `target/criterion`, compares `new` with a saved baseline, and writes Markdown under
+`target/bench-reports/`. `archive-performance` resolves published release pairs, runs isolated local worktrees or downloads durable GitHub Release assets,
+and safely promotes one curated report into `docs/PERFORMANCE.md` while preserving prior pairs under `docs/archive/performance/`.
+
+The benchmark command contracts and interpretation limits live in [`docs/BENCHMARKING.md`](../docs/BENCHMARKING.md).
+
 ## Notebooks
 
 ```bash

--- a/scripts/archive_performance.py
+++ b/scripts/archive_performance.py
@@ -22,7 +22,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from bench_compare import ComparisonSet, ReportSettings, collect_comparisons, render_report
+from bench_compare import ComparisonSet, ReportSettings, _write_text, collect_comparisons, render_report
 from subprocess_utils import ExecutableNotFoundError, run_git_command, run_git_command_with_input, run_safe_command
 
 if TYPE_CHECKING:
@@ -259,29 +259,6 @@ def resolve_release_pair(
     return pair
 
 
-def _write_text(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=path.parent,
-            prefix=f".{path.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as handle:
-            temporary = Path(handle.name)
-            handle.write(text)
-        if temporary is None:
-            msg = f"failed to create a temporary output for {path}"
-            raise RuntimeError(msg)
-        temporary.replace(path)
-    finally:
-        if temporary is not None and temporary.exists():
-            temporary.unlink()
-
-
 def _archive_index(archive_dir: Path) -> str:
     reports = sorted(path.name for path in archive_dir.glob("*.md") if path.name != "README.md")
     lines = [
@@ -372,12 +349,11 @@ def apply_current_tree(repo_root: Path, worktree: Path) -> None:
         shutil.copy2(source, destination)
 
 
-def _run_stepping_benchmark(checkout: Path, *, save_baseline: str | None = None) -> tuple[str, ...]:
+def _run_stepping_benchmark(checkout: Path, *, save_baseline: str | None = None) -> None:
     command = ["bench", "--locked", "--bench", "stepping"]
     if save_baseline is not None:
         command.extend(["--", "--save-baseline", save_baseline])
     run_safe_command("cargo", command, cwd=checkout, timeout=_BENCHMARK_TIMEOUT_SECONDS)
-    return ("cargo", *command)
 
 
 def _criterion_dependency_version(checkout: Path) -> str:
@@ -685,12 +661,12 @@ def main(argv: list[str] | None = None) -> int:
             report = generate_github_asset_report(repo_root, pair)
         else:
             published_tags = {release.tag for release in releases}
-            repair_published_release = mode == "explicit" or (mode == "infer-release" and pair.current_tag in published_tags)
+            current_tag_is_published = mode == "explicit" or (mode == "infer-release" and pair.current_tag in published_tags)
             report = generate_local_report(
                 repo_root,
                 pair,
-                current_reference=pair.current_tag if repair_published_release else "HEAD",
-                apply_working_tree=not repair_published_release,
+                current_reference=pair.current_tag if current_tag_is_published else "HEAD",
+                apply_working_tree=not current_tag_is_published,
             )
         if args.promote:
             promote_report(

--- a/scripts/archive_performance.py
+++ b/scripts/archive_performance.py
@@ -1,0 +1,729 @@
+#!/usr/bin/env python3
+"""Generate, promote, and archive release benchmark reports.
+
+Local comparisons run the current tree and a published release in isolated
+temporary worktrees.  Historical comparisons consume durable Criterion
+archives attached to GitHub Releases and never run Cargo.
+"""
+
+import argparse
+import json
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import tomllib
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from bench_compare import ComparisonSet, ReportSettings, collect_comparisons, render_report
+from subprocess_utils import ExecutableNotFoundError, run_git_command, run_git_command_with_input, run_safe_command
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_REPOSITORY = "acgetchell/markov-chain-monte-carlo"
+_ASSET_TEMPLATE = "markov-chain-monte-carlo-{tag}-criterion-baseline.tar.gz"
+_TAG_RE = re.compile(r"^v(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)$")
+_VERSION_RE = re.compile(r"^\*\*markov-chain-monte-carlo\*\* (?P<version>v[0-9]+\.[0-9]+\.[0-9]+)", re.MULTILINE)
+_BASELINE_RE = re.compile(r"^Comparison against baseline \*\*(?P<baseline>v[0-9]+\.[0-9]+\.[0-9]+)\*\*:", re.MULTILINE)
+_COMMAND_TIMEOUT_SECONDS = 600
+_BENCHMARK_TIMEOUT_SECONDS = 7200
+
+type ResolutionMode = Literal["explicit", "published-latest", "infer-release", "current-vs-latest"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReportId:
+    """The release pair represented by one curated report."""
+
+    current_tag: str
+    baseline_tag: str
+
+    @property
+    def archive_name(self) -> str:
+        """Return the canonical archive filename."""
+        return f"{self.current_tag}-vs-{self.baseline_tag}.md"
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedRelease:
+    """Stable GitHub Release metadata used for pair inference."""
+
+    tag: str
+    published_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseMetadata:
+    """Validated measurement metadata stored beside release Criterion data."""
+
+    tag: str
+    commit: str
+    operating_system: str
+    architecture: str
+    rustc: str
+    criterion_version: str
+
+
+def normalize_tag(tag: str) -> str:
+    """Normalize a stable SemVer release tag to a leading-``v`` form."""
+    normalized = tag.strip()
+    if normalized and not normalized.startswith("v"):
+        normalized = f"v{normalized}"
+    if _TAG_RE.fullmatch(normalized) is None:
+        msg = f"expected a stable SemVer tag like v0.4.0, got {tag!r}"
+        raise ValueError(msg)
+    return normalized
+
+
+def _tag_version(tag: str) -> tuple[int, int, int]:
+    """Return the numeric stable-SemVer components of a normalized tag."""
+    normalized = normalize_tag(tag)
+    match = _TAG_RE.fullmatch(normalized)
+    if match is None:  # normalize_tag already rejects this state.
+        msg = f"expected a normalized stable SemVer tag, got {normalized!r}"
+        raise ValueError(msg)
+    return (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+    )
+
+
+def parse_report_id(text: str) -> ReportId:
+    """Read a release pair from a generated benchmark report."""
+    version = _VERSION_RE.search(text)
+    if version is None:
+        msg = "could not find the markov-chain-monte-carlo version line in the benchmark report"
+        raise ValueError(msg)
+    baseline = _BASELINE_RE.search(text)
+    if baseline is None:
+        msg = "could not find the comparison baseline in the benchmark report"
+        raise ValueError(msg)
+    return ReportId(normalize_tag(version.group("version")), normalize_tag(baseline.group("baseline")))
+
+
+def _parse_publication_time(value: object, index: int) -> datetime:
+    if not isinstance(value, str) or not value:
+        msg = f"GitHub release entry {index} has invalid publishedAt metadata"
+        raise TypeError(msg)
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        msg = f"GitHub release entry {index} has invalid publishedAt metadata"
+        raise ValueError(msg) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        msg = f"GitHub release entry {index} publishedAt must include a UTC offset"
+        raise ValueError(msg)
+    return parsed.astimezone(UTC)
+
+
+def stable_published_releases(document: object) -> tuple[PublishedRelease, ...]:
+    """Validate, filter, and newest-first sort GitHub Release metadata."""
+    if not isinstance(document, list):
+        msg = "GitHub release metadata must be a JSON array"
+        raise TypeError(msg)
+    releases: list[PublishedRelease] = []
+    seen_tags: set[str] = set()
+    for index, raw_release in enumerate(document):
+        if not isinstance(raw_release, dict):
+            msg = f"GitHub release entry {index} must be an object"
+            raise TypeError(msg)
+        draft = raw_release.get("isDraft")
+        prerelease = raw_release.get("isPrerelease")
+        if not isinstance(draft, bool) or not isinstance(prerelease, bool):
+            msg = f"GitHub release entry {index} must contain boolean draft and prerelease flags"
+            raise TypeError(msg)
+        if draft or prerelease:
+            continue
+        raw_tag = raw_release.get("tagName")
+        if not isinstance(raw_tag, str) or _TAG_RE.fullmatch(raw_tag) is None:
+            continue
+        normalized_tag = normalize_tag(raw_tag)
+        if normalized_tag in seen_tags:
+            msg = f"GitHub release metadata contains duplicate tag {normalized_tag}"
+            raise ValueError(msg)
+        seen_tags.add(normalized_tag)
+        releases.append(
+            PublishedRelease(
+                tag=normalized_tag,
+                published_at=_parse_publication_time(raw_release.get("publishedAt"), index),
+            )
+        )
+    releases.sort(key=lambda release: release.published_at, reverse=True)
+    return tuple(releases)
+
+
+def _published_releases(repo_root: Path) -> tuple[PublishedRelease, ...]:
+    result = run_safe_command(
+        "gh",
+        [
+            "release",
+            "list",
+            "--repo",
+            _REPOSITORY,
+            "--limit",
+            "100",
+            "--json",
+            "tagName,isDraft,isPrerelease,publishedAt",
+        ],
+        cwd=repo_root,
+        timeout=_COMMAND_TIMEOUT_SECONDS,
+    )
+    try:
+        document = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        msg = f"GitHub release metadata is not valid JSON: {error}"
+        raise ValueError(msg) from error
+    releases = stable_published_releases(document)
+    if not releases:
+        msg = "no published stable SemVer GitHub Releases were found"
+        raise RuntimeError(msg)
+    return releases
+
+
+def current_package_tag(repo_root: Path) -> str:
+    """Read the current release tag from Cargo package metadata."""
+    cargo_toml = repo_root / "Cargo.toml"
+    document = tomllib.loads(cargo_toml.read_text(encoding="utf-8"))
+    package = document.get("package")
+    if not isinstance(package, dict) or not isinstance(package.get("version"), str):
+        msg = f"could not find package.version in {cargo_toml}"
+        raise TypeError(msg)
+    return normalize_tag(package["version"])
+
+
+def _resolve_inferred_pair(
+    *,
+    mode: ResolutionMode,
+    releases: tuple[PublishedRelease, ...],
+    package_tag: str,
+) -> ReportId:
+    """Resolve one non-explicit comparison mode."""
+    if mode == "published-latest":
+        if len(releases) < 2:
+            msg = "at least two published stable releases are required for a historical asset comparison"
+            raise RuntimeError(msg)
+        return ReportId(releases[0].tag, releases[1].tag)
+    if mode == "current-vs-latest":
+        if not releases:
+            msg = "a published stable release is required for a local comparison"
+            raise RuntimeError(msg)
+        return ReportId(package_tag, releases[0].tag)
+    published_tags = [release.tag for release in releases]
+    if package_tag in published_tags:
+        index = published_tags.index(package_tag)
+        if index + 1 >= len(releases):
+            msg = f"published release {package_tag} has no previous stable release"
+            raise RuntimeError(msg)
+        return ReportId(package_tag, releases[index + 1].tag)
+    if not releases:
+        msg = "a published stable release is required for release preparation"
+        raise RuntimeError(msg)
+    if _tag_version(package_tag) <= _tag_version(releases[0].tag):
+        msg = f"unpublished package {package_tag} must be newer than the latest published stable release {releases[0].tag}"
+        raise ValueError(msg)
+    return ReportId(package_tag, releases[0].tag)
+
+
+def resolve_release_pair(
+    *,
+    mode: ResolutionMode,
+    releases: tuple[PublishedRelease, ...],
+    package_tag: str,
+    current_tag: str | None = None,
+    baseline_tag: str | None = None,
+) -> ReportId:
+    """Resolve an explicit, local, release-prep, or historical comparison."""
+    package_tag = normalize_tag(package_tag)
+    if mode == "explicit":
+        if current_tag is None or baseline_tag is None:
+            msg = "current_tag and baseline_tag are both required for an explicit comparison"
+            raise ValueError(msg)
+        pair = ReportId(normalize_tag(current_tag), normalize_tag(baseline_tag))
+    else:
+        if current_tag is not None or baseline_tag is not None:
+            msg = f"do not pass explicit tags with {mode!r} resolution"
+            raise ValueError(msg)
+        pair = _resolve_inferred_pair(mode=mode, releases=releases, package_tag=package_tag)
+    if pair.current_tag == pair.baseline_tag and mode != "current-vs-latest":
+        msg = f"current and baseline releases must differ: {pair.current_tag}"
+        raise ValueError(msg)
+    return pair
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(text)
+        if temporary is None:
+            msg = f"failed to create a temporary output for {path}"
+            raise RuntimeError(msg)
+        temporary.replace(path)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+
+
+def _archive_index(archive_dir: Path) -> str:
+    reports = sorted(path.name for path in archive_dir.glob("*.md") if path.name != "README.md")
+    lines = [
+        "# Archived Performance Reports",
+        "",
+        "Older curated release-to-release benchmark comparisons are archived here. The latest curated report is written to `docs/PERFORMANCE.md`.",
+        "",
+    ]
+    if reports:
+        lines.extend(f"- [{name.removesuffix('.md')}]({name})" for name in reports)
+    else:
+        lines.append("- No archived performance reports yet.")
+    return "\n".join(lines) + "\n"
+
+
+def promote_report(
+    *,
+    source_text: str,
+    current_path: Path,
+    archive_dir: Path,
+    expected: ReportId,
+) -> None:
+    """Archive the previous curated report and atomically promote a new one."""
+    source_id = parse_report_id(source_text)
+    if source_id != expected:
+        msg = (
+            "benchmark report does not match the requested release pair: "
+            f"found {source_id.current_tag} vs {source_id.baseline_tag}, expected {expected.current_tag} vs {expected.baseline_tag}"
+        )
+        raise ValueError(msg)
+    if current_path.exists():
+        previous_text = current_path.read_text(encoding="utf-8")
+        previous_id = parse_report_id(previous_text)
+        if previous_id != source_id:
+            archive_path = archive_dir / previous_id.archive_name
+            if not archive_path.exists():
+                _write_text(archive_path, previous_text)
+    _write_text(current_path, source_text)
+    _write_text(archive_dir / "README.md", _archive_index(archive_dir))
+
+
+def _ensure_local_tag(repo_root: Path, tag: str) -> None:
+    try:
+        run_git_command(["--no-pager", "rev-parse", "--verify", f"refs/tags/{tag}"], cwd=repo_root, timeout=30)
+    except subprocess.CalledProcessError:
+        run_git_command(["fetch", "origin", f"refs/tags/{tag}:refs/tags/{tag}", "--no-tags"], cwd=repo_root, timeout=_COMMAND_TIMEOUT_SECONDS)
+
+
+@contextmanager
+def temporary_worktree(repo_root: Path, parent: Path, name: str, reference: str) -> Iterator[Path]:
+    """Create and reliably remove one detached temporary worktree."""
+    worktree = parent / name
+    added = False
+    try:
+        run_git_command(["worktree", "add", "--detach", str(worktree), reference], cwd=repo_root, timeout=_COMMAND_TIMEOUT_SECONDS)
+        added = True
+        yield worktree
+    finally:
+        if added:
+            active_error = sys.exception()
+            try:
+                run_git_command(["worktree", "remove", "--force", str(worktree)], cwd=repo_root, timeout=_COMMAND_TIMEOUT_SECONDS)
+            except ExecutableNotFoundError, OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired:
+                if active_error is None:
+                    raise
+
+
+def apply_current_tree(repo_root: Path, worktree: Path) -> None:
+    """Apply tracked and untracked current-tree content to an isolated worktree."""
+    patch = run_git_command(["--no-pager", "diff", "--binary", "HEAD"], cwd=repo_root, timeout=_COMMAND_TIMEOUT_SECONDS).stdout
+    if patch:
+        run_git_command_with_input(
+            ["apply", "--binary", "--whitespace=nowarn"],
+            patch,
+            cwd=worktree,
+            timeout=_COMMAND_TIMEOUT_SECONDS,
+        )
+    untracked = run_git_command(
+        ["ls-files", "--others", "--exclude-standard"],
+        cwd=repo_root,
+        timeout=_COMMAND_TIMEOUT_SECONDS,
+    ).stdout.splitlines()
+    for relative_name in untracked:
+        relative = Path(relative_name)
+        source = repo_root / relative
+        destination = worktree / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
+def _run_stepping_benchmark(checkout: Path, *, save_baseline: str | None = None) -> tuple[str, ...]:
+    command = ["bench", "--locked", "--bench", "stepping"]
+    if save_baseline is not None:
+        command.extend(["--", "--save-baseline", save_baseline])
+    run_safe_command("cargo", command, cwd=checkout, timeout=_BENCHMARK_TIMEOUT_SECONDS)
+    return ("cargo", *command)
+
+
+def _criterion_dependency_version(checkout: Path) -> str:
+    """Read the exact Criterion version from one checkout's Cargo.lock."""
+    document = tomllib.loads((checkout / "Cargo.lock").read_text(encoding="utf-8"))
+    packages = document.get("package")
+    if not isinstance(packages, list):
+        msg = f"Cargo.lock in {checkout} does not contain a package array"
+        raise TypeError(msg)
+    versions = [package.get("version") for package in packages if isinstance(package, dict) and package.get("name") == "criterion"]
+    if len(versions) != 1 or not isinstance(versions[0], str):
+        msg = f"Cargo.lock in {checkout} must contain exactly one Criterion package"
+        raise ValueError(msg)
+    return versions[0]
+
+
+def _release_metadata(criterion_dir: Path, expected_tag: str) -> ReleaseMetadata:
+    """Read and validate durable release measurement metadata."""
+    path = criterion_dir / ".mcmc-release-metadata.json"
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        msg = f"release benchmark metadata is not valid JSON in {path}: {error}"
+        raise ValueError(msg) from error
+    if not isinstance(document, dict):
+        msg = f"release benchmark metadata in {path} must be an object"
+        raise TypeError(msg)
+    if document.get("schema") != 1 or isinstance(document.get("schema"), bool):
+        msg = f"release benchmark metadata in {path} has an unsupported schema"
+        raise ValueError(msg)
+
+    def required_string(field: str) -> str:
+        value = document.get(field)
+        if not isinstance(value, str) or not value.strip():
+            msg = f"release benchmark metadata field {field!r} in {path} must be a non-empty string"
+            raise TypeError(msg)
+        return value
+
+    metadata = ReleaseMetadata(
+        tag=normalize_tag(required_string("tag")),
+        commit=required_string("commit"),
+        operating_system=required_string("operating_system"),
+        architecture=required_string("architecture"),
+        rustc=required_string("rustc"),
+        criterion_version=required_string("criterion_version"),
+    )
+    if metadata.tag != expected_tag:
+        msg = f"release benchmark metadata tag {metadata.tag} does not match requested release {expected_tag}"
+        raise ValueError(msg)
+    if re.fullmatch(r"[0-9a-f]{40}", metadata.commit) is None:
+        msg = f"release benchmark metadata commit for {metadata.tag} must be a full lowercase Git SHA"
+        raise ValueError(msg)
+    return metadata
+
+
+def _local_measurement_context(current_checkout: Path, baseline_checkout: Path, *, working_tree: bool) -> tuple[str, ...]:
+    """Describe enough local context to identify and interpret both samples."""
+    current_commit = run_git_command(["--no-pager", "rev-parse", "HEAD"], cwd=current_checkout, timeout=30).stdout.strip()
+    baseline_commit = run_git_command(["--no-pager", "rev-parse", "HEAD"], cwd=baseline_checkout, timeout=30).stdout.strip()
+    current_rustc = run_safe_command("rustc", ["--version"], cwd=current_checkout, timeout=30).stdout.strip()
+    baseline_rustc = run_safe_command("rustc", ["--version"], cwd=baseline_checkout, timeout=30).stdout.strip()
+    source = "current `HEAD` with tracked and untracked working-tree changes applied" if working_tree else "exact current release tag"
+    return (
+        "Source mode: same-host isolated worktrees; " + source + ".",
+        f"Host: `{platform.platform()}` on `{platform.machine()}`.",
+        f"Current commit: `{current_commit}`; rustc: `{current_rustc}`; Criterion: `{_criterion_dependency_version(current_checkout)}`.",
+        f"Baseline commit: `{baseline_commit}`; rustc: `{baseline_rustc}`; Criterion: `{_criterion_dependency_version(baseline_checkout)}`.",
+    )
+
+
+def _asset_measurement_context(current: ReleaseMetadata, baseline: ReleaseMetadata) -> tuple[str, ...]:
+    """Render validated context from two durable release assets."""
+    return (
+        "Source mode: durable GitHub Release Criterion assets; no local benchmark runs.",
+        (
+            f"Current `{current.tag}`: commit `{current.commit}`; `{current.operating_system}` / `{current.architecture}`; rustc: `{current.rustc}`; "
+            f"Criterion: `{current.criterion_version}`."
+        ),
+        (
+            f"Baseline `{baseline.tag}`: commit `{baseline.commit}`; `{baseline.operating_system}` / `{baseline.architecture}`; rustc: `{baseline.rustc}`; "
+            f"Criterion: `{baseline.criterion_version}`."
+        ),
+    )
+
+
+def copy_criterion_sample(
+    *,
+    source_criterion: Path,
+    destination_criterion: Path,
+    source_sample: str,
+    destination_sample: str,
+) -> int:
+    """Copy one named sample for every benchmark into a combined tree."""
+    copied = 0
+    for estimates in sorted(source_criterion.rglob("estimates.json")):
+        sample_dir = estimates.parent
+        if sample_dir.name != source_sample:
+            continue
+        benchmark_relative = sample_dir.parent.relative_to(source_criterion)
+        destination = destination_criterion / benchmark_relative / destination_sample
+        if destination.exists():
+            shutil.rmtree(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(sample_dir, destination)
+        copied += 1
+    if copied == 0:
+        msg = f"no Criterion sample {source_sample!r} found under {source_criterion}"
+        raise FileNotFoundError(msg)
+    return copied
+
+
+def _render_comparison(
+    criterion_dir: Path,
+    pair: ReportId,
+    *,
+    current_label: str,
+    revision: str,
+    measurement_context: tuple[str, ...],
+) -> str:
+    comparison_set: ComparisonSet = collect_comparisons(criterion_dir, pair.baseline_tag)
+    if not comparison_set.comparisons:
+        msg = f"no comparable Criterion rows found for {pair.current_tag} vs {pair.baseline_tag}"
+        raise RuntimeError(msg)
+    settings = ReportSettings(
+        current_label=current_label,
+        baseline_label=pair.baseline_tag,
+        statistic="median",
+        revision=revision,
+        measurement_context=measurement_context,
+    )
+    return render_report(comparison_set, settings)
+
+
+def generate_local_report(
+    repo_root: Path,
+    pair: ReportId,
+    *,
+    current_reference: str,
+    apply_working_tree: bool,
+) -> str:
+    """Measure two revisions in isolated worktrees and render their overlap."""
+    _ensure_local_tag(repo_root, pair.baseline_tag)
+    if current_reference != "HEAD":
+        _ensure_local_tag(repo_root, current_reference)
+    with tempfile.TemporaryDirectory(prefix="mcmc-performance-") as temporary_name:
+        parent = Path(temporary_name)
+        with temporary_worktree(repo_root, parent, "current", current_reference) as current_checkout:
+            if apply_working_tree:
+                apply_current_tree(repo_root, current_checkout)
+            with temporary_worktree(repo_root, parent, "baseline", pair.baseline_tag) as baseline_checkout:
+                _run_stepping_benchmark(baseline_checkout, save_baseline=pair.baseline_tag)
+                _run_stepping_benchmark(current_checkout)
+                current_criterion = current_checkout / "target" / "criterion"
+                copy_criterion_sample(
+                    source_criterion=baseline_checkout / "target" / "criterion",
+                    destination_criterion=current_criterion,
+                    source_sample=pair.baseline_tag,
+                    destination_sample=pair.baseline_tag,
+                )
+                revision = run_git_command(["--no-pager", "rev-parse", "--short", "HEAD"], cwd=current_checkout, timeout=30).stdout.strip()
+                label = f"{pair.current_tag} working tree" if apply_working_tree else pair.current_tag
+                context = _local_measurement_context(current_checkout, baseline_checkout, working_tree=apply_working_tree)
+                return _render_comparison(
+                    current_criterion,
+                    pair,
+                    current_label=label,
+                    revision=revision,
+                    measurement_context=context,
+                )
+
+
+def safe_extract_tar(archive: Path, destination: Path) -> None:
+    """Extract a regular-file Criterion archive without traversal or links."""
+    destination.mkdir(parents=True, exist_ok=True)
+    root = destination.resolve()
+    with tarfile.open(archive, "r:gz") as tar:
+        for member in tar.getmembers():
+            target = (destination / member.name).resolve()
+            if not target.is_relative_to(root):
+                msg = f"release benchmark archive contains a path outside its root: {member.name}"
+                raise ValueError(msg)
+            if member.issym() or member.islnk() or not (member.isdir() or member.isfile()):
+                msg = f"release benchmark archive contains an unsupported entry: {member.name}"
+                raise ValueError(msg)
+        tar.extractall(destination, filter="data")
+
+
+def _download_release_asset(repo_root: Path, tag: str, destination: Path) -> Path:
+    asset = _ASSET_TEMPLATE.format(tag=tag)
+    destination.mkdir(parents=True, exist_ok=True)
+    run_safe_command(
+        "gh",
+        ["release", "download", tag, "--repo", _REPOSITORY, "--pattern", asset, "--dir", str(destination)],
+        cwd=repo_root,
+        timeout=_COMMAND_TIMEOUT_SECONDS,
+    )
+    path = destination / asset
+    if not path.is_file():
+        msg = f"GitHub Release {tag} does not contain {asset}"
+        raise FileNotFoundError(msg)
+    return path
+
+
+def generate_github_asset_report(repo_root: Path, pair: ReportId) -> str:
+    """Render a historical comparison solely from GitHub Release assets."""
+    with tempfile.TemporaryDirectory(prefix="mcmc-performance-assets-") as temporary_name:
+        root = Path(temporary_name)
+        current_archive = _download_release_asset(repo_root, pair.current_tag, root / "downloads-current")
+        baseline_archive = _download_release_asset(repo_root, pair.baseline_tag, root / "downloads-baseline")
+        current_extract = root / "current"
+        baseline_extract = root / "baseline"
+        safe_extract_tar(current_archive, current_extract)
+        safe_extract_tar(baseline_archive, baseline_extract)
+        current_criterion = current_extract / "criterion"
+        baseline_criterion = baseline_extract / "criterion"
+        current_metadata = _release_metadata(current_criterion, pair.current_tag)
+        baseline_metadata = _release_metadata(baseline_criterion, pair.baseline_tag)
+        combined = root / "combined"
+        copy_criterion_sample(
+            source_criterion=current_criterion,
+            destination_criterion=combined,
+            source_sample=pair.current_tag,
+            destination_sample="new",
+        )
+        copy_criterion_sample(
+            source_criterion=baseline_criterion,
+            destination_criterion=combined,
+            source_sample=pair.baseline_tag,
+            destination_sample=pair.baseline_tag,
+        )
+        return _render_comparison(
+            combined,
+            pair,
+            current_label=pair.current_tag,
+            revision=current_metadata.commit[:7],
+            measurement_context=_asset_measurement_context(current_metadata, baseline_metadata),
+        )
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate and curate release performance reports.")
+    parser.add_argument("current_tag", nargs="?")
+    parser.add_argument("baseline_tag", nargs="?")
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument("--published-latest", action="store_true")
+    modes.add_argument("--infer-release", action="store_true")
+    modes.add_argument("--current-vs-latest", action="store_true")
+    parser.add_argument("--github-assets", action="store_true", help="Use durable GitHub Release assets without local benchmark runs.")
+    parser.add_argument("--promote", action="store_true", help="Promote the report to docs/PERFORMANCE.md and archive the previous report.")
+    parser.add_argument("--output", default="target/bench-reports/performance.md")
+    parser.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[1]))
+    return parser.parse_args(argv)
+
+
+def _resolution_mode(args: argparse.Namespace) -> ResolutionMode:
+    if args.published_latest:
+        return "published-latest"
+    if args.infer_release:
+        return "infer-release"
+    if args.current_vs_latest:
+        return "current-vs-latest"
+    return "explicit"
+
+
+def _validate_mode_combination(mode: ResolutionMode, *, github_assets: bool, promote: bool = False) -> None:
+    """Reject mode combinations that could mislabel a working-tree measurement."""
+    if promote and mode == "current-vs-latest":
+        msg = "working-tree reports cannot be promoted; use --infer-release or explicit release tags"
+        raise ValueError(msg)
+    if github_assets and mode not in {"explicit", "published-latest"}:
+        msg = "--github-assets requires --published-latest or an explicit current/baseline pair"
+        raise ValueError(msg)
+    if not github_assets and mode == "published-latest":
+        msg = "--published-latest is reserved for --github-assets comparisons"
+        raise ValueError(msg)
+
+
+def _format_command_failure(error: subprocess.CalledProcessError) -> str:
+    """Preserve command output needed to diagnose a failed release workflow."""
+    command = " ".join(str(part) for part in error.cmd) if isinstance(error.cmd, list | tuple) else str(error.cmd)
+    parts = [f"command failed with exit {error.returncode}: {command}"]
+    if error.stdout:
+        parts.append(f"stdout:\n{str(error.stdout).strip()}")
+    if error.stderr:
+        parts.append(f"stderr:\n{str(error.stderr).strip()}")
+    return "\n".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Generate a local or historical report and optionally promote it."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    repo_root = Path(args.repo_root).resolve()
+    mode = _resolution_mode(args)
+    try:
+        _validate_mode_combination(mode, github_assets=bool(args.github_assets), promote=bool(args.promote))
+        releases = () if mode == "explicit" else _published_releases(repo_root)
+        pair = resolve_release_pair(
+            mode=mode,
+            releases=releases,
+            package_tag=current_package_tag(repo_root),
+            current_tag=args.current_tag,
+            baseline_tag=args.baseline_tag,
+        )
+        if args.github_assets:
+            report = generate_github_asset_report(repo_root, pair)
+        else:
+            published_tags = {release.tag for release in releases}
+            repair_published_release = mode == "explicit" or (mode == "infer-release" and pair.current_tag in published_tags)
+            report = generate_local_report(
+                repo_root,
+                pair,
+                current_reference=pair.current_tag if repair_published_release else "HEAD",
+                apply_working_tree=not repair_published_release,
+            )
+        if args.promote:
+            promote_report(
+                source_text=report,
+                current_path=repo_root / "docs" / "PERFORMANCE.md",
+                archive_dir=repo_root / "docs" / "archive" / "performance",
+                expected=pair,
+            )
+            print(f"Promoted {pair.current_tag} vs {pair.baseline_tag} to {repo_root / 'docs' / 'PERFORMANCE.md'}")
+        else:
+            output = Path(args.output)
+            if not output.is_absolute():
+                output = repo_root / output
+            _write_text(output, report)
+            print(f"Wrote {output}")
+    except subprocess.CalledProcessError as error:
+        print(f"Performance workflow failed: {_format_command_failure(error)}", file=sys.stderr)
+        return 2
+    except subprocess.TimeoutExpired as error:
+        print(f"Performance workflow timed out after {error.timeout} seconds: {error.cmd}", file=sys.stderr)
+        return 2
+    except (
+        ExecutableNotFoundError,
+        FileNotFoundError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as error:
+        print(f"Performance workflow failed: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_compare.py
+++ b/scripts/bench_compare.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Render Markdown comparisons from Criterion benchmark samples.
+
+Criterion stores every benchmark below ``target/criterion`` with one directory
+per sample.  This utility compares the ordinary ``new`` sample with a named
+saved baseline and writes a compact, reviewable report.
+"""
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from subprocess_utils import ExecutableNotFoundError, run_git_command
+
+type Statistic = Literal["mean", "median"]
+
+
+@dataclass(frozen=True, slots=True)
+class Estimate:
+    """One validated Criterion estimate in nanoseconds."""
+
+    point_ns: float
+    lower_ns: float | None
+    upper_ns: float | None
+
+    def __post_init__(self) -> None:
+        """Reject incomplete, non-positive, or non-finite timings."""
+        values = (self.point_ns, self.lower_ns, self.upper_ns)
+        if any(value is not None and (not math.isfinite(value) or value <= 0) for value in values):
+            msg = f"Criterion timings must be finite and positive: {values!r}"
+            raise ValueError(msg)
+        if (self.lower_ns is None) != (self.upper_ns is None):
+            msg = "Criterion confidence intervals require both bounds"
+            raise ValueError(msg)
+        if self.lower_ns is not None and self.upper_ns is not None and self.lower_ns > self.upper_ns:
+            msg = "Criterion confidence interval lower bound exceeds upper bound"
+            raise ValueError(msg)
+        if self.lower_ns is not None and self.upper_ns is not None and not self.lower_ns <= self.point_ns <= self.upper_ns:
+            msg = "Criterion point estimate must lie within its confidence interval"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class Comparison:
+    """A current estimate paired with its saved baseline."""
+
+    benchmark: str
+    baseline: Estimate
+    current: Estimate
+
+    @property
+    def percent_change(self) -> float:
+        """Return signed current-vs-baseline change; negative is faster."""
+        return ((self.current.point_ns - self.baseline.point_ns) / self.baseline.point_ns) * 100.0
+
+    @property
+    def speedup(self) -> float:
+        """Return baseline/current; values above one are faster."""
+        return self.baseline.point_ns / self.current.point_ns
+
+
+@dataclass(frozen=True, slots=True)
+class ComparisonSet:
+    """Comparable rows plus samples missing from either revision."""
+
+    comparisons: tuple[Comparison, ...]
+    missing_baseline: tuple[str, ...]
+    missing_current: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReportSettings:
+    """Labels, statistic, and provenance rendered into one report."""
+
+    current_label: str
+    baseline_label: str
+    statistic: Statistic
+    revision: str
+    measurement_context: tuple[str, ...] = ()
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _numeric_field(data: dict[str, object], field: str, path: Path) -> float:
+    value = data.get(field)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        msg = f"{field!r} in {path} must be numeric"
+        raise TypeError(msg)
+    number = float(value)
+    if not math.isfinite(number) or number <= 0:
+        msg = f"{field!r} in {path} must be finite and positive"
+        raise ValueError(msg)
+    return number
+
+
+def read_estimate(path: Path, statistic: Statistic = "median") -> Estimate:
+    """Read one Criterion estimate file with contextual validation errors."""
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        msg = f"malformed Criterion JSON in {path}: {error}"
+        raise ValueError(msg) from error
+    if not isinstance(document, dict):
+        msg = f"Criterion estimate in {path} must be a JSON object"
+        raise TypeError(msg)
+    raw_statistic = document.get(statistic)
+    if not isinstance(raw_statistic, dict):
+        msg = f"Criterion statistic {statistic!r} is missing from {path}"
+        raise KeyError(msg)
+    statistic_data = {str(key): value for key, value in raw_statistic.items()}
+    point = _numeric_field(statistic_data, "point_estimate", path)
+    raw_interval = statistic_data.get("confidence_interval")
+    if raw_interval is None:
+        return Estimate(point, None, None)
+    if not isinstance(raw_interval, dict):
+        msg = f"Criterion confidence interval in {path} must be an object"
+        raise TypeError(msg)
+    interval = {str(key): value for key, value in raw_interval.items()}
+    return Estimate(
+        point,
+        _numeric_field(interval, "lower_bound", path),
+        _numeric_field(interval, "upper_bound", path),
+    )
+
+
+def collect_sample(criterion_dir: Path, sample: str, statistic: Statistic = "median") -> dict[str, Estimate]:
+    """Collect all estimates whose immediate sample directory matches *sample*."""
+    results: dict[str, Estimate] = {}
+    if not criterion_dir.is_dir():
+        return results
+    for path in sorted(criterion_dir.rglob("estimates.json")):
+        if path.parent.name != sample:
+            continue
+        relative_benchmark = path.parent.parent.relative_to(criterion_dir)
+        benchmark = "/".join(relative_benchmark.parts)
+        if benchmark in results:
+            msg = f"duplicate Criterion result for {benchmark!r} in sample {sample!r}"
+            raise ValueError(msg)
+        results[benchmark] = read_estimate(path, statistic)
+    return results
+
+
+def collect_comparisons(
+    criterion_dir: Path,
+    baseline_name: str,
+    statistic: Statistic = "median",
+) -> ComparisonSet:
+    """Pair the ``new`` sample with *baseline_name* across all benchmarks."""
+    current = collect_sample(criterion_dir, "new", statistic)
+    baseline = collect_sample(criterion_dir, baseline_name, statistic)
+    shared = sorted(current.keys() & baseline.keys())
+    return ComparisonSet(
+        comparisons=tuple(Comparison(name, baseline[name], current[name]) for name in shared),
+        missing_baseline=tuple(sorted(current.keys() - baseline.keys())),
+        missing_current=tuple(sorted(baseline.keys() - current.keys())),
+    )
+
+
+def _format_duration(nanoseconds: float) -> str:
+    if nanoseconds < 1_000:
+        return f"{nanoseconds:.2f} ns"
+    if nanoseconds < 1_000_000:
+        return f"{nanoseconds / 1_000:.2f} µs"
+    if nanoseconds < 1_000_000_000:
+        return f"{nanoseconds / 1_000_000:.2f} ms"
+    return f"{nanoseconds / 1_000_000_000:.2f} s"
+
+
+def _format_estimate(estimate: Estimate) -> str:
+    point = _format_duration(estimate.point_ns)
+    if estimate.lower_ns is None or estimate.upper_ns is None:
+        return point
+    return f"{point} ({_format_duration(estimate.lower_ns)} - {_format_duration(estimate.upper_ns)})"
+
+
+def _interval_relation(comparison: Comparison) -> str:
+    baseline = comparison.baseline
+    current = comparison.current
+    if baseline.lower_ns is None or baseline.upper_ns is None or current.lower_ns is None or current.upper_ns is None:
+        return "unknown"
+    if current.upper_ns < baseline.lower_ns:
+        return "current lower"
+    if baseline.upper_ns < current.lower_ns:
+        return "current higher"
+    return "overlap"
+
+
+def _git_revision(root: Path) -> str:
+    try:
+        return run_git_command(["--no-pager", "rev-parse", "--short", "HEAD"], cwd=root, timeout=10).stdout.strip()
+    except ExecutableNotFoundError, OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired:
+        return "unknown"
+
+
+def render_report(
+    comparison_set: ComparisonSet,
+    settings: ReportSettings,
+) -> str:
+    """Render a deterministic Markdown comparison report."""
+    lines = [
+        "# Benchmark Performance",
+        "",
+        f"**markov-chain-monte-carlo** {settings.current_label} · `{settings.revision}`",
+        f"**Statistic**: {settings.statistic}",
+        "",
+        f"Comparison against baseline **{settings.baseline_label}**:",
+        "",
+        (
+            "Negative change means the current point estimate is lower. The CI relation describes only overlap between Criterion's marginal intervals; "
+            "it is not a paired significance test."
+        ),
+    ]
+    if settings.measurement_context:
+        lines.extend(["", "## Measurement Context", ""])
+        lines.extend(f"- {item}" for item in settings.measurement_context)
+    lines.extend(
+        [
+            "",
+            "## Results",
+            "",
+            "| Benchmark | Baseline | Current | Change | Baseline/current | CI relation |",
+            "|:----------|---------:|--------:|-------:|-----------------:|:------------|",
+        ]
+    )
+    for comparison in comparison_set.comparisons:
+        lines.append(
+            f"| `{comparison.benchmark}` | {_format_estimate(comparison.baseline)} | {_format_estimate(comparison.current)} | "
+            f"{comparison.percent_change:+.2f}% | {comparison.speedup:.2f}x | {_interval_relation(comparison)} |"
+        )
+
+    if comparison_set.missing_baseline or comparison_set.missing_current:
+        lines.extend(["", "## Coverage Notes", ""])
+        if comparison_set.missing_baseline:
+            lines.append("Current-only rows without a saved baseline:")
+            lines.extend(f"- `{name}`" for name in comparison_set.missing_baseline)
+        if comparison_set.missing_current:
+            if comparison_set.missing_baseline:
+                lines.append("")
+            lines.append("Baseline-only rows without a current sample:")
+            lines.extend(f"- `{name}`" for name in comparison_set.missing_current)
+
+    lines.extend(
+        [
+            "",
+            "## How to Update",
+            "",
+            "```bash",
+            "just performance-local",
+            "just performance-github-assets",
+            "just performance-release",
+            "just performance-release <current-tag> <baseline-tag>",
+            "```",
+            "",
+            (
+                "Local reports live under `target/bench-reports/`. The curated release report is `docs/PERFORMANCE.md`; older curated reports are indexed "
+                "under `docs/archive/performance/`."
+            ),
+            "",
+            "See `docs/BENCHMARKING.md` for command semantics and reproducibility limits.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(text)
+        if temporary is None:
+            msg = f"failed to create a temporary output for {path}"
+            raise RuntimeError(msg)
+        temporary.replace(path)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare Criterion's current sample with a saved baseline.")
+    parser.add_argument("baseline", nargs="?", default="last", help="Criterion baseline name (default: last).")
+    parser.add_argument("--criterion-dir", default="target/criterion")
+    parser.add_argument("--output", default="target/bench-reports/performance.md")
+    parser.add_argument("--current-label", default="working tree")
+    parser.add_argument("--baseline-label")
+    parser.add_argument("--revision", help="Revision label to record instead of the current checkout's short commit.")
+    parser.add_argument("--stat", choices=("mean", "median"), default="median")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Render a comparison report, returning 2 for missing or invalid samples."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    root = _repo_root()
+    criterion_dir = Path(args.criterion_dir)
+    if not criterion_dir.is_absolute():
+        criterion_dir = root / criterion_dir
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = root / output
+    baseline_name = str(args.baseline)
+    statistic: Statistic = args.stat
+
+    try:
+        comparison_set = collect_comparisons(criterion_dir, baseline_name, statistic)
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        print(f"Invalid Criterion data: {error}", file=sys.stderr)
+        return 2
+    if not collect_sample(criterion_dir, "new", statistic):
+        print(f"No current Criterion results found under {criterion_dir}. Run `just bench-latest` first.", file=sys.stderr)
+        return 2
+    if not comparison_set.comparisons:
+        print(
+            f"No comparable Criterion results found for baseline {baseline_name!r}. Run `just bench-save-baseline {baseline_name}` first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    baseline_label = str(args.baseline_label or baseline_name)
+    settings = ReportSettings(
+        current_label=str(args.current_label),
+        baseline_label=baseline_label,
+        statistic=statistic,
+        revision=str(args.revision or _git_revision(root)),
+    )
+    report = render_report(comparison_set, settings)
+    try:
+        _write_text(output, report)
+    except (OSError, RuntimeError) as error:
+        print(f"Could not write benchmark report: {error}", file=sys.stderr)
+        return 2
+    print(f"Wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_compare.py
+++ b/scripts/bench_compare.py
@@ -72,6 +72,7 @@ class ComparisonSet:
     comparisons: tuple[Comparison, ...]
     missing_baseline: tuple[str, ...]
     missing_current: tuple[str, ...]
+    current_sample: tuple[tuple[str, Estimate], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -161,6 +162,7 @@ def collect_comparisons(
         comparisons=tuple(Comparison(name, baseline[name], current[name]) for name in shared),
         missing_baseline=tuple(sorted(current.keys() - baseline.keys())),
         missing_current=tuple(sorted(baseline.keys() - current.keys())),
+        current_sample=tuple(sorted(current.items())),
     )
 
 
@@ -324,7 +326,7 @@ def main(argv: list[str] | None = None) -> int:
     except (OSError, KeyError, TypeError, ValueError) as error:
         print(f"Invalid Criterion data: {error}", file=sys.stderr)
         return 2
-    if not collect_sample(criterion_dir, "new", statistic):
+    if not comparison_set.current_sample:
         print(f"No current Criterion results found under {criterion_dir}. Run `just bench-latest` first.", file=sys.stderr)
         return 2
     if not comparison_set.comparisons:

--- a/scripts/tests/test_archive_performance.py
+++ b/scripts/tests/test_archive_performance.py
@@ -1,0 +1,396 @@
+import io
+import json
+import subprocess
+import tarfile
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+import archive_performance
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+def _release(tag: str, days_ago: int = 0) -> archive_performance.PublishedRelease:
+    return archive_performance.PublishedRelease(tag, datetime(2026, 8, 1, tzinfo=UTC) - timedelta(days=days_ago))
+
+
+def _report(current: str, baseline: str, marker: str = "") -> str:
+    return (
+        "# Benchmark Performance\n\n"
+        f"**markov-chain-monte-carlo** {current} · `abc1234`\n"
+        "**Statistic**: median\n\n"
+        f"Comparison against baseline **{baseline}**:\n\n"
+        f"{marker}\n"
+    )
+
+
+def _write_sample(root: Path, benchmark: str, sample: str) -> None:
+    sample_dir = root / benchmark / sample
+    sample_dir.mkdir(parents=True, exist_ok=True)
+    (sample_dir / "estimates.json").write_text(json.dumps({"median": {"point_estimate": 1.0}}), encoding="utf-8")
+    (sample_dir / "sample.json").write_text("{}", encoding="utf-8")
+
+
+def test_stable_published_releases_filters_and_sorts() -> None:
+    document = [
+        {"tagName": "v0.3.0", "isDraft": False, "isPrerelease": False, "publishedAt": "2026-05-01T00:00:00Z"},
+        {"tagName": "v0.5.0-rc.1", "isDraft": False, "isPrerelease": True, "publishedAt": "2026-07-01T00:00:00Z"},
+        {"tagName": "v0.4.0", "isDraft": False, "isPrerelease": False, "publishedAt": "2026-06-01T00:00:00+00:00"},
+        {"tagName": "nightly", "isDraft": False, "isPrerelease": False, "publishedAt": "2026-08-01T00:00:00Z"},
+    ]
+
+    releases = archive_performance.stable_published_releases(document)
+
+    assert [release.tag for release in releases] == ["v0.4.0", "v0.3.0"]
+
+
+def test_stable_published_releases_rejects_non_boolean_flags() -> None:
+    document = [{"tagName": "v0.4.0", "isDraft": "false", "isPrerelease": False, "publishedAt": "2026-06-01T00:00:00Z"}]
+
+    with pytest.raises(TypeError, match="boolean"):
+        archive_performance.stable_published_releases(document)
+
+
+def test_stable_published_releases_rejects_duplicate_tags() -> None:
+    document = [
+        {"tagName": "v0.4.0", "isDraft": False, "isPrerelease": False, "publishedAt": "2026-06-01T00:00:00Z"},
+        {"tagName": "v0.4.0", "isDraft": False, "isPrerelease": False, "publishedAt": "2026-06-02T00:00:00Z"},
+    ]
+
+    with pytest.raises(ValueError, match="duplicate"):
+        archive_performance.stable_published_releases(document)
+
+
+def test_infer_release_uses_latest_for_an_unpublished_package() -> None:
+    releases = (_release("v0.4.0"), _release("v0.3.0", 30))
+
+    pair = archive_performance.resolve_release_pair(mode="infer-release", releases=releases, package_tag="v0.5.0")
+
+    assert pair == archive_performance.ReportId("v0.5.0", "v0.4.0")
+
+
+def test_infer_release_uses_previous_when_package_is_already_published() -> None:
+    releases = (_release("v0.4.0"), _release("v0.3.0", 30), _release("v0.2.1", 60))
+
+    pair = archive_performance.resolve_release_pair(mode="infer-release", releases=releases, package_tag="v0.4.0")
+
+    assert pair == archive_performance.ReportId("v0.4.0", "v0.3.0")
+
+
+@pytest.mark.parametrize("package_tag", ["v0.3.9", "v0.1.0"])
+def test_infer_release_rejects_an_unpublished_package_not_newer_than_latest(package_tag: str) -> None:
+    releases = (_release("v0.4.0"), _release("v0.3.0", 30))
+
+    with pytest.raises(ValueError, match="must be newer"):
+        archive_performance.resolve_release_pair(
+            mode="infer-release",
+            releases=releases,
+            package_tag=package_tag,
+        )
+
+
+def test_published_latest_requires_two_stable_releases() -> None:
+    with pytest.raises(RuntimeError, match="at least two"):
+        archive_performance.resolve_release_pair(mode="published-latest", releases=(_release("v0.4.0"),), package_tag="v0.5.0")
+
+
+def test_explicit_pair_requires_both_tags() -> None:
+    with pytest.raises(ValueError, match="both required"):
+        archive_performance.resolve_release_pair(
+            mode="explicit",
+            releases=(_release("v0.4.0"),),
+            package_tag="v0.5.0",
+            current_tag="v0.5.0",
+        )
+
+
+def test_github_assets_rejects_working_tree_resolution() -> None:
+    with pytest.raises(ValueError, match="requires --published-latest"):
+        archive_performance._validate_mode_combination("current-vs-latest", github_assets=True)
+
+
+def test_published_latest_rejects_local_measurements() -> None:
+    with pytest.raises(ValueError, match="reserved"):
+        archive_performance._validate_mode_combination("published-latest", github_assets=False)
+
+
+def test_current_vs_latest_promotion_is_rejected_before_release_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def unexpected_release_lookup(_repo_root: Path) -> tuple[archive_performance.PublishedRelease, ...]:
+        pytest.fail("release lookup must not run for an invalid mode combination")
+
+    monkeypatch.setattr(archive_performance, "_published_releases", unexpected_release_lookup)
+
+    status = archive_performance.main(
+        [
+            "--current-vs-latest",
+            "--promote",
+            "--repo-root",
+            str(tmp_path),
+        ]
+    )
+
+    assert status == 2
+    assert "working-tree reports cannot be promoted" in capsys.readouterr().err
+
+
+def test_promote_report_archives_the_previous_pair_and_updates_index(tmp_path: Path) -> None:
+    current = tmp_path / "docs" / "PERFORMANCE.md"
+    archive_dir = tmp_path / "docs" / "archive" / "performance"
+    current.parent.mkdir(parents=True)
+    current.write_text(_report("v0.4.0", "v0.3.0", "old"), encoding="utf-8")
+
+    archive_performance.promote_report(
+        source_text=_report("v0.5.0", "v0.4.0", "new"),
+        current_path=current,
+        archive_dir=archive_dir,
+        expected=archive_performance.ReportId("v0.5.0", "v0.4.0"),
+    )
+
+    assert "new" in current.read_text(encoding="utf-8")
+    assert "old" in (archive_dir / "v0.4.0-vs-v0.3.0.md").read_text(encoding="utf-8")
+    index = (archive_dir / "README.md").read_text(encoding="utf-8")
+    assert "[v0.4.0-vs-v0.3.0](v0.4.0-vs-v0.3.0.md)" in index
+
+
+def test_promote_report_preserves_an_existing_archive(tmp_path: Path) -> None:
+    current = tmp_path / "PERFORMANCE.md"
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    current.write_text(_report("v0.4.0", "v0.3.0", "old current"), encoding="utf-8")
+    archive = archive_dir / "v0.4.0-vs-v0.3.0.md"
+    archive.write_text("preserved archive\n", encoding="utf-8")
+
+    archive_performance.promote_report(
+        source_text=_report("v0.5.0", "v0.4.0"),
+        current_path=current,
+        archive_dir=archive_dir,
+        expected=archive_performance.ReportId("v0.5.0", "v0.4.0"),
+    )
+
+    assert archive.read_text(encoding="utf-8") == "preserved archive\n"
+
+
+def test_promote_report_rejects_a_mismatched_release_pair(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="does not match"):
+        archive_performance.promote_report(
+            source_text=_report("v0.5.0", "v0.4.0"),
+            current_path=tmp_path / "PERFORMANCE.md",
+            archive_dir=tmp_path / "archive",
+            expected=archive_performance.ReportId("v0.6.0", "v0.5.0"),
+        )
+
+
+def test_generated_working_tree_report_can_be_promoted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pair = archive_performance.ReportId("v0.5.0", "v0.4.0")
+    applied: list[tuple[Path, Path]] = []
+
+    @contextmanager
+    def fake_worktree(
+        _repo_root: Path,
+        parent: Path,
+        name: str,
+        _reference: str,
+    ) -> Iterator[Path]:
+        checkout = parent / name
+        checkout.mkdir()
+        yield checkout
+
+    def fake_benchmark(checkout: Path, *, save_baseline: str | None = None) -> tuple[str, ...]:
+        sample = save_baseline or "new"
+        _write_sample(checkout / "target" / "criterion", "chain/step_by_value", sample)
+        return ("cargo", "bench")
+
+    def fake_apply(repo_root: Path, worktree: Path) -> None:
+        applied.append((repo_root, worktree))
+
+    monkeypatch.setattr(archive_performance, "_ensure_local_tag", lambda *_args: None)
+    monkeypatch.setattr(archive_performance, "temporary_worktree", fake_worktree)
+    monkeypatch.setattr(archive_performance, "_run_stepping_benchmark", fake_benchmark)
+    monkeypatch.setattr(archive_performance, "apply_current_tree", fake_apply)
+    monkeypatch.setattr(archive_performance, "_local_measurement_context", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(
+        archive_performance,
+        "run_git_command",
+        lambda args, **_kwargs: subprocess.CompletedProcess(args, 0, stdout="abc1234\n"),
+    )
+
+    report = archive_performance.generate_local_report(
+        tmp_path,
+        pair,
+        current_reference="HEAD",
+        apply_working_tree=True,
+    )
+    current = tmp_path / "docs" / "PERFORMANCE.md"
+    archive_performance.promote_report(
+        source_text=report,
+        current_path=current,
+        archive_dir=tmp_path / "docs" / "archive" / "performance",
+        expected=pair,
+    )
+
+    assert applied
+    assert archive_performance.parse_report_id(current.read_text(encoding="utf-8")) == pair
+    assert "**markov-chain-monte-carlo** v0.5.0 working tree" in report
+
+
+def test_apply_current_tree_applies_tracked_changes_and_copies_untracked_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "source"
+    worktree = tmp_path / "worktree"
+    untracked = repo_root / "nested" / "fixture.txt"
+    untracked.parent.mkdir(parents=True)
+    untracked.write_text("fixture\n", encoding="utf-8")
+    worktree.mkdir()
+    applied: list[tuple[list[str], str, Path]] = []
+
+    def fake_git(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        stdout = "tracked patch\n" if "diff" in args else "nested/fixture.txt\n"
+        return subprocess.CompletedProcess(args, 0, stdout=stdout)
+
+    def fake_git_with_input(args: list[str], input_text: str, *, cwd: Path, **_kwargs: object) -> object:
+        applied.append((args, input_text, cwd))
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(archive_performance, "run_git_command", fake_git)
+    monkeypatch.setattr(archive_performance, "run_git_command_with_input", fake_git_with_input)
+
+    archive_performance.apply_current_tree(repo_root, worktree)
+
+    assert applied == [
+        (["apply", "--binary", "--whitespace=nowarn"], "tracked patch\n", worktree),
+    ]
+    assert (worktree / "nested" / "fixture.txt").read_text(encoding="utf-8") == "fixture\n"
+
+
+def test_temporary_worktree_removes_checkout_after_body_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_git(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="")
+
+    monkeypatch.setattr(archive_performance, "run_git_command", fake_git)
+
+    msg = "benchmark failed"
+    with pytest.raises(RuntimeError, match="benchmark failed"), archive_performance.temporary_worktree(tmp_path, tmp_path, "checkout", "HEAD"):
+        raise RuntimeError(msg)
+
+    assert calls == [
+        ["worktree", "add", "--detach", str(tmp_path / "checkout"), "HEAD"],
+        ["worktree", "remove", "--force", str(tmp_path / "checkout")],
+    ]
+
+
+def test_copy_criterion_sample_renames_each_benchmark_sample(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    _write_sample(source, "chain/step_by_value", "v0.4.0")
+    _write_sample(source, "sampler/run_by_value_100", "v0.4.0")
+
+    copied = archive_performance.copy_criterion_sample(
+        source_criterion=source,
+        destination_criterion=destination,
+        source_sample="v0.4.0",
+        destination_sample="new",
+    )
+
+    assert copied == 2
+    assert (destination / "chain" / "step_by_value" / "new" / "sample.json").is_file()
+    assert (destination / "sampler" / "run_by_value_100" / "new" / "estimates.json").is_file()
+
+
+def test_copy_criterion_sample_fails_when_asset_has_no_requested_baseline(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="no Criterion sample"):
+        archive_performance.copy_criterion_sample(
+            source_criterion=tmp_path / "missing",
+            destination_criterion=tmp_path / "destination",
+            source_sample="v0.4.0",
+            destination_sample="new",
+        )
+
+
+def test_release_metadata_validates_tag_and_measurement_context(tmp_path: Path) -> None:
+    metadata = {
+        "schema": 1,
+        "tag": "v0.5.0",
+        "commit": "a" * 40,
+        "operating_system": "Linux",
+        "architecture": "x86_64",
+        "rustc": "rustc 1.97.1",
+        "criterion_version": "0.8.2",
+    }
+    (tmp_path / ".mcmc-release-metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+
+    parsed = archive_performance._release_metadata(tmp_path, "v0.5.0")
+
+    assert parsed.commit == "a" * 40
+    assert parsed.criterion_version == "0.8.2"
+
+
+def test_release_metadata_rejects_a_mismatched_tag(tmp_path: Path) -> None:
+    metadata = {
+        "schema": 1,
+        "tag": "v0.4.0",
+        "commit": "a" * 40,
+        "operating_system": "Linux",
+        "architecture": "x86_64",
+        "rustc": "rustc 1.97.1",
+        "criterion_version": "0.8.2",
+    }
+    (tmp_path / ".mcmc-release-metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not match"):
+        archive_performance._release_metadata(tmp_path, "v0.5.0")
+
+
+def test_safe_extract_tar_rejects_path_traversal(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.tar.gz"
+    payload = b"unsafe"
+    with tarfile.open(archive, "w:gz") as tar:
+        member = tarfile.TarInfo("../outside.txt")
+        member.size = len(payload)
+        tar.addfile(member, io.BytesIO(payload))
+
+    with pytest.raises(ValueError, match="outside its root"):
+        archive_performance.safe_extract_tar(archive, tmp_path / "extract")
+
+    assert not (tmp_path / "outside.txt").exists()
+
+
+def test_safe_extract_tar_rejects_links(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe-link.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        member = tarfile.TarInfo("criterion/link")
+        member.type = tarfile.SYMTYPE
+        member.linkname = "../../outside.txt"
+        tar.addfile(member)
+
+    with pytest.raises(ValueError, match="unsupported entry"):
+        archive_performance.safe_extract_tar(archive, tmp_path / "extract")
+
+
+def test_command_failure_preserves_stdout_and_stderr() -> None:
+    error = subprocess.CalledProcessError(7, ["cargo", "bench"], output="partial output\n", stderr="compiler failed\n")
+
+    message = archive_performance._format_command_failure(error)
+
+    assert "exit 7: cargo bench" in message
+    assert "partial output" in message
+    assert "compiler failed" in message

--- a/scripts/tests/test_archive_performance.py
+++ b/scripts/tests/test_archive_performance.py
@@ -29,11 +29,30 @@ def _report(current: str, baseline: str, marker: str = "") -> str:
     )
 
 
-def _write_sample(root: Path, benchmark: str, sample: str) -> None:
+def _write_sample(root: Path, benchmark: str, sample: str, point: float = 1.0) -> None:
     sample_dir = root / benchmark / sample
     sample_dir.mkdir(parents=True, exist_ok=True)
-    (sample_dir / "estimates.json").write_text(json.dumps({"median": {"point_estimate": 1.0}}), encoding="utf-8")
+    (sample_dir / "estimates.json").write_text(json.dumps({"median": {"point_estimate": point}}), encoding="utf-8")
     (sample_dir / "sample.json").write_text("{}", encoding="utf-8")
+
+
+def _write_release_archive(root: Path, tag: str, point: float, commit: str) -> Path:
+    criterion = root / tag / "criterion"
+    _write_sample(criterion, "chain/step_by_value", tag, point)
+    metadata = {
+        "schema": 1,
+        "tag": tag,
+        "commit": commit,
+        "operating_system": "Linux",
+        "architecture": "x86_64",
+        "rustc": "rustc 1.97.1",
+        "criterion_version": "0.8.2",
+    }
+    (criterion / ".mcmc-release-metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    archive = root / f"{tag}.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(criterion, arcname="criterion")
+    return archive
 
 
 def test_stable_published_releases_filters_and_sorts() -> None:
@@ -207,10 +226,9 @@ def test_generated_working_tree_report_can_be_promoted(
         checkout.mkdir()
         yield checkout
 
-    def fake_benchmark(checkout: Path, *, save_baseline: str | None = None) -> tuple[str, ...]:
+    def fake_benchmark(checkout: Path, *, save_baseline: str | None = None) -> None:
         sample = save_baseline or "new"
         _write_sample(checkout / "target" / "criterion", "chain/step_by_value", sample)
-        return ("cargo", "bench")
 
     def fake_apply(repo_root: Path, worktree: Path) -> None:
         applied.append((repo_root, worktree))
@@ -324,6 +342,29 @@ def test_copy_criterion_sample_fails_when_asset_has_no_requested_baseline(tmp_pa
             source_sample="v0.4.0",
             destination_sample="new",
         )
+
+
+def test_generate_github_asset_report_renames_current_sample_and_renders_release_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pair = archive_performance.ReportId("v0.5.0", "v0.4.0")
+    archives = {
+        pair.current_tag: _write_release_archive(tmp_path, pair.current_tag, 80.0, "a" * 40),
+        pair.baseline_tag: _write_release_archive(tmp_path, pair.baseline_tag, 100.0, "b" * 40),
+    }
+
+    def fake_download(_repo_root: Path, tag: str, _destination: Path) -> Path:
+        return archives[tag]
+
+    monkeypatch.setattr(archive_performance, "_download_release_asset", fake_download)
+
+    report = archive_performance.generate_github_asset_report(tmp_path, pair)
+
+    assert "**markov-chain-monte-carlo** v0.5.0 · `aaaaaaa`" in report
+    assert "Comparison against baseline **v0.4.0**:" in report
+    assert "Source mode: durable GitHub Release Criterion assets" in report
+    assert "| `chain/step_by_value` | 100.00 ns | 80.00 ns | -20.00% | 1.25x | unknown |" in report
 
 
 def test_release_metadata_validates_tag_and_measurement_context(tmp_path: Path) -> None:

--- a/scripts/tests/test_bench_compare.py
+++ b/scripts/tests/test_bench_compare.py
@@ -1,0 +1,131 @@
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+import bench_compare
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_estimate(
+    root: Path,
+    benchmark: str,
+    sample: str,
+    point: float,
+    interval: tuple[float, float] | None = None,
+) -> None:
+    path = root / benchmark / sample / "estimates.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    statistic: dict[str, object] = {"point_estimate": point}
+    if interval is not None:
+        statistic["confidence_interval"] = {"lower_bound": interval[0], "upper_bound": interval[1]}
+    path.write_text(json.dumps({"median": statistic, "mean": statistic}), encoding="utf-8")
+
+
+def test_collect_comparisons_reports_shared_and_missing_rows(tmp_path: Path) -> None:
+    criterion = tmp_path / "criterion"
+    _write_estimate(criterion, "chain/step_by_value", "v0.4.0", 100.0, (95.0, 105.0))
+    _write_estimate(criterion, "chain/step_by_value", "new", 80.0, (75.0, 85.0))
+    _write_estimate(criterion, "observing/new_metric", "new", 200.0)
+    _write_estimate(criterion, "chain/removed_metric", "v0.4.0", 300.0)
+
+    collected = bench_compare.collect_comparisons(criterion, "v0.4.0")
+
+    assert len(collected.comparisons) == 1
+    assert collected.comparisons[0].benchmark == "chain/step_by_value"
+    assert collected.comparisons[0].percent_change == pytest.approx(-20.0)
+    assert collected.comparisons[0].speedup == pytest.approx(1.25)
+    assert collected.missing_baseline == ("observing/new_metric",)
+    assert collected.missing_current == ("chain/removed_metric",)
+
+
+def test_render_report_includes_release_pair_and_coverage_notes(tmp_path: Path) -> None:
+    criterion = tmp_path / "criterion"
+    _write_estimate(criterion, "chain/step_by_value", "v0.4.0", 100.0, (95.0, 105.0))
+    _write_estimate(criterion, "chain/step_by_value", "new", 80.0, (75.0, 85.0))
+    _write_estimate(criterion, "chain/new_path", "new", 90.0)
+    comparison_set = bench_compare.collect_comparisons(criterion, "v0.4.0")
+
+    settings = bench_compare.ReportSettings(
+        current_label="v0.5.0",
+        baseline_label="v0.4.0",
+        statistic="median",
+        revision="abc1234",
+        measurement_context=("Source mode: fixture.",),
+    )
+    report = bench_compare.render_report(comparison_set, settings)
+
+    assert "**markov-chain-monte-carlo** v0.5.0 · `abc1234`" in report
+    assert "Comparison against baseline **v0.4.0**:" in report
+    assert "## Measurement Context" in report
+    assert "Source mode: fixture." in report
+    assert "| `chain/step_by_value` |" in report
+    assert "-20.00%" in report
+    assert "current lower" in report
+    assert "Current-only rows without a saved baseline:" in report
+    assert "`chain/new_path`" in report
+
+
+def test_main_supports_an_explicit_saved_baseline(tmp_path: Path) -> None:
+    criterion = tmp_path / "criterion"
+    output = tmp_path / "report.md"
+    _write_estimate(criterion, "sampler/run_by_value_100", "release-a", 10_000.0)
+    _write_estimate(criterion, "sampler/run_by_value_100", "new", 9_000.0)
+
+    status = bench_compare.main(
+        [
+            "release-a",
+            "--criterion-dir",
+            str(criterion),
+            "--output",
+            str(output),
+            "--current-label",
+            "working tree",
+            "--revision",
+            "fixture-revision",
+        ]
+    )
+
+    assert status == 0
+    output_text = output.read_text(encoding="utf-8")
+    assert "Comparison against baseline **release-a**:" in output_text
+    assert "`fixture-revision`" in output_text
+
+
+def test_main_fails_cleanly_when_the_baseline_is_missing(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    criterion = tmp_path / "criterion"
+    _write_estimate(criterion, "chain/step_by_value", "new", 100.0)
+
+    status = bench_compare.main(["missing", "--criterion-dir", str(criterion), "--output", str(tmp_path / "report.md")])
+
+    assert status == 2
+    assert "No comparable Criterion results" in capsys.readouterr().err
+
+
+def test_read_estimate_rejects_invalid_timing_data(tmp_path: Path) -> None:
+    criterion = tmp_path / "criterion"
+    _write_estimate(criterion, "chain/step_by_value", "new", -1.0)
+
+    with pytest.raises(ValueError, match="finite and positive"):
+        bench_compare.collect_sample(criterion, "new")
+
+
+@pytest.mark.parametrize(
+    ("point", "interval"),
+    [
+        (90.0, (100.0, 120.0)),
+        (130.0, (100.0, 120.0)),
+    ],
+)
+def test_read_estimate_rejects_a_point_outside_its_confidence_interval(
+    tmp_path: Path,
+    point: float,
+    interval: tuple[float, float],
+) -> None:
+    criterion = tmp_path / "criterion"
+    _write_estimate(criterion, "chain/step_by_value", "new", point, interval)
+
+    with pytest.raises(ValueError, match="must lie within"):
+        bench_compare.collect_sample(criterion, "new")

--- a/scripts/tests/test_bench_compare.py
+++ b/scripts/tests/test_bench_compare.py
@@ -112,6 +112,31 @@ def test_read_estimate_rejects_invalid_timing_data(tmp_path: Path) -> None:
         bench_compare.collect_sample(criterion, "new")
 
 
+def test_collect_sample_reads_the_requested_mean_statistic(tmp_path: Path) -> None:
+    criterion = tmp_path / "criterion"
+    path = criterion / "chain" / "step_by_value" / "new" / "estimates.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({"median": {"point_estimate": 100.0}, "mean": {"point_estimate": 80.0}}),
+        encoding="utf-8",
+    )
+
+    collected = bench_compare.collect_sample(criterion, "new", statistic="mean")
+
+    assert collected["chain/step_by_value"].point_ns == 80.0
+
+
+def test_read_estimate_wraps_malformed_json_with_the_criterion_path(tmp_path: Path) -> None:
+    path = tmp_path / "criterion" / "chain" / "step_by_value" / "new" / "estimates.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"malformed Criterion JSON in .*estimates\.json") as raised:
+        bench_compare.read_estimate(path)
+
+    assert isinstance(raised.value.__cause__, json.JSONDecodeError)
+
+
 @pytest.mark.parametrize(
     ("point", "interval"),
     [

--- a/scripts/tests/test_justfile_discoverability.py
+++ b/scripts/tests/test_justfile_discoverability.py
@@ -146,12 +146,26 @@ def test_latest_vs_last_composes_measurement_and_report_steps() -> None:
     assert dependencies == {"bench-latest", "python-sync"}
 
 
-def test_repository_file_validators_include_untracked_files() -> None:
+def test_repository_file_commands_include_nonignored_untracked_files() -> None:
     recipes = _recipes()
+    expected = {
+        "action-lint",
+        "markdown-check",
+        "markdown-fix",
+        "semgrep",
+        "toml-fmt",
+        "toml-fmt-check",
+        "toml-lint",
+        "validate-json",
+        "yaml-check",
+        "yaml-fix",
+    }
+    discovered = {name for name, recipe in recipes.items() if "git ls-files" in json.dumps(recipe["body"])}
 
-    for name in ("action-lint", "markdown-check", "markdown-fix", "semgrep"):
+    assert discovered == expected
+    for name in expected:
         body = json.dumps(recipes[name]["body"])
-        assert "git ls-files -co --exclude-standard" in body, name
+        assert "git ls-files -co --exclude-standard -z --" in body, name
 
 
 def test_release_workflow_uses_the_canonical_baseline_recipe() -> None:

--- a/scripts/tests/test_justfile_discoverability.py
+++ b/scripts/tests/test_justfile_discoverability.py
@@ -1,0 +1,170 @@
+"""Regression tests for the public Just recipe surface."""
+
+import json
+import re
+import shutil
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JUSTFILE = REPO_ROOT / "justfile"
+RECIPE_DECLARATION = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*)(?:\s+.*?)?:(?=\s|$)", re.MULTILINE)
+WORKFLOW_VERSION_LOOKUP = re.compile(r"(?:just --evaluate|resolve_version) [\"']?([a-z0-9_]+_version)")
+RELEASE_PERFORMANCE_RECIPES = {
+    "bench-compare",
+    "bench-latest",
+    "bench-latest-vs-last",
+    "bench-save-baseline",
+    "bench-save-last",
+    "performance-github-assets",
+    "performance-local",
+    "performance-release",
+}
+
+
+def _run_just(*args: str) -> subprocess.CompletedProcess[str]:
+    executable = shutil.which("just")
+    assert executable is not None
+    return subprocess.run(  # noqa: S603 - executable is resolved and arguments are test constants.
+        [executable, *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+
+def _recipes() -> dict[str, dict[str, Any]]:
+    document = json.loads(_run_just("--dump", "--dump-format", "json").stdout)
+    recipes = document["recipes"]
+    assert isinstance(recipes, dict)
+    return recipes
+
+
+def test_recipe_declarations_are_lexicographically_sorted() -> None:
+    names = RECIPE_DECLARATION.findall(JUSTFILE.read_text(encoding="utf-8"))
+
+    assert names == sorted(names)
+
+
+def test_bare_just_shows_curated_help() -> None:
+    result = _run_just()
+
+    assert result.stdout.startswith("Common Just workflows:\n")
+    assert "Use 'just --list' for the complete grouped recipe reference." in result.stdout
+
+
+def test_public_recipes_have_one_group_and_a_description() -> None:
+    for name, recipe in _recipes().items():
+        if recipe["private"]:
+            continue
+        groups = [attribute["group"] for attribute in recipe["attributes"] if "group" in attribute]
+        assert recipe["doc"], f"public recipe {name!r} has no description"
+        assert len(groups) == 1, f"public recipe {name!r} has groups {groups!r}"
+
+
+def test_public_recipes_do_not_duplicate_exact_behavior() -> None:
+    signatures: defaultdict[str, list[str]] = defaultdict(list)
+    for name, recipe in _recipes().items():
+        if recipe["private"]:
+            continue
+        signature = json.dumps(
+            {
+                "body": recipe["body"],
+                "dependencies": recipe["dependencies"],
+                "parameters": recipe["parameters"],
+            },
+            sort_keys=True,
+        )
+        signatures[signature].append(name)
+
+    duplicates = [names for names in signatures.values() if len(names) > 1]
+    assert duplicates == []
+
+
+def test_workflow_tool_version_lookups_resolve_from_just() -> None:
+    workflow_text = "\n".join(path.read_text(encoding="utf-8") for path in sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml")))
+    version_names = sorted(set(WORKFLOW_VERSION_LOOKUP.findall(workflow_text)))
+
+    assert version_names
+    for name in version_names:
+        result = _run_just("--evaluate", name)
+        assert result.stdout.strip(), name
+
+
+def test_pinned_tool_guards_reference_their_justfile_versions() -> None:
+    recipes = _recipes()
+    guards = {
+        "_ensure-cargo-llvm-cov": "cargo_llvm_cov_version",
+        "_ensure-cargo-nextest": "cargo_nextest_version",
+        "_ensure-dprint": "dprint_version",
+        "_ensure-git-cliff": "git_cliff_version",
+        "_ensure-rumdl": "rumdl_version",
+        "_ensure-taplo": "taplo_version",
+        "_ensure-typos": "typos_version",
+        "_ensure-uv": "uv_version",
+        "_ensure-zizmor": "zizmor_version",
+    }
+
+    for guard, version_name in guards.items():
+        assert version_name in json.dumps(recipes[guard]["body"]), guard
+
+
+def test_justfile_validation_is_wired_into_repository_gates() -> None:
+    recipes = _recipes()
+
+    repository_checks = {dependency["recipe"] for dependency in recipes["check-repository-tooling"]["dependencies"]}
+    ci_checks = {dependency["recipe"] for dependency in recipes["ci"]["dependencies"]}
+    tooling_ci = {dependency["recipe"] for dependency in recipes["ci-repository-tooling"]["dependencies"]}
+
+    assert "justfile-fmt-check" in repository_checks
+    assert {"justfile-fmt-check", "test-python"} <= ci_checks
+    assert tooling_ci == {"check-repository-tooling", "test-python"}
+
+
+def test_release_performance_recipes_are_public_and_documented() -> None:
+    recipes = _recipes()
+
+    for name in RELEASE_PERFORMANCE_RECIPES:
+        assert name in recipes
+        assert recipes[name]["private"] is False
+        assert recipes[name]["doc"], name
+
+
+def test_release_performance_recipes_are_discoverable_in_help() -> None:
+    help_text = _run_just("help-workflows").stdout
+
+    for name in RELEASE_PERFORMANCE_RECIPES:
+        assert f"just {name}" in help_text
+
+
+def test_latest_vs_last_composes_measurement_and_report_steps() -> None:
+    dependencies = {dependency["recipe"] for dependency in _recipes()["bench-latest-vs-last"]["dependencies"]}
+
+    assert dependencies == {"bench-latest", "python-sync"}
+
+
+def test_repository_file_validators_include_untracked_files() -> None:
+    recipes = _recipes()
+
+    for name in ("action-lint", "markdown-check", "markdown-fix", "semgrep"):
+        body = json.dumps(recipes[name]["body"])
+        assert "git ls-files -co --exclude-standard" in body, name
+
+
+def test_release_workflow_uses_the_canonical_baseline_recipe() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release-benchmarks.yml").read_text(encoding="utf-8")
+
+    assert 'run: just bench-save-baseline "$RELEASE_TAG"' in workflow
+
+
+def test_workflows_resolve_the_python_version_from_the_justfile() -> None:
+    ci_workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    release_workflow = (REPO_ROOT / ".github" / "workflows" / "release-benchmarks.yml").read_text(encoding="utf-8")
+
+    assert 'python_version="$(resolve_version python_version)"' in ci_workflow
+    assert "python-version: ${{ steps.tool_versions.outputs.PYTHON_VERSION }}" in ci_workflow
+    assert 'python_version="$(just --evaluate python_version)"' in release_workflow
+    assert "python-version: ${{ steps.python_version.outputs.value }}" in release_workflow

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -433,7 +433,7 @@ rules:
         - "/tests/semgrep/github-actions/**/*.yml"
         - "/tests/semgrep/github-actions/**/*.yaml"
     patterns:
-      - pattern-regex: '(?m)^\s*uses:\s*(?!\./)(?!docker://)(?!(?:actions/checkout|actions/cache|actions/upload-artifact|actions/setup-python|actions-rust-lang/setup-rust-toolchain|astral-sh/setup-uv|swatinem/rust-cache|taiki-e/cache-cargo-install-action|github/codeql-action/(?:upload-sarif|init|analyze)|codecov/codecov-action|zizmorcore/zizmor-action)@)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@'
+      - pattern-regex: '(?m)^\s*uses:\s*(?!\./)(?!docker://)(?!(?:actions/checkout|actions/cache|actions/download-artifact|actions/upload-artifact|actions/setup-python|actions-rust-lang/setup-rust-toolchain|astral-sh/setup-uv|swatinem/rust-cache|taiki-e/cache-cargo-install-action|github/codeql-action/(?:upload-sarif|init|analyze)|codecov/codecov-action|zizmorcore/zizmor-action)@)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@'
 
   - id: mcmc.github-actions.external-action-version-comment
     languages:

--- a/tests/semgrep/github-actions/workflow_actions.yml
+++ b/tests/semgrep/github-actions/workflow_actions.yml
@@ -25,6 +25,12 @@ jobs:
         # ok: mcmc.github-actions.external-action-version-comment
         uses: actions/upload-artifact@0123456789abcdef0123456789abcdef01234567 # v7.0.1
 
+      - name: Approved download action
+        # ok: mcmc.github-actions.external-action-sha-pinned
+        # ok: mcmc.github-actions.external-action-approved-allowlist
+        # ok: mcmc.github-actions.external-action-version-comment
+        uses: actions/download-artifact@0123456789abcdef0123456789abcdef01234567 # v8.0.1
+
       - name: Approved Rust cache action
         # ok: mcmc.github-actions.external-action-sha-pinned
         # ok: mcmc.github-actions.external-action-approved-allowlist


### PR DESCRIPTION
- Add fixed-seed Criterion workloads and Just commands for local, saved-baseline, release-asset, and curated comparisons.
- Publish durable release baselines with provenance metadata and archive prior curated reports.
- Enforce release-pair and report invariants while documenting the prospective two-release rollout.
- Group and validate the Just command surface with Justfile-sourced workflow pins.