### PR TITLE
fix: harden v0.4.1 release preparation

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,7 +21,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     env:
-      CARGO_AUDIT_VERSION: "0.22.1"
+      CARGO_AUDIT_VERSION: "0.22.2"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@ Commit subjects and bodies feed `CHANGELOG.md` through `git-cliff`. Write them a
 
 #### Breaking Changes
 
+Breaking API changes are allowed in any release up to and including v1.0.0, including patch releases. Maintainers choose the pre-v1.0 release number based on
+project scope rather than the presence of a breaking-change marker alone. After v1.0.0, follow Semantic Versioning for incompatible public changes.
+
 Breaking changes must use one of these conventional commit markers so `git-cliff` can detect them:
 
 - Bang notation: `feat!: remove deprecated API`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Before you begin, ensure you have:
 4. **Try the examples**:
 
    ```bash
-   just examples        # Runs all examples (normal_1d, ising_1d, iterator_sampling, detailed_balance)
+   just examples        # Runs all six examples, including additive-target and delayed-telemetry workflows
    ```
 
 5. **Run benchmarks** (optional):
@@ -270,7 +270,7 @@ requiring `expect()` reasons, and forbidding unwrap-default-on-non-finite. Run t
   cargo bench --no-run
   ```
 
-- **Broad Rust CI tests** — library unit and integration tests share one optimized build, while doctests remain separate:
+- **Broad Rust CI tests** — all-feature library unit and integration tests share one optimized build, while doctests remain separate:
 
   ```bash
   just test-rust-ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,19 @@ documentation = "https://docs.rs/markov-chain-monte-carlo"
 license = "BSD-3-Clause"
 repository = "https://github.com/acgetchell/markov-chain-monte-carlo"
 readme = "README.md"
+include = [
+    "/benches/**",
+    "/examples/**",
+    "/src/**",
+    "/tests/*.rs",
+    "/Cargo.lock",
+    "/Cargo.toml",
+    "/CHANGELOG.md",
+    "/CITATION.cff",
+    "/LICENSE",
+    "/README.md",
+    "/REFERENCES.md",
+]
 
 keywords = [ "mcmc", "markov-chain", "monte-carlo", "sampling", "metropolis-hastings" ]
 categories = [ "science", "mathematics", "algorithms" ]

--- a/cliff.toml
+++ b/cliff.toml
@@ -95,8 +95,8 @@ commit_parsers = [
     { message = '(?i)^(chore(:|\(release\):) |Changed: )?(prepare|release) v[0-9]', skip = true },
 
     # Dependency bumps: keep Rust library dependencies, skip CI/action noise.
-    { message = "^chore\\(deps\\): bump (rand|proptest|serde|serde_json)\\b", group = "Dependencies" },
-    { message = "^chore\\(deps\\): bump ", skip = true },
+    { message = "^chore\\(deps(?:-[^)]+)?\\): bump (rand|proptest|serde|serde_json)\\b", group = "Dependencies" },
+    { message = "^chore\\(deps(?:-[^)]+)?\\): bump ", skip = true },
     { message = "(?i)^bump (rand|proptest|serde|serde_json)\\b", group = "Dependencies" },
     { message = "(?i)^bump ", skip = true },
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -17,7 +17,7 @@ just setup            # Install/verify external dev tools
 just test             # Focused unit + doc tests
 just test-unit        # Focused library unit tests
 just test-integration # Focused integration tests
-just test-rust-ci     # Release lib + integration tests in one nextest pass
+just test-rust-ci     # All-feature release lib + integration tests in one nextest pass
 just test-rust        # Broad Rust CI tests + doctests
 just test-all         # Broad Rust + Python tooling tests
 just notebook-check   # Notebook lint + fast headless execution
@@ -56,10 +56,10 @@ For cross-repo muscle memory, the same checks are also available through grouped
 spelling, JSON, TOML, YAML/CFF, Python, Python tests, Semgrep, notebooks, Rust formatting and core Clippy, documentation, broad Rust runnable tests, doctests,
 benchmark-harness compilation, and deterministic example validation. It does not depend on nested `ci-*`, `check`, `lint`, or `test-all` bundles.
 
-Runnable library unit and integration tests share one release-profile nextest invocation through `just test-rust-ci`:
+Runnable library unit and integration tests across all public features share one release-profile nextest invocation through `just test-rust-ci`:
 
 ```bash
-cargo nextest run --locked --release --profile ci --lib --tests --verbose
+cargo nextest run --locked --release --profile ci --all-features --lib --tests --verbose
 ```
 
 Doctests remain in `just test-doc` because nextest does not execute rustdoc examples. `just clippy` checks the core library;
@@ -118,11 +118,11 @@ remains on the narrower `rustfmt` `max_width = 100` setting because wide Rust si
 
 ## Testing
 
-- All default Rust and Python tests: `just test-all`
+- All Rust and Python tests: `just test-all`
 - Focused library unit tests plus rustdoc doctests: `just test`
 - Focused unit tests: `just test-unit`
 - Focused integration tests: `just test-integration`
-- Broad release-profile unit and integration tests: `just test-rust-ci`
+- Broad all-feature release-profile unit and integration tests: `just test-rust-ci`
 - Broad Rust runnable tests plus doctests: `just test-rust`
 - Python tooling tests: `just test-python`
 - Single runnable test by name filter: `cargo nextest run chain_samples_near_mode`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,9 +3,8 @@
 This roadmap records likely directions for the `markov-chain-monte-carlo` crate. It is not a stability promise; release scope depends on scientific need, API
 maturity, and validation quality.
 
-Until v1.0, API breaks are acceptable when they improve correctness, performance, or orthogonality. Patch releases should normally stay focused on fixes,
-documentation, tooling hardening, and invariant cleanup, while new sampler APIs, changed acceptance semantics, and MSRV bumps belong in minor releases so the
-feature roadmap stays understandable.
+Breaking API changes and MSRV bumps are acceptable in any release up to and including v1.0.0, including patch releases, when they improve correctness,
+performance, orthogonality, or invariant safety. Maintainers choose the pre-v1.0 release number based on project scope rather than compatibility impact alone.
 
 ## Completed
 
@@ -45,13 +44,13 @@ API breaks are acceptable when they make invalid states unrepresentable or prese
 
 - [#82](https://github.com/acgetchell/markov-chain-monte-carlo/issues/82) - Run general parse-don't-validate audit
 - [#84](https://github.com/acgetchell/markov-chain-monte-carlo/issues/84) - Update Python tooling to 3.14 and parse scripts at boundaries
+- [x] [#104](https://github.com/acgetchell/markov-chain-monte-carlo/issues/104) - Update Rust toolchain and MSRV to 1.97.1
 
 ### v0.5.0 Adaptive Diagnostics
 
 After the CDT-facing continuation and acceptance APIs settle, invest in classical adaptive sampling and diagnostics that help users decide whether a run is
 scientifically trustworthy. This should happen before learned-proposal work so there is a baseline to compare against.
 
-- [x] [#104](https://github.com/acgetchell/markov-chain-monte-carlo/issues/104) - Update Rust toolchain and MSRV to 1.97.1
 - [#10](https://github.com/acgetchell/markov-chain-monte-carlo/issues/10) - Adaptive Metropolis-Hastings
 - [#13](https://github.com/acgetchell/markov-chain-monte-carlo/issues/13) - Diagnostics: ESS, autocorrelation, and R-hat
 - [#42](https://github.com/acgetchell/markov-chain-monte-carlo/issues/42) - Continuous proposal diagnostics

--- a/justfile
+++ b/justfile
@@ -849,7 +849,7 @@ test-rust: test-rust-ci test-doc
 # Broad release-profile Rust CI bucket: lib unit and integration tests together.
 [group('tests and coverage')]
 test-rust-ci: _ensure-cargo-nextest
-    cargo nextest run --locked --release --profile ci --lib --tests --verbose
+    cargo nextest run --locked --release --profile ci --all-features --lib --tests --verbose
 
 # Focused library unit tests for changed-surface validation.
 [group('tests and coverage')]

--- a/scripts/archive_performance.py
+++ b/scripts/archive_performance.py
@@ -259,8 +259,9 @@ def resolve_release_pair(
     return pair
 
 
-def _archive_index(archive_dir: Path) -> str:
-    reports = sorted(path.name for path in archive_dir.glob("*.md") if path.name != "README.md")
+def _archive_index(archive_dir: Path, *, additional_reports: tuple[str, ...] = ()) -> str:
+    reports = {path.name for path in archive_dir.glob("*.md") if path.name != "README.md"}
+    reports.update(additional_reports)
     lines = [
         "# Archived Performance Reports",
         "",
@@ -268,10 +269,41 @@ def _archive_index(archive_dir: Path) -> str:
         "",
     ]
     if reports:
-        lines.extend(f"- [{name.removesuffix('.md')}]({name})" for name in reports)
+        lines.extend(f"- [{name.removesuffix('.md')}]({name})" for name in sorted(reports))
     else:
         lines.append("- No archived performance reports yet.")
     return "\n".join(lines) + "\n"
+
+
+def _publish_texts(outputs: tuple[tuple[Path, str], ...]) -> None:
+    """Publish a set of text files, restoring every prior target on failure."""
+    paths = tuple(path for path, _text in outputs)
+    if len(paths) != len(set(paths)):
+        msg = "transactional publication requires unique output paths"
+        raise ValueError(msg)
+
+    previous = {path: path.read_text(encoding="utf-8") if path.exists() else None for path in paths}
+    completed: list[Path] = []
+    try:
+        for path, text in outputs:
+            _write_text(path, text)
+            completed.append(path)
+    except (OSError, RuntimeError) as error:
+        rollback_failures: list[str] = []
+        for path in reversed(completed):
+            try:
+                previous_text = previous[path]
+                if previous_text is None:
+                    path.unlink(missing_ok=True)
+                else:
+                    _write_text(path, previous_text)
+            except (OSError, RuntimeError) as rollback_error:
+                rollback_failures.append(f"{path}: {rollback_error}")
+        if rollback_failures:
+            details = "; ".join(rollback_failures)
+            msg = f"publication failed and rollback was incomplete: {details}"
+            raise RuntimeError(msg) from error
+        raise
 
 
 def promote_report(
@@ -281,7 +313,7 @@ def promote_report(
     archive_dir: Path,
     expected: ReportId,
 ) -> None:
-    """Archive the previous curated report and atomically promote a new one."""
+    """Archive the previous curated report and promote all outputs with rollback."""
     source_id = parse_report_id(source_text)
     if source_id != expected:
         msg = (
@@ -289,15 +321,24 @@ def promote_report(
             f"found {source_id.current_tag} vs {source_id.baseline_tag}, expected {expected.current_tag} vs {expected.baseline_tag}"
         )
         raise ValueError(msg)
+    outputs: list[tuple[Path, str]] = []
+    additional_reports: list[str] = []
     if current_path.exists():
         previous_text = current_path.read_text(encoding="utf-8")
         previous_id = parse_report_id(previous_text)
         if previous_id != source_id:
             archive_path = archive_dir / previous_id.archive_name
             if not archive_path.exists():
-                _write_text(archive_path, previous_text)
-    _write_text(current_path, source_text)
-    _write_text(archive_dir / "README.md", _archive_index(archive_dir))
+                outputs.append((archive_path, previous_text))
+                additional_reports.append(archive_path.name)
+    outputs.append((current_path, source_text))
+    outputs.append(
+        (
+            archive_dir / "README.md",
+            _archive_index(archive_dir, additional_reports=tuple(additional_reports)),
+        )
+    )
+    _publish_texts(tuple(outputs))
 
 
 def _ensure_local_tag(repo_root: Path, tag: str) -> None:

--- a/scripts/postprocess_changelog.py
+++ b/scripts/postprocess_changelog.py
@@ -13,7 +13,9 @@ Usage:
 """
 
 import argparse
+import stat
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -26,13 +28,30 @@ class PostprocessOptions:
 
 
 def postprocess(path: Path) -> None:
-    """Read *path*, apply hygiene fixes, and write it back."""
+    """Read *path*, apply hygiene fixes, and replace it atomically."""
     text = path.read_text(encoding="utf-8")
 
     # 1. Strip trailing blank lines — keep exactly one trailing newline.
     text = text.rstrip("\n") + "\n"
 
-    path.write_text(text, encoding="utf-8")
+    mode = stat.S_IMODE(path.stat().st_mode)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(text)
+        temporary.chmod(mode)
+        temporary.replace(path)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
 
 
 def parse_args(argv: list[str] | None = None) -> PostprocessOptions:

--- a/scripts/tag_release.py
+++ b/scripts/tag_release.py
@@ -189,10 +189,6 @@ def _tag_exists(tag_version: str) -> bool:
         return True
 
 
-def _delete_tag(tag_version: str) -> None:
-    run_git_command(["tag", "-d", tag_version])
-
-
 def parse_github_repository_url(raw: str) -> GitHubRepositoryUrl:
     """Parse a supported GitHub remote into its canonical HTTPS URL."""
     patterns = [
@@ -290,15 +286,16 @@ def create_tag(tag_version: str | ReleaseVersion, *, force: bool = False) -> Non
             print("... (truncated for preview)")
         print("----------------------------------------")
 
-    # Delete existing tag only after all validation succeeds
-    if tag_existed and force:
-        print(f"{_BLUE}Deleting existing tag '{tag}'...{_RESET}")
-        _delete_tag(tag)
-
-    # Create annotated tag
+    # Create or atomically replace the annotated tag. Git prepares the tag
+    # object before updating the ref, so a failed command preserves any
+    # existing tag.
     label = "reference" if is_truncated else "full changelog"
     print(f"{_BLUE}Creating annotated tag '{tag}' with {label} content...{_RESET}")
-    run_git_command_with_input(["tag", "-a", tag, "-F", "-", "--cleanup=verbatim"], input_data=tag_message)
+    command = ["tag"]
+    if tag_existed and force:
+        command.append("--force")
+    command.extend(["--annotate", tag, "-F", "-", "--cleanup=verbatim"])
+    run_git_command_with_input(command, input_data=tag_message)
 
     # Success
     print(f"{_GREEN}✓ Successfully created tag '{tag}'{_RESET}")

--- a/scripts/tests/test_archive_performance.py
+++ b/scripts/tests/test_archive_performance.py
@@ -180,6 +180,58 @@ def test_promote_report_archives_the_previous_pair_and_updates_index(tmp_path: P
     assert "[v0.4.0-vs-v0.3.0](v0.4.0-vs-v0.3.0.md)" in index
 
 
+def test_promote_report_rolls_back_every_output_if_index_write_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = tmp_path / "docs" / "PERFORMANCE.md"
+    archive_dir = tmp_path / "docs" / "archive" / "performance"
+    index = archive_dir / "README.md"
+    current.parent.mkdir(parents=True)
+    archive_dir.mkdir(parents=True)
+    old_report = _report("v0.4.0", "v0.3.0", "old")
+    old_index = "# Existing index\n"
+    current.write_text(old_report, encoding="utf-8")
+    index.write_text(old_index, encoding="utf-8")
+    archive = archive_dir / "v0.4.0-vs-v0.3.0.md"
+    real_write = archive_performance._write_text
+    failed = False
+
+    def fail_index_once(path: Path, text: str) -> None:
+        nonlocal failed
+        if path == index and not failed:
+            failed = True
+            msg = "injected index write failure"
+            raise OSError(msg)
+        real_write(path, text)
+
+    monkeypatch.setattr(archive_performance, "_write_text", fail_index_once)
+
+    with pytest.raises(OSError, match="injected index write failure"):
+        archive_performance.promote_report(
+            source_text=_report("v0.5.0", "v0.4.0", "new"),
+            current_path=current,
+            archive_dir=archive_dir,
+            expected=archive_performance.ReportId("v0.5.0", "v0.4.0"),
+        )
+
+    assert current.read_text(encoding="utf-8") == old_report
+    assert index.read_text(encoding="utf-8") == old_index
+    assert not archive.exists()
+
+    monkeypatch.setattr(archive_performance, "_write_text", real_write)
+    archive_performance.promote_report(
+        source_text=_report("v0.5.0", "v0.4.0", "new"),
+        current_path=current,
+        archive_dir=archive_dir,
+        expected=archive_performance.ReportId("v0.5.0", "v0.4.0"),
+    )
+
+    assert "new" in current.read_text(encoding="utf-8")
+    assert archive.read_text(encoding="utf-8") == old_report
+    assert "[v0.4.0-vs-v0.3.0](v0.4.0-vs-v0.3.0.md)" in index.read_text(encoding="utf-8")
+
+
 def test_promote_report_preserves_an_existing_archive(tmp_path: Path) -> None:
     current = tmp_path / "PERFORMANCE.md"
     archive_dir = tmp_path / "archive"

--- a/scripts/tests/test_postprocess_changelog.py
+++ b/scripts/tests/test_postprocess_changelog.py
@@ -1,6 +1,9 @@
 """Tests for postprocess_changelog.py — trailing blank line hygiene."""
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
 
 from postprocess_changelog import postprocess
 
@@ -59,3 +62,17 @@ class TestPostprocess:
         postprocess(f)
 
         assert f.read_text(encoding="utf-8") == "\n"
+
+    def test_preserves_original_if_atomic_replace_fails(self, tmp_path: Path) -> None:
+        f = tmp_path / "CHANGELOG.md"
+        original = "# Changelog\n\n- Existing entry\n\n"
+        f.write_text(original, encoding="utf-8")
+
+        with (
+            patch.object(type(f), "replace", side_effect=OSError("injected replace failure")),
+            pytest.raises(OSError, match="injected replace failure"),
+        ):
+            postprocess(f)
+
+        assert f.read_text(encoding="utf-8") == original
+        assert tuple(tmp_path.iterdir()) == (f,)

--- a/scripts/tests/test_tag_release.py
+++ b/scripts/tests/test_tag_release.py
@@ -296,7 +296,7 @@ class TestCreateTag:
 
         mock_git_input.assert_called_once()
         call_args = mock_git_input.call_args
-        assert call_args[0][0] == ["tag", "-a", "v1.0.0", "-F", "-", "--cleanup=verbatim"]
+        assert call_args[0][0] == ["tag", "--annotate", "v1.0.0", "-F", "-", "--cleanup=verbatim"]
         assert "### Added" in call_args[1]["input_data"]
         assert "Something new" in call_args[1]["input_data"]
 
@@ -336,16 +336,14 @@ class TestCreateTag:
             tag_release.create_tag("v1.0.0", force=False)
 
     @patch("tag_release.run_git_command_with_input")
-    @patch("tag_release._delete_tag")
     @patch("tag_release._tag_exists", return_value=True)
     @patch("tag_release.find_changelog")
     @patch("tag_release.extract_changelog_section", return_value="### Fixed\n\n- Bug fix")
-    def test_force_recreates_tag(
+    def test_force_replaces_tag_with_one_git_command(
         self,
         _mock_extract: MagicMock,
         mock_find: MagicMock,
         _mock_exists: MagicMock,
-        mock_delete: MagicMock,
         mock_git_input: MagicMock,
         tmp_path: Path,
     ) -> None:
@@ -355,22 +353,24 @@ class TestCreateTag:
 
         tag_release.create_tag("v1.0.0", force=True)
 
-        mock_delete.assert_called_once_with("v1.0.0")
-        mock_git_input.assert_called_once()
+        mock_git_input.assert_called_once_with(
+            ["tag", "--force", "--annotate", "v1.0.0", "-F", "-", "--cleanup=verbatim"],
+            input_data="### Fixed\n\n- Bug fix",
+        )
 
+    @patch("tag_release.run_git_command_with_input")
     @patch("tag_release._tag_exists", return_value=True)
     @patch("tag_release.find_changelog")
     @patch("tag_release.extract_changelog_section", side_effect=LookupError("not found"))
-    @patch("tag_release._delete_tag")
-    def test_force_does_not_delete_tag_if_changelog_fails(
+    def test_force_does_not_replace_tag_if_changelog_fails(
         self,
-        mock_delete: MagicMock,
         _mock_extract: MagicMock,
         mock_find: MagicMock,
         _mock_exists: MagicMock,
+        mock_git_input: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Tag must not be deleted if changelog extraction fails."""
+        """Tag must not be replaced if changelog extraction fails."""
         changelog = tmp_path / "CHANGELOG.md"
         changelog.write_text("# Changelog\n", encoding="utf-8")
         mock_find.return_value = changelog
@@ -378,4 +378,4 @@ class TestCreateTag:
         with pytest.raises(LookupError):
             tag_release.create_tag("v1.0.0", force=True)
 
-        mock_delete.assert_not_called()
+        mock_git_input.assert_not_called()


### PR DESCRIPTION
- Preserve existing tags and generated release artifacts when replacement fails.
- Run release tests with all features and filter development-dependency noise from changelogs.
- Trim crate contents and align audit, example, and pre-v1 compatibility guidance.